### PR TITLE
Use Markdown for introduction of Tech Team minutes

### DIFF
--- a/tech/2021-05-25.md
+++ b/tech/2021-05-25.md
@@ -1,23 +1,24 @@
-#SPDX Tech Team Meeting,   May 25, 2021
+# SPDX Tech Team Meeting, May 25, 2021
 
 ## Attendees
-Bob Martin
-David Kemp
-Jeff Schutt
-Jim Hutchison
-John Horan
-Karsten Klein
-Kate Stewart
-Nisha Kumar
-Peter Shin
-Rose Judge
-Sean Barnum
-Sebastian Crane
-Steve Lasker
-Steve Winslow
-Thomas Steenbergen
-William Bartholomew
-William Cox
+
+* Bob Martin
+* David Kemp
+* Jeff Schutt
+* Jim Hutchison
+* John Horan
+* Karsten Klein
+* Kate Stewart
+* Nisha Kumar
+* Peter Shin
+* Rose Judge
+* Sean Barnum
+* Sebastian Crane
+* Steve Lasker
+* Steve Winslow
+* Thomas Steenbergen
+* William Bartholomew
+* William Cox
 
 
 ### Regrets

--- a/tech/2021-06-08.md
+++ b/tech/2021-06-08.md
@@ -1,31 +1,32 @@
 # SPDX Technical Team Meeting, June 8, 2021
-## Attendees
-Gary O'Neall
-Sebastian Crane
-Alexios Zavras
-Bob Martin
-Alex Goodman
-Jeff Schutt
-John Horan
-Sean Barnum
-William Bartholomew
-Thomas Steenbergen
-Peter Shin
-Steve Lasker
-Nirmal Suthar
-Nisha Kumar
-David Kemp
-Maximillian Huber
 
-### Regrets
-Kate
+## Attendees
+
+* Alex Goodman
+* Alexios Zavras
+* Bob Martin
+* David Kemp
+* Gary O'Neall
+* Jeff Schutt
+* John Horan
+* Maximillian Huber
+* Nirmal Suthar
+* Nisha Kumar
+* Peter Shin
+* Sean Barnum
+* Sebastian Crane
+* Steve Lasker
+* Thomas Steenbergen
+* William Bartholomew
+
+## Regrets
+
+* Kate Stewart
 
 ## Agenda
 * NTIA Plugfest
 * Alexios -  Template next steps
 * Sean - Proposal to improve Identity class
-
-
 
 ## Notes
 

--- a/tech/2021-09-07.md
+++ b/tech/2021-09-07.md
@@ -2,19 +2,18 @@
 
 ## Attendees
 
-Adrian Diglio
-David Edelsohn
-David Kemp
-Gary O'Neall
-Jeff Schut
-John Horan
-Kate Stewart
-Nisha Kumar
-Rose Judge
-Sebastian Crane
-Steve Lasker
-William Bartholomew
-
+* Adrian Diglio
+* David Edelsohn
+* David Kemp
+* Gary O'Neall
+* Jeff Schut
+* John Horan
+* Kate Stewart
+* Nisha Kumar
+* Rose Judge
+* Sebastian Crane
+* Steve Lasker
+* William Bartholomew
 
 ## Agenda
 * Identities continued

--- a/tech/2022-01-04.md
+++ b/tech/2022-01-04.md
@@ -1,25 +1,28 @@
-Attendees:
-    Bob Martin
-    David Edelsohn
-    David Kemp
-    Dick Brooks
-    Gary O'Neall
-    John Horan
-    Karsten Klein
-    Kate Stewart
-    Maximillian Huber
-    Nisha Kumar
-    Rose Judge
-    Sebastian Crane
-    Steve Lasker
-    Thomas Steenbergen
-    William Bartholomew
+# SPDX Tech Team Meeting, January 1, 2022
+
+## Attendees
+
+* Bob Martin
+* David Edelsohn
+* David Kemp
+* Dick Brooks
+* Gary O'Neall
+* John Horan
+* Karsten Klein
+* Kate Stewart
+* Maximillian Huber
+* Nisha Kumar
+* Rose Judge
+* Sebastian Crane
+* Steve Lasker
+* Thomas Steenbergen
+* William Bartholomew
     
-Agenda:
+## Agenda
 - General Update - Gary
 - Core Punchlist - Gary / William - https://github.com/spdx/spdx-3-model/issues
 
-Notes:
+## Notes
 
 - General Updates:
     - Conversation about potential collaboration between SPDX and CycloneDX to avoid friction for organizations that plan to use both.  Andrew & Phil arranged meeting w/ Allan, SPDX and CycloneDX specification reps. 

--- a/tech/2022-01-11.md
+++ b/tech/2022-01-11.md
@@ -1,25 +1,26 @@
-SPDX Tech Team Minutes
+# SPDX Tech Team Meeting, January 11, 2022
 
-Attendees:
-     Bob Martin
-     David Edelsohn
-     David Kemp
-     Dick Brooks
-     Gary O'Neal
-     Henk Birkholz
-     Jacob Williamson
-     Jeff Schutt
-     John Horan
-     Karsten Klein
-     Kate Stewart
-     Peter ?
-     Rose Judge
-     Sean Barnum
-     Sebastian Crane
-     Steve Lasker
-     William Bartholomew
-    
-Agenda:
+## Attendees
+* Bob Martin
+* David Edelsohn
+* David Kemp
+* Dick Brooks
+* Gary O'Neal
+* Henk Birkholz
+* Jacob Williamson
+* Jeff Schutt
+* John Horan
+* Karsten Klein
+* Kate Stewart
+* Peter ?
+* Rose Judge
+* Sean Barnum
+* Sebastian Crane
+* Steve Lasker
+* William Bartholomew
+
+## Agenda
+
 * Closing the open github questions
     
 Notes: 

--- a/tech/2022-01-18.md
+++ b/tech/2022-01-18.md
@@ -1,27 +1,29 @@
-SPDX Minutes from 18 Jan 2022
+# SPDX Tech Team Meeting, January 18, 2022
 
-Attendees:
-    Bob Martin
-    David Edelsohn
-    David Kemp
-    Dick Brooks
-    Gary O'Neall
-    Henk Birkholz
-    Jim Hutchinson
-    Karsten Klein
-    Kate Stewart
-    Nisha Kumar
-    Rose Judge
-    Sebastian Crane
-    Thomas Steenbergen
-    William Bartholomew
+## Attendees
+
+* Bob Martin
+* David Edelsohn
+* David Kemp
+* Dick Brooks
+* Gary O'Neall
+* Henk Birkholz
+* Jim Hutchinson
+* Karsten Klein
+* Kate Stewart
+* Nisha Kumar
+* Rose Judge
+* Sebastian Crane
+* Thomas Steenbergen
+* William Bartholomew
     
-Agenda
-     VEX maturity
-     SPDX 3.0 Core
-     SPDX outreach team meeting on Thursday
+## Agenda
 
-Notes:
+* VEX maturity
+* SPDX 3.0 Core
+* SPDX Outreach Team meeting on Thursday
+
+## Notes:
   * VEX
     * Gary found https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md#45-profile-5-vex
     * David K also points to https://www.csa.gov.sg/-/media/Csa/Documents/Events/OTCEP-2021/aDolus-White-Paper--Introduction-to-VEX--V0100.pdf   - "When used to release a VEX document, the CSAF document


### PR DESCRIPTION
Some of the documents for the Tech Team's minutes do not use Markdown syntax for their introduction, causing them to display strangely when converted to HTML. This commit adds the correct Markdown syntax.