### PR TITLE
Add implementers meeting notes of 20220713

### DIFF
--- a/implementers/2022-07-13.md
+++ b/implementers/2022-07-13.md
@@ -1,0 +1,20 @@
+# SPDX Implementers Team Meeting - 13th July, 2022
+
+## Attendees
+* Adolfo García Veytia
+* Ivana Atanasova
+
+## Agenda
+* Approve meeting minutes from the last call. (Adolfo sent a non-binding approval)
+
+## Notes
+
+### Meeting Cancelled
+
+We cancelled the meeting due to low attendance, presumably because of the CISA
+listening sessions which are taking place this week.
+
+### Approve meeting minutes from last week
+* https://github.com/spdx/meetings/pull/198
+
+### Other Topics


### PR DESCRIPTION

This PR adds the implementers meeting notes for July 13 2022, really a cancellation notice due to
low attendance.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>