### PR TITLE
Create decisions.md

### DIFF
--- a/tech/decisions.md
+++ b/tech/decisions.md
@@ -1,6 +1,6 @@
 |Decision|Date|Alternatives|Minutes Link|
 |--|--|--|--|
-| ExternalMap is a property of Collection | 9-Nov-2021|ExternalMap is only a property of Document | [Tech Team Meeting 9 Nov 2021](https://github.com/spdx/meetings/blob/master/tech/2021-11-05.md)
+| ExternalMap is a property of Collection | 9-Nov-2021|ExternalMap is only a property of Document | [Tech Team Meeting 9 Nov 2021](https://github.com/spdx/meetings/blob/master/tech/2021-11-09.md)
 | Elements are immutable | 19-Oct-2021 | Elements can change after "minting" | [Tech Team Meeting 19 Oct 2021](https://github.com/spdx/meetings/blob/master/tech/2021-10-19.md)
 | SPDX-3.0-Model is a new repo | 12-Oct-2021 | Add 3.0 to existing repo | [Tech Team Meeting 12 Oct 2021](https://github.com/spdx/meetings/blob/master/tech/2021-10-12.md)
 | DCO for contributions | 12-Oct-2021 | Individual copyrights | [Tech Team Meeting 12 Oct 2021](https://github.com/spdx/meetings/blob/master/tech/2021-10-12.md)

--- a/tech/decisions.md
+++ b/tech/decisions.md
@@ -1,0 +1,7 @@
+
+|Decision|Date|Alternatives|Minutes Link|
+|--|--|--|--|
+| ExternalMap is a property of Collection | 9-Nov-2022|ExternalMap is only a property of Document | [Tech Team Meeting 9 Nov 2022](https://github.com/spdx/meetings/blob/master/tech/2021-11-05.md)
+| Elements are immutable | 19-Oct-2022 | Elements can change after "minting" | [Tech Team Meeting 19 Oct 2022](https://github.com/spdx/meetings/blob/master/tech/2022-10-19.md)
+| SPDX-3.0-Model is a new repo | 12-Oct-2022 | Add 3.0 to existing repo | [Tech Team Meeting 12 Oct 2022](https://github.com/spdx/meetings/blob/master/tech/2022-10-12.md)
+| DCO for contributions | 12-Oct-2022 | Individual copyrights | [Tech Team Meeting 12 Oct 2022](https://github.com/spdx/meetings/blob/master/tech/2022-10-12.md)

--- a/tech/decisions.md
+++ b/tech/decisions.md
@@ -1,7 +1,6 @@
-
 |Decision|Date|Alternatives|Minutes Link|
 |--|--|--|--|
-| ExternalMap is a property of Collection | 9-Nov-2022|ExternalMap is only a property of Document | [Tech Team Meeting 9 Nov 2022](https://github.com/spdx/meetings/blob/master/tech/2021-11-05.md)
-| Elements are immutable | 19-Oct-2022 | Elements can change after "minting" | [Tech Team Meeting 19 Oct 2022](https://github.com/spdx/meetings/blob/master/tech/2022-10-19.md)
-| SPDX-3.0-Model is a new repo | 12-Oct-2022 | Add 3.0 to existing repo | [Tech Team Meeting 12 Oct 2022](https://github.com/spdx/meetings/blob/master/tech/2022-10-12.md)
-| DCO for contributions | 12-Oct-2022 | Individual copyrights | [Tech Team Meeting 12 Oct 2022](https://github.com/spdx/meetings/blob/master/tech/2022-10-12.md)
+| ExternalMap is a property of Collection | 9-Nov-2021|ExternalMap is only a property of Document | [Tech Team Meeting 9 Nov 2021](https://github.com/spdx/meetings/blob/master/tech/2021-11-05.md)
+| Elements are immutable | 19-Oct-2021 | Elements can change after "minting" | [Tech Team Meeting 19 Oct 2021](https://github.com/spdx/meetings/blob/master/tech/2021-10-19.md)
+| SPDX-3.0-Model is a new repo | 12-Oct-2021 | Add 3.0 to existing repo | [Tech Team Meeting 12 Oct 2021](https://github.com/spdx/meetings/blob/master/tech/2021-10-12.md)
+| DCO for contributions | 12-Oct-2021 | Individual copyrights | [Tech Team Meeting 12 Oct 2021](https://github.com/spdx/meetings/blob/master/tech/2021-10-12.md)


### PR DESCRIPTION
I thought it might be easier to track our past decisions if we kept a summary table of our decisions.

The attached PR is in reverse chronological order.  I only included decisions back through 12 October, 2022 (I added them to the PR as I was copying the minutes from the etherpad to GitHub).

The decisions are what I thought were clear in the minutes.  I excluded several cases where it wasn't clear if a consensus was reached.

If this is useful, I'll continue to maintain this as I move the minutes to this repo.  The process I would like to use is to create a PR for each update, have at least one other person who was on the call approve, then merge the changes.

To keep the merge conflicts low, we should only have one PR open at a time against the master branch - but we can allow PR's against the PR.