### PR TITLE
Add Outreach Team meeting minutes from 2022-02-17

### DIFF
--- a/outreach/2022-02-17.md
+++ b/outreach/2022-02-17.md
@@ -1,0 +1,91 @@
+# SPDX Outreach Team meeting - 17 February, 2022
+
+## Attendees
+
+* Bob Martin
+* Joshua Marpet
+* Kate Stewart
+* Sebastian Crane
+* Vicky Brasseur
+
+## Agenda
+
+* Minutes approval
+* Podcast
+* Promoting SPDX-related talks
+* FAQ
+* Sign-up for members on website
+* REUSE (Max?)
+* AOB
+
+## Notes
+
+**Approval of minutes from last meeting: minutes from SPDX Outreach Team meeting on 20th of January approved**
+
+### Podcast
+
+* Joshua sent out invitations to the SPDX Asia Team. Is cooperating with a local podcasting group.
+* Need to nail down regular date and times
+* Monday & Friday are the best bet for Sebastian; around 10am Eastern will be good for him (Mondays)
+* Joshua will coordinate
+
+### Membership signup page
+
+* The 'join' button is active on the site
+* Kate has added logos for the organisations that have already joined
+* Do send folks to sign up! (must be LF members)
+
+### REUSE
+
+* SC invited Max to join the call
+* SC thinking of writing a blog post about new REUSE version; get quotes from Max
+
+### FAQ
+
+* Wrote stuff for this but it's not on the website?
+    * <https://github.com/seabass-labrax/spdx-license-list-faqs> (converted to Markdown)
+
+* Can work with Jack to get it onto the site
+    * Let Legal have another look so they aren't surprised that changes happen
+
+### Website:
+- Any updates pending? Up to date.
+
+### Landscape:
+- README is updated,  AI: Kate to review/fix
+- Reach out to FOSSlight - GitHub issue? Slack?
+
+### Kate's update on DocFest:
+* Identified and worked through six issues during the DocFest
+* 24 participants
+* Rose Judge led the meeting
+* Being able to link to vulnerability and attestation information; should be going into SPDX 2.3
+* Being able to indicate what purpose a package is for (eg. Container image)
+
+### SPDX contributor onboarding
+* Joshua volunteering Melissa to monitor emails, if we can come up with canned response.
+* Sebastian monitors [Gitter](https://gitter.im/spdx-org/Lobby)
+* Kate to help provide list projects to point people at where is needing help.
+* GitHub project board? <https://github.com/orgs/todogroup/projects/1?card_filter_query=type%3Aissue>
+* Some preliminary areas where we know we need help (to revisit each month) until we can get something more sophisticated set up:
+    * Python Library
+    * Go Library
+    * kubernetes BOM tool
+    * FSFE REUSE - better generation of package level
+    * binutils - compiler/linking - generate SPDX doc during build (like Zephyr dashboard)
+    * llvm - generate SPDX BOM during build
+    * packaging systems - incorporating SPDX SBOM generation during builds, different languages, etc.
+
+### SPDX-related talks:
+* FOSDEM Software Composition Analysis Devroom: <https://fosdem.org/2022/schedule/track/software_composition_and_dependency_management/>
+* FOSDEM Security track talk: <https://fosdem.org/2022/schedule/event/security_sbom/>
+* Oman Open Source CoE conference this week: <https://www.youtube.com/watch?v=CPjdHAMQLOE> (VMB w/intro to supply chain security & mentions of SPDX starting at 1:10:00)
+
+### Community News:
+* <https://zephyr-dashboard.renode.io/> has source & built SPDX SBOMs enabled on builds
+* JFrog webinar on SBOMs includes ability to join SPDX now (tag:value, spreadsheet, JSON)
+* GitBOM efforts:  working to include in SPDX external reference
+* Cost of vulnerability remediation
+* Kate speaking at [OpenChain Security Summit](https://www.openchainproject.org/featured/2022/02/10/security-summit-2022)
+* Bob speaking at [CISQ](https://www.brighttalk.com/webcast/12231/531015)
+* Sebastian had talk accepted for LibrePlanet - advanced package managers


### PR DESCRIPTION
Minutes taken by Vicky Brasseur, Kate Stewart and Sebastian Crane.

You may have noticed the month of these minutes; this is not a mistake! Usually, the minutes would be merged into this repository at the subsequent SPDX Outreach Team meeting, but GitHub was down last month, delaying this.