### PR TITLE
Add implementer's meeting notes of Aug 10th, 2022

### DIFF
--- a/implementers/2022-08-10.md
+++ b/implementers/2022-08-10.md
@@ -1,0 +1,33 @@
+# SPDX Implementers Team Meeting - 10th August, 2022
+
+## Attendees
+* Marc-Etienne Vargenau
+* Nisha Kumar
+* Adolfo García Veytia
+
+## Agenda
+* (No previous agenda items)
+
+## Notes
+
+* Marc-Etienne: SPDX 2.3 is now available for review! ([markdown](https://github.com/spdx/spdx-spec/tree/development/v2.3/chapters) | [json schema](https://github.com/spdx/spdx-spec/blob/development/v2.3/schemas/spdx-schema.json)) 
+* ### Nisha: Let's restart the [SPDX Generator](https://github.com/opensbom-generator/spdx-sbom-generator) project! 
+    * Adolfo: Should we concentrate on the [spdx/tools-golang](https://github.com/spdx/tools-golang)?
+    * Nisha is taking over the project, some engineers will be working on the Java generators. Will go over the project this weekend to check what is missing.
+    * Part of the motivation is that there aren't any tools that generate "compatible" SPDX 3.0-ish SBOMs so far.
+    * Nisha will try to poke the current mantainers and start running community meetings.
+    * Announcements will go on the SPDX mailing list, OpenSSF and Twitter
+    * We will try to setup a common Document model which hopefully can be shared between tools. 
+    * We will try to sync efforts between the [SPDX Generator](https://github.com/opensbom-generator/spdx-sbom-generator), [bom](https://github.com/kubernetes-sigs/bom) (and it's cousins [ko](https://github.com/google/ko) and [apko](http://github.com/chainguard-dev/apko)) and the [SPDX/tools-golang](https://github.com/spdx/tools-golang) to share models, package interpreters and as much code as possible.
+    * Consensus that the document models should live in spdx/golang-tools, we will seek approval from the SPDX community.
+    * Considerations around making the [Tern command library](https://github.com/tern-tools/tern/blob/main/tern/analyze/default/command_lib/base.yml) more visible to reuse its recipes in common projects
+    * #### Action Items
+        * Nisha will set up new meetings for the Generator project and will notify the SPDX community.
+        * Adolfo will set up a meeting with the SPDX tools-golang maintainers.
+        * Adolfo will set up a meeting with Brandon Lum to chat about integrating models and where things should live.
+        * Adolfo will work on the bom 2.3 document model.
+
+### Approve meeting minutes from last week
+*  (No notes from last week)
+
+### Other Topics


### PR DESCRIPTION
This PR adds the meeting notes for the SPDX Implementers call of August 10th 2022 

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>