### PR TITLE
Organize general meeting notes by year

### DIFF
--- a/general/2010/2010-08-11.md
+++ b/general/2010/2010-08-11.md
@@ -1,0 +1,77 @@
+LinuxCon2010 Boston SPDX BOF
+
+## Current status
+
+  - need to focus on goals for next 3 months
+  - [spdx.org](http://spdx.org/) rollout, shadows
+    [fossbazaar.org](http://fossbazaar.org/) for data.
+  - mail list transfering to <spdx@fossbazaar.org> with self
+    subscription to mail list now possible, and public archives.
+  - <package-facts@fossbazaar.org> now depreciated, mail list there will
+    remain private, per original commitment.
+
+## Web site overview
+
+  - site design is still evolving, participation welcome.
+  - log in to comment on wiki etc.
+  - anyone can blog on site, and postings on topic welcome.
+  - presentation material available on site for outreach support.
+  - AI: Phil/Martin - update on participation page where to join
+    (suggestion was to put link in text, not just at top, consider "I
+    want to use the spec, vs. I want to contribute to the spec).
+  - AI: Kate to transfer document (.pdf) back to WIKI.
+  - AI: Phil update standard presentation with LinuxCon2010 input
+  - AI: Kate clean up the sharing analysis to what is accurate
+  - AI: Kate publish the current version number of the specification in
+    brackets behind reference.
+
+## License Discussion
+
+  - Look at Fedora's approach as a single page.
+
+Example license text - canonical form. Good from tooling perspective.
+Suck info off the pages. HTML at low technical level is easy. RDF?
+
+  - see
+    [fedoraproject.org/wiki/Licensing](http://fedoraproject.org/wiki/Licensing)
+    licenses table.
+  - Used License Text - uses tag to identify in page. Fedora provide
+    notes, and canonical text.
+  - For SPDX problem is where store templated version? Suggestion is to
+    use come up with standardized naming of the sections, and embed the
+    text of the licence "template" version, so it shows up on the
+    "official" license page. (example to consider, verify that BSD
+    hasn't been modified and do it with a template).
+  - Fields to put on each "web license WIKI page"
+      - short form name
+      - long form name
+      - link to formal license
+      - notes on license
+      - full license text
+      - template version
+  - Note: need to figure out and document how to add a license (ie. When
+    you add a license - 1) create separate page; raw template text, user
+    visible text - here's out how embed this text. etc.)
+  - AI: Tom to define a proposal for user front page.
+  - Decide section names to correspond to spec
+  - AI: Group: discuss further following questions:
+      - what does it mean to be "on the list" for a license.
+      - what is it going to take to add and maintain a license.
+      - Consider when english isn't spoken language? (what can be
+        translated, what can't, work into template)
+
+## roll out - operational aspects
+
+  - what do we want to get accomplished?
+  - divy out and how get accomplished?
+  - Target to have spec at 1.0 in 2010Q4
+  - What are building blocks needed? Consider: documenting tooling;
+    training; how to use.....
+  - Strong feeling one shot to get this right, want free and comercial
+    tool support available for supply chain.
+  - AI: Kim & John to work on operationalize plan. (including a date can
+    tell supply chain people? GOAL is understand a date to have industry
+    changing/financially impacting. Tie to next LinuxCon??)
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-08-26.md
+++ b/general/2010/2010-08-26.md
@@ -1,0 +1,145 @@
+**Administrative**
+
+## Agenda
+
+  - Attendance - 18
+  - Approval of minutes from BoF session – Approved.
+  - New Logistics and Expanding Group
+  - Outreach and evangelism:
+      - Common Messaging/Presentation – Phil O
+      - Industry Venues – Phil R
+          - LinuxCon Debrief- Phil O
+      - Website – Martin M
+
+## Logistics
+
+PhilO discussed need for evolving logistics with the group getting
+larger and including new folks. We're doing away with the "Who just
+joined?" approach to attendance and will mainly depend on log-ins to
+Webshare to record attendance. In addition everyone is encouraged to
+state their name when speaking. There also some discussion (actually it
+came up towards the end of the meeting) about providing minutes via a
+link rather than an attached Word doc.
+
+## Common Messaging/Presentation
+
+PhilO is updating the presentation to reflect Kate's LinuxCon
+presentation content.
+
+Industry Venues ==
+
+PhilO reported on LinuxCon. Jim Zemlin's keynote was all about the new
+Open Compliance Program, and SPDX was prominently featured. SPDX got
+some good PR out of it and one article said it was the key to the bigger
+program. Phil Koltun delivered a more detailed session on the OCP and
+Kate had one on SPDX. Both were well attended. Finally, we had a Birds
+of a Feature session.
+
+## Website
+
+Kudos to Martin for helping PhilO get the new spdx.org launched in time
+for LinuxCon. There was some discussion about making it more obvious how
+one joins both the group and the mailing list; it's better to be
+redundant in order to be more welcoming. There was also a discussion
+about getting examples up to date and getting the Wiki going again. We
+finally got into a discussion about hosting code for tools.
+Possibilities were: SourceForge, GitHub.
+
+## Rollout
+
+PhilO mentioned the JohnE and KimW have been working on a rollout plan,
+expanding on both out technical efforts and outreach/evangelism efforts.
+More at the next meeting.
+
+## Action Items
+
+  - PhilO/Martin - Update on participation page where to join
+    (suggestion was to put link in text, not just at top, consider "I
+    want to use the spec, vs. I want to contribute to the spec" in
+    navigation section.
+  - Kate- Transfer document (.pdf) back to WIKI.
+  - PhilO- Update standard presentation with LinuxCon2010 input
+  - Kate- Clean up the sharing analysis to what is accurate.
+  - Kate- Publish the current version number of the specification in
+    brackets behind reference
+  - Kim/PhilO- Add and element of 'What's in this for me?" to
+    presentation
+  - JeffL (w/Bill/Gary- Update zlib based on new specification
+  - All- Look for new examples to add to site.
+  - PhilK- Explore possibility of LF hosting source for SPDX tools.
+  - Gary- Explore other possible hosting options
+  - PhilO- Start making minutes available via link.
+  - BillS- Start up RDF sub-group. Solicite members.
+
+**Technical**
+
+## Agenda
+
+  - Review mock up from Spot Calloway
+    <https://fedoraproject.org/wiki/TomCallaway/SPDX_License_List>
+  - License Short Form Discussion- Kate
+  - General RDF Discussion
+
+## Mock Up
+
+Spot was not in attendance, but we reviewed the mock-up. There was fair
+agreement that its close to what we are looking for (if not "Spot" on)
+
+## Short Form Licenses
+
+Our implicit path had tied a fixed license list of licenses to the spec
+rev, but JohnE put forth an impassioned argument as to why they should
+be decoupled: Essentially we'll want the license list to change with
+more frequency than the spec (months vs. years). A new license can't
+mean a new spec rev. There was much discussion about how to manage the
+license list.
+
+There was fair agreement just as there is a "playground" for working on
+the spec and a release process to the current rev, there should be a
+similar arrangement for licenses (though decoupled) and certainly there
+should be legal review.
+
+There was not complete agreement about the intended scope of the list,
+but there was agreement that there needed so be some nomination process
+and that anyone wishing to add a license must be willing to take on the
+associated work. BobG is willing to be a contributor. A topic of future
+discussion is how we will come down on the initial V1.0 list of
+licenses. These issues in contemplated in the rollout framework that
+we'll be putting forth.
+
+## RDF
+
+We reviewed the intent of using RDF and BillS described what's been done
+with DOAP as a model. Essentially, we're exploring RDF as a reasonable
+balance between the needs of people being able to view and create SPDX
+docs, and machines to be able to consume and produce the format.
+
+There was agreement that there is lots of work to be done in this area:
+defining the syntax, defining web repository of license info,
+documenting usage, etc. We decided that we need a sub-team to take this
+on. BillS will coordinate and PeterW, Gary and Kate will participate, as
+well as others who are interested.
+
+## Attendance
+
+  - Michael Herzog, NexB
+  - Bob Gobeille, FOSSology.org, HP
+  - Ann Thornton, Freescale
+  - Martin Michlmayr, HP
+  - Gary O'Neall, Source Auditor
+  - Jeff Luszcz, Palamida
+  - Richard Fontana, Red Hat
+  - Mark Gisi, Wind River
+  - Phil Koltun, Linux Foundation
+  - John Ellis, Motorola
+  - David Wolfe, Freescale
+  - Tom Incorvia, Micro Focus
+  - Kim Weins, Open Logic
+  - Peter Williams, OpenLogic
+  - Bill Schineller, Black Duck Software
+  - Jack Manbeck, TI
+  - Kate Stewart, Canonical
+  - Philip Odence, Black Duck Software
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-09-09.md
+++ b/general/2010/2010-09-09.md
@@ -1,0 +1,166 @@
+**Administrative**
+
+## Agenda
+
+  - Attendance - 19
+  - Approval of minutes - Pending til next meeting
+  - Outreach and evangelism:
+      - Common Messaging/Presentation – PhilO
+      - Industry Venues – PhilR
+      - Website – PhilO/MartinM
+  - Rollout- KimW
+
+## Common Messaging/Presentation
+
+PhilO reported that he'd updated the presentation. He's added a slide
+describing to people why they should participate; he and Kim will update
+in the context of her OWF presentation.
+
+## Industry Venues
+
+PhilO reviewed process for new participatns
+
+## Website
+
+PhilO walked through changes implemented to make how to participate more
+obvious. There are pointers to where to sign up and get on the mailing
+list from every major tab.
+
+## Rollout
+
+Kim described the motivations for, approach to and elements of the
+rollout that will require work. There's a fair amount to be done, but it
+is now well framed. There will likely be a different thread of meetings
+on rollout issues (vs. spec completion) starting after a face to face
+meeting in mid-November. Some of the areas that need work would benefit
+from skills from outside the current group, so please think about others
+in your organization that might help.
+
+## Issue Tracking
+
+We agreed that we should implement an issue tracking system for spec
+issues. We can use Linux Foundations Bugzilla. Peter Williams agreed to
+drive and administer with help from Marshall.
+
+## Action Items
+
+  - PhilO/Martin - Update on participation page where to join
+    (suggestion was to put link in text, not just at top, consider "I
+    want to use the spec, vs. I want to contribute to the spec" in
+    navigation section. DONE
+  - Kate- Transfer document (.pdf) back to WIKI. IN PROCESS
+  - PhilO- Update standard presentation with LinuxCon2010 input DONE
+  - Kate- Clean up the sharing analysis to what is accurate. IN PROCESS
+  - Kate- Publish the current version number of the specification in
+    brackets behind reference DONE
+  - Kim/PhilO- Add and element of 'What's in this for me?" to
+    presentation DONE
+  - JeffL (w/Bill/Gary- Update zlib based on new specification IN
+    PROCESS
+  - All- Look for new examples to add to site. IN PROCESS
+  - PhilK- Explore possibility of LF hosting source for SPDX tools.
+    DONE.
+  - Gary- Explore other possible hosting options. DONE.
+  - PhilO- Start making minutes available via link. DONE
+  - BillS- Start up RDF sub-group. Solicite members. DONE
+
+New
+
+  - KimW- Sent rollout slides to mailing list
+  - RDF Group- Work out syntax for 5.6/5.7
+  - Bill S- Add Ed W to the RDF group
+  - Kate- Track and (when Wiki is back up) implement changes described
+    in Spec section below.
+  - PeterW- Implement issue tracking system.
+
+**Technical**
+
+## Agenda
+
+  - Spec current status and open areas- Kate
+  - RDF Focus Group update - Bill
+  - Tools update - Gary
+  - Issue Tracking
+
+## License Discussion
+
+As there has been a lot of discussion of licenses on the mailing list
+(decoupling from spec, etc.), we decided to have a separate session
+dedicated to that discussion. Kate will be hosting on Thurs, Sept 16 at
+12:00 EDT (one hour later than our normal.) Invitation and agenda to be
+sent out early next week.
+
+## Specification - Current Draft 20100806
+
+No changes have been implemented since the beta release as we are
+working through some formatting issues getting the .pdf back into Wiki
+form.
+
+Additional Fields: 5.6/5.7 We picked up on the discussion from the
+maillist of adding 5.6/5.7 fields to the file section which would
+designate the name and URL of the package from which a file is known to
+come. There was agreement that we should go ahead with this in concept
+and that the RDF group would work out the syntax.
+
+Revisit 3.3 To deal with the recursive problem (wanting to include the
+SPDX file in a package but also wanting it to include a SHA-1 for the
+package) there has been a proposal based off of the SHA-1s of all the
+other files in the package. Kate is looking for others interested in
+this, to brainstorm with as to algorithms to generate this new package
+level checksum. We got into a discussion of "unique identifier" vs.
+"validator" and it became clear our nomenclature needs to be cleaned up
+to indicate that this is a validator and not an identifier. Someone
+proposed "Package Check Sum" as the name of the field and there was
+agreement. Kate will clean up the language requested more discussion on
+the maillist of the technical approach.
+
+Appendices- The RDF group identified the need for an ontology and an XML
+schema appendix. Place holders for these will be added to the WIKI.
+
+## RDF Group
+
+There was a good kickoff meeting last Thursday. Most of the discussion
+was about approaches and concerns. Both an ontology and a schema are to
+be the targeted outputs from this subgroup. Bill has since found a
+collaborative ontology site that will be useful in the development.
+
+## Tools & Infrastructure
+
+Linux Foundation has agreed to make the source code revision
+infrastructure (git based) available to SPDX tools. There will be a
+meeting next week between Gary, Ibrahim, Kate to discuss the logistics
+in more details. The first project will be Gary's Pretty Printer (which
+has components that can be reused in other projects).
+
+Request was made on the list for an issue tracker. Current mechanism is
+a WIKI, but it was felt something more formal would give us better
+history. After group discussion and the willingness of Peter to
+volunteer to adminster it (thanks Peter\!), we will be looking at
+setting up a bugzilla system. Options on where it can be hosted (linux
+foundation?), will be investigated by Kate. Goal would be that this
+could be used for the SPDX tools as well.
+
+## Attendees
+
+  - Gary O'Neall, Source Auditor
+  - Daniel Germain, U of Victoria
+  - Marshall Clow, Qualcomm
+  - Peter Williams, OpenLogic
+  - Kim Weins, OpenLogic
+  - Kate Stewart, Canonical
+  - Ed Warnicke, Cisco
+  - Ann Thornton, Freescale
+  - Alan Stern, Cisco
+  - Phil Robb, HP
+  - Tom Incorvia, Micro Focus
+  - Phil Koltun, Linux Foundation
+  - Mark Gisi, Wind River
+  - Jeff Luszcz, Palamida
+  - Pierre Lapointe, NexB
+  - Esteban Rockett, Motorola
+  - Philip Odence, Black Duck Software
+  - Eric Weidner, OpenLogic
+  - Dave McLoughlin, OpenLogic
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-09-23.md
+++ b/general/2010/2010-09-23.md
@@ -1,0 +1,124 @@
+**DRAFT**
+
+**Administrative**
+
+## Agenda
+
+  - Attendance - 17
+  - Approval of minutes: Approved Aug 26 and Sept 9
+  - Outreach and evangelism:
+      - Common Messaging/Presentation – PhilO
+      - Industry Venues – PhilR
+      - Website – PhilO/MartinM
+  - Roll Out Update - KimW/JohnE (volunteer needs, face to face plan)
+  - Legal update from LF Member Counsel call- Rockett
+
+## Common Messaging/Presentation
+
+PhilO once again expressed openness to any feedback on the standards
+slides we should all be using to describe SPDX
+
+## Industry Venues
+
+PhilR lead a discussion about future events we should be getting on the
+list. He will be updating. All are encouraged to crowdsource this list.
+
+## Website
+
+Website is still developing and PhilO is open to feedback.
+
+## Rollout
+
+PhilO summarized the need for a roll out plan. Kim emphasized that we
+are looking for volunteers from the group and our respective
+organizations. A face to face meeting will be scheduled for Nov 16/17,
+with location to be determined based on who is coming.
+
+## Legal Update
+
+Rockett summarized a call with Linux Foundation legal group, the Member
+Counsel. (Kim, Kate, JohnE and PhilO also participated.) The Member
+Council has been aware of standardization efforts for a couple of year
+and this call was to provide status. A number of the participants were
+new to the MC, so it was important to get them up to speed. They
+encouraged us to provide them with an example.
+
+## Action Items
+
+  - Kate- Transfer document (.pdf) back to WIKI. IN PROCESS; FORMATTING
+    IS A BEAST
+  - Kim (formerly Kate)- Clean up the sharing analysis to what is
+    accurate. IN PROCESS
+  - JeffL (w/Bill/Gary- Update zlib based on new specification IN
+    PROCESS
+  - KimW- Sent rollout slides to mailing list DONE
+  - RDF Group- Work out syntax for 5.6/5.7 IN PROCESS ON RECOMMENDATION
+  - Bill S- Add Ed W to the RDF group DONE
+  - Kate- Track and (when Wiki is back up) implement changes described
+    in Spec section below. WAITING FOR WIKI
+  - PeterW- Implement issue tracking system. TO BE DISCUSSED.
+
+New
+
+  - Phil R- Update Industry Events.
+  - Kate- Draft example for LF Member Counsel; include XML and
+    corresponding spreadsheet (or spreadsheet-like) format.
+
+**Technical**
+
+## Agenda
+
+  - Spec update- Kate
+  - RDF work group update - Bill
+  - Tools repository - Gary/Kate/Bill
+  - Licenses: special working session on Friday at 12 CDT
+
+## Spec
+
+Formatting difficulties have slowed getting the spec back in the Wiki.
+That's in process. Kate will add 5.6/5.7.
+
+## RDF
+
+Work group is in process defining the ontology. Using knodle site:
+<http://knoodl.com/ui/groups/SPDX/vocab/SPDX(dev-only);jsessionid=16BABC384D81ECF9EC6DC52C93977C3E>
+
+Participating are Bill, Kate, Gary, Peter, Jeff, Ed, Kyle (from
+Canonical), Pierre. Bruno and Marshall have been monitoring as well. We
+discussed using DOAP (description of a project) as a way to extend SPDX
+capability.
+
+## Tools Repository
+
+LF is willing to host Bugzilla (as well as code). No one in the group
+saw any problem with going ahead. Kate, Bill and Peter are open to input
+for defining the hierarchy.
+
+## License Discussion
+
+We discussed the call (Friday, Sept 24) dedicated to the big picture
+license discussion. Decoupling versioning from spec versioning, process
+for including new licenses, list for version 1, etc.
+
+## Attendees
+
+  - Jack Manbeck, Texas Instruments
+  - Michael Herzog, nexB
+  - Soeren Rabenstein, ASUS
+  - Philippe Ombredanne, nexB Inc.
+  - Esteban Rockett, Motorola
+  - Phil Robb, Hewlett Packard
+  - Bill Schineller, Black Duck Software
+  - Philip Odence, Black Duck Software
+  - Phil Koltun, Linux Foundation
+  - Janet Campbell, Eclipse Foundation
+  - Pierre Lapointe, nexB
+  - Peter Williams, OpenLogic
+  - Kim Weins, OpenLogic
+  - Gary O'Neall, Source Auditor
+  - Mark Gisi, Wind River
+  - Ann Thornton, Freescale
+  - Kate Stewart, Canonical
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-10-14.md
+++ b/general/2010/2010-10-14.md
@@ -1,0 +1,61 @@
+**DRAFT**
+
+## Minutes
+
+  - Approval of minutes from Sept 23
+      - approved
+  - Outreach and evangelism:
+      - Industry Venues – PhilR - no update
+      - Website – MartinM - no update
+  - Roll Out Update - KimW
+      - Have seen some volunteers, more needed
+      - Provided summary of Open World Forum talk - good feedback and
+        interest.
+  - Legal Update - Rockett
+      - no update
+  - Licensing Subgroup Update - Kate/KimW
+      - meeting held on 9/24 with good input and discussions
+      - we'll be adopting the 1 page per license proposal that Callaway
+        put forward.
+      - discussion on what should be in initial version of spec, vs. web
+        site.
+  - RDF Subgroup Update - BillS
+      - Peter has been working on prototype that lets us encode the
+        specification within the RDF, approach looks promising.
+      - working through external vocabularies to see if concept match,
+        and we can leverage.
+  - Linux Foundation Code Repository - Kate
+      - got account info from Peter, Gary & Bill - need to forward on to
+        Linux Foundation.
+
+## Action Items
+
+  - Kate- Transfer document (.pdf) back to WIKI. - in porgress
+  - Kim- Clean up the sharing analysis to what is accurate. - Dave will
+    help out
+  - JeffL (w/Bill/Gary) - Update zlib based on new specification - Dave
+    is looking at as one of Open Logic examples.
+  - RDF Group- Work out syntax for 5.6/5.7 - pending
+  - Kate- Track and implement changes described in Spec from maillist. -
+    pending WIKI updates
+  - PeterW- Implement issue tracking system with Linux Foundation
+    infrastructure. - pending Kate communication
+  - Phil R- Update Industry Events. - pending
+  - Kate- Draft example for LF Member Counsel; include XML and
+    corresponding spreadsheet (or spreadsheet-like) format. - pending.
+
+## Attendees
+
+  - Tom Incorvia - MicroFocus
+  - Michael Herzog, nexB
+  - Phil Koltun, Linux Foundation
+  - Janet Campbell, Eclipse Foundation
+  - Peter Williams, OpenLogic
+  - Kim Weins, OpenLogic
+  - Ann Thompson, Freescale
+  - Dave M., Open Logic
+  - Gary O'Neall, Source Auditor
+  - Kate Stewart, Canonical
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-10-21.md
+++ b/general/2010/2010-10-21.md
@@ -1,0 +1,132 @@
+**DRAFT**
+
+## Agenda
+
+  - Attendance - 14
+  - Approval of minutes: 9/23 were approved on 10/14; 10/14 still need
+    to be entered and reviewed.
+  - Outreach and evangelism:
+      - Common Messaging/Presentation – PhilO
+          - no update
+      - Industry Venues – PhilR
+          - no update
+      - Website – MartinM
+          - website has been running smoothly for while, no missing
+            feature requests recently
+          - SPDX listed in spam databases - working to get spdx removed.
+          - BillS: any issue with posting HTML page? look to getting
+            subdirectory should be ok
+          - ''( **AI: Bill S** to send Martin some examples. '')
+  - Legal Update - Rockett
+      - SPDX file contents license - working on draft with Bradley,
+        under creative commons - make sure last person editing absolves
+        the previous person. Ideal goal is to work with Creative Commons
+        open source license author.
+      - Trademark use policy - Karen & Rockett to work on it. To be
+        reviewed with SPDX work group, prior to wider publishing**''
+        (AI: Rockett** to mail out trademark policy draft to SPDX
+        list)''
+      - Trademark processing in progress - looking for response back
+        early November '' (**AI: Rockett** to query status)''
+      - Second dedicated LF meeting is still to be scheduled, SPDX cliff
+        notes version needed for (see action item for Kate below),
+        Rockett to announce date.
+      - Some concern to make sure that SPDX is cast at appropriate light
+        with Linux Foundation, and is not oversold.
+  - Roll Out Update - KimW
+      - no changes on roll out - face to face date still pending
+      - key is how many people can participate, will be discussed
+        tomorrow, and Kim to mail out to wider group the plans. **''
+        (AI: Kim** to announce F2F plans after discussion)''
+  - Licensing Subgroup Update - Jilayne
+      - spreadsheet sent out with first list.
+      - guidelines created as went along - looking for review and
+        feedback from group.
+      - questions came up as looking at it - to be discussed in next
+        licensing meeting.
+      - next licensing meeting now scheduled for 11/12 at this time -
+        '**'(AI: Kim** to set up invite.) ''
+      - ***(AI all**: please review 6 months mail and contrast against
+        spreadsheet.)*
+      - Some discussion on headers and decision made to keep the syntax
+        of the text to be language neutral was made. (ie. C style
+        comments, Java style, etc. ignored )
+      - For now we'll keep working in spreadsheet, with goal of auto
+        translating it over to the html pages when stabilizes. (see
+        action for Martin/Bill to look at html pages written directly to
+        WIKI)
+  - RDF Subgroup Update - Peter
+      - concensus of how code RDF semantics into spec still in
+        discussion.
+      - group is at work on adding additional capabilities to licensing
+        part.
+      - 5.6/5.7 issue - one proposal adds 5.6 & 5.7 additional
+        properties (name and URL of project file belongs to) - alternate
+        proposal links to DOAP project that encodes the name and URL. ''
+        (**AI: Peter** will write up formal proposal between the two
+        proposal, and mail out to list. )''
+      - ***(AI: All** - Next meeting will be voting on it explicitly,
+        those that can't attend, are urged to post feedback/vote to
+        list.)*
+  - Spec Update - Kate
+      - 3.3 - changing field from SHA of tarball to XOR of file level
+        SHAs. '' (**AI: Kate** to write up formal proposal for change of
+        field and mail out to the list.''
+      - *(**AI: All** - please review and if there are technical flaws
+        open discussion on list, if no flaws figured out, next meeting
+        will vote on it changing).*
+      - 5.6/5.7 - discussion of mail list threads - clarification of
+        proposals? (see comments under RDF)
+      - no other spec field issues known pending at this time. Any new
+        suggestions/requests/comments, please post to list, and add
+        entry into appropriate point in WIKI.
+      - *(**AI: Kate** add back to SPEC page in WIKI - prefered syntax
+        for adding comments into SPEC)*
+
+## Action Items
+
+  - Kate- Transfer document (.pdf) back to WIKI. DONE
+  - Dave - Clean up the WIKI to only have analysis visible that reflects
+    current spec. IN PROCESS
+  - Dave/JeffL - Update zlib based on new specification IN PROCESS
+  - Peter - Mail out competing proposals for 5.6/5.7 IN PROCESS
+  - Kate- Track and (when Wiki is back up) implement changes described
+    in Spec section below. DONE (see above)
+  - PeterW- Implement issue tracking system. BLOCKED ON KATE
+  - Kate - submit ids to Linux Foundation so infrastructure setup can
+    proceed - pending.
+  - Kate- Draft example for LF Member Counsel; include XML and
+    corresponding spreadsheet (or spreadsheet-like) format. peinding
+  - Kim - list of questions from Open World Forum to form start of FAQ -
+    pending - will send mail to list with questions remembered, request
+    Phillipe O, add comments.
+  - Phil R - Update Industry Events.
+  - Kim/Martin - slides from OWF made available. Now posted on open
+    world - matin to post to SPDX or link. - DONE
+  - Kate - 10/14 minutes to be added to WIKI for review. - IN PROCESS
+
+New - See notes in above minutes.
+
+## Next Meeting
+
+  - 2010/01/04 at same time.
+
+## Attendees
+
+  - Tom Incorvia - MicroFocus
+  - Michael Herzog, nexB
+  - Esteban Rockett, Motorola
+  - Bill Schineller, Black Duck Software
+  - Phil Koltun, Linux Foundation
+  - Janet Campbell, Eclipse Foundation
+  - Peter Williams, OpenLogic
+  - Kim Weins, OpenLogic
+  - Eric W., Open Logic
+  - Dave M. Open Logic
+  - Jilayne Lovejoy, Open Logic
+  - Martin Michlmyer, HP
+  - Kate Stewart, Canonical
+  - Mark Gisi, Wind River
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-11-04.md
+++ b/general/2010/2010-11-04.md
@@ -1,0 +1,88 @@
+## Minutes
+
+  - Attendance - 13
+  - Approval of minutes: 10/14 and 10/21 minutes approved
+  - Outreach and evangelism:
+      - Common Messaging/Presentation – PhilO
+          - no update
+      - Industry Venues – PhilR
+          - no update
+      - Website – MartinM
+          - Rearranged so that spec under Specification tab can not be
+            edited with the working version being under Participation
+          - Dealt with some legacy spam reputation issues with spdx.org.
+  - Roll Out Update - KimW/JohnE
+      - Face to Face pushed out into Dec/Jan
+      - Need more volunteers before scheduling
+      - Beta program is most urgent item; John is back in action and
+        focusing on that.
+  - Legal Update - Rockett
+      - No update.
+  - Linux Plumbers report live from Cambridge
+      - Well received licensing presentation from Mark Gisi and Sven
+        Dummer included good plug for SPDX
+      - Interest from Yahoo\! in participation
+      - BoF discussion on creating SPDX report for the kernal.
+
+## Action Items
+
+Note: Drafting related action items are embedded in the Wiki.
+
+  - Dave - Clean up the WIKI to only have analysis visible that reflects
+    current spec. ON HOLD FOR MARTIN TO PROVIDE PRIVS; SHOULD BE
+    UNDERWAY
+  - Dave/JeffL - Update zlib based on new specification DONE, BUT
+    AWAITING FEEDBACK
+  - Peter - Mail out competing proposals for 5.6/5.7 DONE
+  - PeterW- Implement issue tracking system. BLOCKED ON KATE
+  - Kate - submit ids to Linux Foundation so infrastructure setup can
+    proceed - PENDING
+  - Kate- Draft example for LF Member Counsel; include XML and
+    corresponding spreadsheet (or spreadsheet-like) format. PENDING
+  - Kim - list of questions from Open World Forum to form start of FAQ -
+    pending - will send mail to list with questions remembered, request
+    Phillipe O, add comments. DONE
+  - Phil R - Update Industry Events. IN PROCESS
+  - Kate - 10/14 minutes to be added to WIKI for review. - DONE
+  - Bill S - Send Martin some examples of issue posting HTML. DONE
+  - Rockett- Mail out trademark policy draft to SPDX list. WAITING FOR
+    SIGNOFF BY LF
+  - Rockett- Query status of trademark application TBD
+  - Kim- Update of plans for Face to Face DONE
+  - Kim- Send out invite for next licensing meeting. DONE. WILL INCLUDE
+    FOLKS FROM DEBIAN.
+  - All- Review 6 months mail and contrast against licensing group
+    spreadsheet. FOR NEXT LICENSE GRP MEETING
+  - All- If you can't attend meeting, post feedback/vote to list on
+    5.6/5.7 proposals. FOR TECH AGENDA NXT MTG.
+  - Kate- Write up formal proposal on SHA field change and mail to list.
+    IN PROCESS
+  - All- Review SHA field change proposal for technical flaws; if so,
+    discuss on list. FOR TECH AGENDA NXT MEETING
+  - Kate- Add back to SPEC page in WIKI preferred syntax for adding
+    comments. TBD
+
+## Next Meeting
+
+  - 2010/11/18 at same time. NOTE EURO/US TIME DIFF WILL BE BACK TO
+    NORMAL.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Tom Incorvia - MicroFocus
+  - Esteban Rockett, MotorolA
+  - Peter Williams, OpenLogic
+  - Kim Weins, OpenLogic
+  - Dave M. Open Logic
+  - Jilayne Lovejoy, Open Logic
+  - Martin Michlmyer, HP
+  - Kate Stewart, Canonical
+  - Ann Thompson, Freescale
+  - Gary O'Neall, Source Auditor
+  - Phil Robb, HP
+  - John Ellis, Motorola
+  - Marshall Clow, Qualcomm
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-11-18.md
+++ b/general/2010/2010-11-18.md
@@ -1,0 +1,105 @@
+## Minutes
+
+  - Attendance - 14
+  - Approval of minutes: 11/4 minutes approved
+  - Outreach and evangelism:
+      - Common Messaging/Presentation – PhilO
+          - no update
+      - Industry Venues – PhilR
+          - no update
+      - Website – MartinM
+          - Enhanced as per Organizational Structure discussion below.
+  - Roll Out Update - KimW/JohnE
+      - In lieu of Face to Face will start bi-weekly virtually meetings
+        as "Business Team"
+      - Critical that we get betas going in Q1. Looking for friendlies
+        and ideally pairs of companies who exchange software in a supply
+        chain. Anyone interested should talk to John E
+  - Legal Update - Rockett
+      - No update.
+  - SPDX Group Organizational Structure- PhilO
+      - Organization has been organically developing into 3 distinct,
+        thought interdependent workstreams
+          - Technical, Business and Legal
+      - We are evolving the organization into three teams to reflect
+        this.
+      - Each team will have it's own place on spdx.org, mailing list,
+        and meetings
+      - This meeting will continue as the General Meeting, run by Phil,
+        to coordinate workstreams.
+      - Details in attached slides
+  - Git Repo - Pete W
+      - Peter has set up the Git repository such that
+          - It embeds the RDF ontology
+          - Can export to HTML or .pdf
+          - Handles process for proposing/approving changes
+  - RDF - BillS
+      - Weekly meeting with Kate, Peter, Gary, Bill.
+      - Recommended one of two alternatives for handling file
+        information.
+      - Group approved [artifactOf
+        proposal](Technical_Team/Proposals/2010-10-21/artifactOf "wikilink")
+      - Note: This involves referencing a DOAP file, but does not
+        require all fields in complete DOAP file
+  - Licensing Team- KimW
+      - GPL "or later" issue
+      - Group agreed that "or later" licenses need to be handled as
+        separate items in license list.
+      - Next item on licensing agenda is to develop a strategy for
+        handling exceptions
+      - This work will migrate to the Legal Team
+
+## Action Items
+
+Note: Drafting related action items are embedded in the Wiki.
+
+  - Dave - Clean up the WIKI to only have analysis visible that reflects
+    current spec. DONE
+  - Dave/JeffL - Update zlib based on new specification DONE, BUT
+    AWAITING FEEDBACK FROM GARY
+  - PeterW- Implement issue tracking system. BLOCKED ON KATE
+  - Kate - submit ids to Linux Foundation so infrastructure setup can
+    proceed - PENDING
+  - Kate- Draft example for LF Member Counsel; include XML and
+    corresponding spreadsheet (or spreadsheet-like) format. PENDING
+  - Phil R - Update Industry Events. DONE
+  - Rockett- Mail out trademark policy draft to SPDX list. DONE.
+  - Rockett- Query status of trademark application DONE. APPLICATION IS
+    IN AN WAITING FOR ASSIGNMENT OF A TM EXAMINER
+  - All- Review 6 months mail and contrast against licensing group
+    spreadsheet. FOR NEXT LICENSE GRP MEETING
+  - All- If you can't attend meeting, post feedback/vote to list on
+    5.6/5.7 proposals. DONE
+  - Kate- Write up formal proposal on SHA field change and mail to list.
+    IN PROCESS
+  - All- Review SHA field change proposal for technical flaws; if so,
+    discuss on list. FOR TECH AGENDA NXT MEETING
+  - Kate- Add back to SPEC page in WIKI preferred syntax for adding
+    comments. TO BE DONE
+  - Michael H- Write up and share position on "reporting" vs.
+    "interpreting."
+  - PhilO- Get legal team input on Michael's position.
+
+## Next Meeting
+
+  - 2010/12/2 at same time.
+
+## Attendees
+
+  - Peter Williams, OpenLogic
+  - Kim Weins, OpenLogic
+  - Marshall Clow, Qualcomm
+  - John Ellis, Motorola
+  - Eric Weidner - OpenLogic
+  - Tom Incorvia, MicroFocus
+  - Gary O'Neall, Source Auditor
+  - Michael Herzog, nexB
+  - Phil Koltun, Linux Foundation
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Jilayne Lovejoy, OpenLogic
+  - Bill Schineller, Black Duck Software
+  - Philip Odence, Black Duck Software
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-12-02.md
+++ b/general/2010/2010-12-02.md
@@ -1,0 +1,74 @@
+  - Attendance - 14
+  - Minutes from 18 Nov meeting approved
+
+## Technical Team Report
+
+  - Working through RDF issues to make sure consistent with tagged
+    version.
+  - Proposals floating around on the technical mailing list.
+  - Regular meetings on Tuesdays.
+  - Need more folks to migrate to technical mailing list.
+
+## Business Team Report
+
+  - Regular meetings are on the schedule. Same day/time as General
+    Meeting on alternate weeks.
+  - Kim has posted slides overviewing roll out issues with initial
+    ideas.
+  - A working draft wiki for FAQs has been started. Looking for as much
+    input at possible.
+
+## Legal Team Report
+
+  - Regular meetings will be the day before General Meeting.
+  - First scheduled for 15 Dec (and will be longer than normal).
+  - Invitations going out to general SPDX list, Linux Found Member
+    Counsel list, and Project Harmony
+  - Items for first meeting:
+      - Handing off work from License Team
+      - Addressing any questions from LF Member Counsel
+      - Setting going-forward agenda for Team
+  - License Team meeting for 3 Dec is still on.
+
+## Cross Functional Issues
+
+  - Agenda for this meeting seems to work fine. Meeting schedule may go
+    to 30 mins.
+  - Need folks to migrate to respective mailing lists.
+      - Current lists, Technical- 8, Business- 6, Legal- 7
+
+## Action Items
+
+  - Kate- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+  - Kate- Add back to Spec page in wiki preferred syntax for adding
+    comments. PENDING
+      - **\<kes\>** *20101215 done. see:
+        <http://www.spdx.org/spec/current/> have also added same
+        commentary to other related WIKI pages.*
+  - MichaelH- Write up and share postion on "reporting" vs.
+    "interpreting. NO UPDATE
+  - PhilO- Get input on MH position from Legal Team and get resolution.
+  - GaryO- Post regular meeting times on Tech Team page.
+  - Rockett- Post regular meeting times on Legal Team page.
+  - MartinM- Report back on \# of people on respective mailing lists.
+
+## Attendees
+
+  - Kate Stewart, Canonical
+  - Phil Odence, Black Duck Software
+  - Bill Schineller, Black Duck Software
+  - Tom Incorvia, MicroFocus
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Jilayne Lovejoy, OpenLogic
+  - Dave McLoughlin, OpenLogic
+  - Phil Koltun, Linux Foundation
+  - Gary O'Neall, Source Auditor
+  - Martin Michlmayr, HP
+  - Ann Thornton, Freescale
+  - John Ellis, Motorola
+  - Esteban Rockett, Motorola
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2010/2010-12-16.md
+++ b/general/2010/2010-12-16.md
@@ -1,0 +1,74 @@
+  - Attendance - 12
+  - Minutes from 2 Dec meeting approved
+
+## Technical Team Report
+
+  - Still going back and forth on grammar and syntax, resolving RDF and
+    tag value
+  - Various proposals will be circulating
+  - Next priority is defining a license template
+
+## Business Team Report
+
+  - Beta program starting up. Aiming to start late Q1 and wrap in late
+    Q2
+  - Some tooling needs to be in place prior to make it easier to
+    generate syntactically correct RDF as well as to create human
+    readable format. Gary's 'pretty printer' is a good starting point
+  - Ideally seeking pairs of supply chain partners for beta. Motorola
+    and HP are interested. Maybe Fedora.
+  - Ping KimW if interested or with ideas
+
+## Legal Team Report
+
+  - Kicked of regular meetings.
+  - First Meeting: successfully bridging from licensing sub-team to new
+    Legal Team. Good discussion about handling GPL3 exceptions. Also
+    about rev'ing license list. And what is "required" for valid SPDX
+  - Much discussion about license list. Conclusion as that we should add
+    a field to SPDX that specifies the version of the license list used
+    to generate the file. The version number for the list will be date
+    based.
+
+## Cross Functional Issues
+
+  - Collaboration Summit. April 6-8, San Francisco
+      - Will be a compliance track on Thursday morning, the 7th
+        including SPDX presentation
+      - Tech Team will meet Thursday afternoon; Business Team, Friday
+        morning
+      - Legal Team may meet at Euro event or may try a teleconference
+  - Need folks to migrate to respective mailing lists.
+      - Current lists, Technical- 10 (up 2), Business- 7 (up 1), Legal-
+        12 (up 5)
+
+## Action Items
+
+  - Kate/Kim- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+  - Kate- Add back to Spec page in wiki preferred syntax for adding
+    comments. DONE
+  - MichaelH/Rockett- Write up and share postion on "reporting" vs.
+    "interpreting. PENDING
+  - GaryO- Post regular meeting times on Tech Team page. DONE
+  - Rockett- Post regular meeting times on Legal Team page. PENDING
+  - MartinM- Report back on \# of people on respective mailing lists.
+    DONE, BUT LET'S KEEP UPDATING
+
+## Attendees
+
+  - Kate Stewart, Canonical
+  - Phil Odence, Black Duck Software
+  - Bill Schineller, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Jilayne Lovejoy, OpenLogic
+  - Phil Koltun, Linux Foundation
+  - Gary O'Neall, Source Auditor
+  - Martin Michlmayr, HP
+  - Esteban Rockett, Motorola
+  - Michael Herzog, nexB
+  - Pierre Lapointe, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-01-13.md
+++ b/general/2011/2011-01-13.md
@@ -1,0 +1,85 @@
+  - Attendance - 13
+  - Minutes from 16 Dec meeting approved
+
+## Technical Team Report
+
+  - New Infrastructure is up and running
+      - [Bugzilla is in place](http://bugs.linux-foundation.org/). (use
+        will be broad including tracking issues with documentation and
+        the website for example) All are encouraged to set up accounts.
+      - GIT repository- Gary's pretty printer and the RDF version are up
+        already.
+  - DEP-5 proposal is in draft state. if we want to sync with them in
+    any way, the time is right. They are open, for example to using the
+    same license short names. We'll assess current gaps and then decide
+    how to proceed.
+  - The spdx-tech mailing list is very active; interested parties are
+    encouraged to
+    [join](https://fossbazaar.org/mailman/listinfo/spdx-tech).
+  - Started on the grammar for the tag version to facilitate the
+    comprehension of it for the RDF/tag form translation.
+
+## Business Team Report
+
+  - Beta program
+      - Progressing
+      - 5 organizations are interested. (WindRiver/HP have agreed to
+        work together)
+      - Kickoff meeting with participants Feb3 during the normal Biz
+        Team.
+  - Next big issue to deal with is getting end user content developed
+    (doc, training, etc.).
+
+## Legal Team Report
+
+  - Task of developing a process for adding new licenses to the license
+    list has been handed off to Biz Team.
+  - Rockett/Jilayne and Soren working on the license template scheme.
+  - Team has been discussing how the spec will influence the way in
+    which the content of SPDX docs is licensed. Team is leaning towards
+    MIT/BSD.
+
+## Cross Functional Issues
+
+  - Much discussion on the issue of subjectivity v. objectivity with
+    respect to file licenses.
+  - Example- License A text in header, but author of SPDX doc believes
+    actually License B.
+  - Several in the discussion were adamant that the stated license in
+    the file needed to be specified.
+  - Others felt it was important to include the license author's
+    believed correct license.
+  - Group came to broad agreement on the idea of including fields for
+    both and a comments field to explain discrepancies.
+  - Discussion to be continued in ad hoc Legal Team meeting tomorrow.
+
+## Action Items
+
+  - Kate/Kim- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+  - MichaelH/Rockett- Write up and share postion on "reporting" vs.
+    "interpreting. PENDING
+  - Rockett- Post regular meeting times on Legal Team page. DONE
+  - MartinM- Report back on \# of people on respective mailing lists.
+    DONE, BUT LET'S KEEP UPDATING
+  - Jilayne- Add column to license list showing DEP-5 short names for
+    comparison.
+
+## Attendees
+
+  - Kate Stewart, Canonical
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Jilayne Lovejoy, OpenLogic
+  - Phil Koltun, Linux Foundation
+  - Gary O'Neall, Source Auditor
+  - Esteban Rockett, Motorola
+  - Michael Herzog, nexB
+  - Pierre Lapointe, nexB
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Tom Incorvia, Microfocus
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-01-27.md
+++ b/general/2011/2011-01-27.md
@@ -1,0 +1,58 @@
+  - Attendance - 9
+  - Minutes from 13 Jan meeting approved
+
+## Technical Team Report
+
+  - Met Tuesday with Kate joining from Australia
+  - Most of the discussion was about new license fields in file section
+    of spec
+
+## Business Team Report
+
+  - Questions for Tech Team on how the schedule looks. Generally good
+    for end of Q1 completion of what's required for beta, albeit Kate
+    was not here to weigh in.
+  - Beta program
+      - Kickoff meeting with participants Feb3 during the normal Biz
+        Team. Feel free to participate or invite anyone interested.
+      - There will be subsequent meetings with partner pairs
+      - Should be ready to go in April
+
+## Legal Team Report From PhilO/Jilayne in Rockett's absence)
+
+  - Recent focus has been on new fields for file licenses:
+      - Concluded License- Based on author's analysis
+      - License Information in File- Just what's in the file
+      - Also a field for explanation of basis for conclusion
+  - We will change a handful of license short names for consistency with
+    DEP-5 list
+
+## Cross Functional Issues
+
+  - PhilO explained new Master Schedule under General Meeting
+
+## Action Items
+
+  - Kate/Kim- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+  - MichaelH/Rockett- Write up and share postion on "reporting" vs.
+    "interpreting". PENDING
+  - MartinM- Report back on \# of people on respective mailing lists.
+    DONE, BUT LET'S KEEP UPDATING
+  - Jilayne- Add column to license list showing Deb5 short names for
+    comparison. DONE
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Jilayne Lovejoy, OpenLogic
+  - Phil Koltun, Linux Foundation
+  - Gary O'Neall, Source Auditor
+  - Mark Gisi, Wind River
+  - Guillaume Rousseau, Antelink
+  - Bill Schineller, Black Duck Software
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-02-10.md
+++ b/general/2011/2011-02-10.md
@@ -1,0 +1,70 @@
+  - Attendance - 13
+  - Minutes from 27 Jan meeting approved
+
+## Technical Team Report
+
+  - Gary/Peter created punchlist of key issues that need to be addressed
+    before beta.
+      - Finalize RDF/XML
+      - Clean up Grammer
+      - Mesh spreadsheet license list, on-line list and RDF
+  - Kate drafted spreadsheet view of SPDX file which Gary is using as
+    basis for translation tools. Will circulate.
+  - Seem to be on schedule genearlly
+
+## Business Team Report
+
+  - Beta program
+      - Good briefing meeting with 4 candidates. Following up wth two
+        more.
+      - Need coordinator volunteers
+  - Starting to address need for end user content developed (doc,
+    training, etc.).
+  - Next issue in the queue is defining the process to add a license to
+    the standard list.
+
+## Legal Team Report
+
+  - Section 5.3 revision is mostly settled. Some final tweaking of field
+    names was the last issue.
+  - Karen and Rockett are updating LF Member Counsel with the message
+    "it's time" to pay attention and weigh in.
+  - In process of making recommendations for default license for SPDX
+    data in a file and for SPDX tool licensing.
+
+## Cross Functional Issues
+
+  - Tech and Biz teams will meet face to face at Linux Collab Summit
+    (Tech pm 4/7, Biz am 4/8)
+  - Agreed that SPDX general list should not be for extended
+    discussions, which should be directed to respective team lists.
+
+## Action Items
+
+  - Kate/Kim- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+  - MichaelH/Rockett- Write up and share postion on "reporting" vs.
+    "interpreting. PENDING
+  - MartinM- Report back on \# of people on respective mailing lists.
+    DONE, BUT LET'S KEEP UPDATING
+  - Kim/Kate- Provide PhilK with paragraph descriptions of Collab Summit
+    sessions by 2/17
+
+## Attendees
+
+  - Kate Stewart, Canonical
+  - Phil Odence, Black Duck Software
+  - Kirsten Newcomer, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Jilayne Lovejoy, OpenLogic
+  - Phil Koltun, Linux Foundation
+  - Gary O'Neall, Source Auditor
+  - Michael Herzog, nexB
+  - Pierre Lapointe, nexB
+  - Mark Gisi, Wind River
+  - Tom Incorvia, Microfocus
+  - Karen Copenhaver, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-02-24.md
+++ b/general/2011/2011-02-24.md
@@ -1,0 +1,116 @@
+  - Attendance: 9
+  - Minutes from 2012-02-10 approved
+
+## Technical Team Report - Kate
+
+Mid March is now target for spreadsheet in draft form, with spec that
+correlates to spreadsheet.
+
+  - license spreadsheet - hooking up with legal team (Jilayne, Rockett,
+    Soren - needs work)
+  - templatizing of license and headers - will go with copy of main text
+    directly as backup position, will work with legal team to get
+    guidelines for automated translation to templatized version.
+
+## Business Team Report - Kim
+
+  - current focus on nailing down beta sites. 3- trading partner groups
+    committed, handful of other on investigation list
+  - will have beta coordinator assigned to each trading group; for
+    facilitation and working with beta partner, need technical and
+    support help to work through beta coords. ( content for FAQ, etc. )
+  - Will need to do technical training?- Kristen will work on tools
+      - AI tech team: drafts of spreadsheet, and spec by March 17th.
+      - AI tech team: Need Technical Training volunteers
+  - Face to face meeting at Collab will focus on see where things are
+    with Beta; talk about roll out - 4 months away.
+  - AI: Kim to document - coodinator volunteers associated with beta
+    sites listed.
+
+## Legal Team Report - Rockett
+
+  - meeting schedule has shifted meeting from 2/23 to 3/2. Resume normal
+    bi-weekly on on 3/9.
+  - finalized section 5.3 - how ones concludes the license. Last
+    revision from the call documented in Legal team minutes
+  - license template would like to move from having to copy text as
+    default for templatized version of license
+  - license list candidates - please let Jilayne know if there's input
+    before next Wednesday
+  - Linux Foundation Legal Counsels meeting went smoothly, no issues
+    raised.
+  - Jilayne and Rockett - attending European Legal Conference, on
+    panels; looking for input from prior presentations, and will
+    Kate/Kim prior to meeting.
+
+## Other
+
+  - IFOSSLR article came out
+  - RDF format, no one is opposed to its inclusion. Also desire to keep
+    XML as readable as possible, maybe look at HTML 5 as a varient of
+    output. Need to contact Scott Lehman at HP, FOSSology.
+
+## Cross Functional Issues – Kate (for Phil)
+
+  - '''Collaboration Summit ''' - Phil Kolton, Phil Odence, Kate
+    Stewart, ??
+      - Tech meeting Thursday afternoon
+      - Business meeting Friday,
+      - 1/2 day track on legal related issues Thursday morning
+      - anyone needing invite, please work with Phil Kolton, who else
+        planning to attend?
+  - '''European Legal Conf '''- Scott Peterson, Rockett, Jilyane, Karen
+    C.
+      - who else there, make sense for separate meeting?
+  - **OSBC** - May
+      - Kim reported Mark Radcliff will talk there, may mention SPDX as
+        part of this.
+  - '''OSCON '''- anything about SPDX? maybe look at targetting?
+      - AI: Business team to follow up?
+  - **CFP for Linux Foundation** - LinuxCon north america - getting
+    ready for launch.
+      - AI: need to get proposals put together
+
+## Action Items
+
+Most of the action items belong with the Teams. So, in addition to
+statusing, we will dispatch them to the respective teams and will not
+continue to track in this meeting. Action items for this meeting will be
+cross functional.
+
+  - Kate/Kim- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+      - Beta collateral - March 17th.
+  - MichaelH/Rockett- Write up and share postion on "reporting" vs.
+    "interpreting. PENDING
+      - converged on section 5.3; so can declare it done, will make sure
+        that revised 5.3 can resolve with Michael offline.
+  - MartinM- Report back on \# of people on respective mailing lists.
+    DONE, BUT LET'S KEEP UPDATING
+      - Business 11 -\> 15; Legal 17-\>21 ; Tech 16-\>20
+  - Kim/Kate- Provide PhilK with paragraph descriptions of Collab Summit
+    sessions by 2/17
+      - DONE
+
+**New Actions:**
+
+We need to capture a list of who will be at face to face meeting - each
+of the work groups to
+
+  - AI: create signup on WIKI, adverstise in subgroups, and on these
+    minutes/list.
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Bill Schineller, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Esteban Rockett, Motorola
+  - Phil Koltun, Linux Foundation
+  - Kate Stewart, Canonical
+  - Tom Incorvia, Microfocus
+  - Martin Michlmayr, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-03-11.md
+++ b/general/2011/2011-03-11.md
@@ -1,0 +1,93 @@
+  - Attendance: 11
+  - Minutes from 2011-02-24 -- acceptance deferred
+
+## Technical Team Report - Kate
+
+Still working through RDF issues/model and spreadsheet to resolve
+naming, and with a focus on:
+
+  - licensing substructure; team plans to post a proposal for general
+    review
+  - templatizing of license and headers to support legal team;
+    guidelines are available on the legal team wiki
+
+## Business Team Report
+
+Kim was traveling. No update from Business Team at this time.
+
+## Legal Team Report - Rockett
+
+  - license templatizing: 75% of the way through on proposal for
+    normalization of non-significant variants. Goal is to have proposal
+    ready by March 23rd.
+  - granular discussion of metadata is on-going. No conclusions yet.
+    Karen and Rockett will make a proposal; date for proposal TBD.
+  - Concluded: any tools coming out of the SPDX project will be licensed
+    under Apache 2.0 and SPDX will recommend Apache 2.0 for 3rd party
+    FOSS tools for this project. Gary will update the tools he's writing
+    to use the Apache 2.0 license.
+
+## Cross Functional Issues – Kate (for Phil)
+
+  - '''Collaboration Summit ''' - Phil Kolton, Phil Odence, Kate
+    Stewart, ??
+      - Agenda has been posted:
+        <http://events.linuxfoundation.org/events/collaboration-summit/schedule>
+          - Tech meeting Thursday afternoon
+          - Business meeting Friday,
+          - 1/2 day track on legal related issues Thursday morning
+      - anyone planning to attend should request an invite via the Linux
+        Collaboration web site. (see link above)
+      - Phil O. will set up wiki page to help us track those planning to
+        attend
+  - '''European Legal Conf '''- Scott Peterson, Rockett, Jilyane, Karen
+    C.
+      - legal team is planning a panel presentation with spdx
+        description and open session for questions
+      - Karen suggested it would be helpful to have beta participants in
+        audience
+      - Karen also recommended that the description include broader
+        context about why the SPDX standard is needed and its goals
+      - Consider conference to be a mini-launch of SPDX spec. Karen will
+        work with Kim to get press release announcing beta
+  - **CFP for Linux Foundation** - LinuxCon north america - getting
+    ready for launch.
+      - Phil Koulton to provide deadline info for call for papers
+
+## Action Items
+
+Most of the action items belong with the Teams. So, in addition to
+statusing, we will dispatch them to the respective teams and will not
+continue to track in this meeting. Action items for this meeting will be
+cross functional.
+
+  - Kate/Kim- Draft example for LF Member Counsel; include XML and
+    spreadsheet. PENDING
+      - Beta collateral - March 17th.
+  - MichaelH/Rockett- Write up and share postion on "reporting" vs.
+    "interpreting. CLOSED
+      - converged on section 5.3; Update available in legal team minutes
+  - MartinM- Report back on \# of people on respective mailing lists.
+    DONE, BUT LET'S KEEP UPDATING
+      - Business 11 -\> 15; Legal 17-\>21 ; Tech 16-\>20
+  - Phil O. - Capture a list of who will be at face to face meeting -
+    PENDING
+  - create signup on WIKI for LinuxCollabSummit attendees, adverstise in
+    subgroups, and on these minutes/list.
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Bill Schineller, Black Duck Software
+  - Peter Williams, OpenLogic
+  - Esteban Rockett, Motorola
+  - Phil Koltun, Linux Foundation
+  - Kate Stewart, Canonical
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Jillayne Lovejoy, OpenLogic
+  - Karen Copenhaver, LF/Choate
+  - Michael Herzog, NexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-03-24.md
+++ b/general/2011/2011-03-24.md
@@ -1,0 +1,107 @@
+  - Attendance: 15
+  - Minutes accepted
+    [General\_Meeting/Minutes/2011-02-24](General_Meeting/Minutes/2011-02-24 "wikilink")
+    and
+    [General\_Meeting/Minutes/2011-03-11](General_Meeting/Minutes/2011-03-11 "wikilink")
+
+## Technical Team Report - Kate
+
+After a great deal of effort, the team has converged on a consistent set
+of field names which will by synch'ed with all forms of spec shortly.
+
+There are still a couple of areas of open issues which are dependent on
+the Legal Team, most having to do with who created the SPDX file.
+
+Kate will be starting up a wiki page with an agenda for the upcoming
+Face to Face; participants should feel free to provide input.
+
+## Business Team Report - Phil
+
+Beta training materials are not complete, but are in motion and should
+be fine for beta.
+
+In the last meeting there was a lot of discussion about a process for
+requesting/evaluating/adding new licenses to the standard list. See
+[last Business Team meeting's
+minutes](Business_Team/Minutes/2011-03-17 "wikilink") for details.
+
+## Legal Team Report - Rockett
+
+SPDX Tool/Template Licensing- Done, we'll be using Apache 2.0
+
+Metadata Licensing
+
+  - Stil active discussion delving in aspects of:
+      - Confidentiality
+      - Trace ability and change logging
+      - Copyright
+  - Rockett and Kate are having an offline discussion to pull it all
+    together.
+
+Templatizing (defining what insubstantial variants are OK for a match to
+a standard license)
+
+  - Proposal being reviewed within Legal Team
+  - Ready for presentation to other teams in the next 1-2 months
+
+## Cross Functional Issues – Phil
+
+Collaboration Summit:
+
+  - Agenda has been posted:
+    <http://events.linuxfoundation.org/events/collaboration-summit/schedule>
+      - Tech Team meeting Thursday afternoon
+      - Business Team meeting Friday,
+      - 1/2 day track on legal related issues Thursday morning
+  - anyone planning to attend should request an invite via the Linux
+    Collaboration web site. (see link above)
+  - Please RSVP for Face to Face sessions on [Wiki
+    page](Old/Linux_Collaboration_Summit_2011 "wikilink")
+
+Discussion about how to handle "Newbee" question that come in on lists
+
+  - Asking Business Team to take on providing guidelines to other teams
+    and general
+  - General feeling that we need a process to
+      - Respond in 24 hours
+      - Provide answers that are consistent with "party line" but at the
+        same time helpful
+      - Ensure that good questions / answers get captured in FAQ
+
+## Action Items
+
+Most of the action items belong with the Teams. So, in addition to
+statusing, we will dispatch them to the respective teams and will not
+continue to track in this meeting. Action items for this meeting will be
+cross functional.
+
+  - Kate- Beta collateral: Examples in XML and spreadsheet form. PENDING
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+      - \*\* spdx: 98
+      - spdz-biz: 17
+      - spdx-legal: 23
+      - spdx-tech: 21
+  - Phil O. - Capture a list of who will be at face to face meeting -
+    DONE
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kirsten Newcomer, Black Duck Software
+  - Esteban Rockett, Motorola
+  - Phil Koltun, Linux Foundation
+  - Kate Stewart, Canonical
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Jillayne Lovejoy, OpenLogic
+  - Karen Copenhaver, LF/Choate
+  - Michael Herzog, NexB
+  - Pierre Lapointe, NexB
+  - Kamal Hassin, Protecode
+  - Jilayne Lovejoy, Open Logic
+  - Martin Michlmayr, HP
+  - Bill Schineller, Black Duck Software
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-04-21.md
+++ b/general/2011/2011-04-21.md
@@ -1,0 +1,104 @@
+  - Attendance: 10
+  - Minutes accepted
+    [General\_Meeting/Minutes/2011-02-24](General_Meeting/Minutes/2011-02-24 "wikilink")
+
+## Technical Team Report - Kate
+
+Team is recovering from specification review held at the Linux
+Collaboration Summit face-to-face meeting.
+
+An initial revised draft (PDF) incorporating first round of feedback,
+dated 20110411, is posted here:
+<http://spdx.org/wiki/spdx/specification>
+
+Team is working through discrepancies and adding examples for RDF
+
+It's still possible to have the tools complete (alpha quality) by the
+end of April, or within one week of beta spec being finalized.
+
+Requested feedback from legal team on web page location (URI) for
+special terms such as UNDETERMINED.
+
+  - Previously specified: the URI for these terms points to entries on
+    on the spdx.org/licenses web page
+  - New proposal: the URL for these terms points to appropriate Terms
+    page on the spdx.org web page. Reasoning: These special terms are
+    used for data fields for License, Copyright, and Project
+    download/homepage URIs. Since the terms are not specific to
+    licenses, it seems more appropriate to post the definitions for
+    these terms on a terminology web page rather than the
+    spdx.org/licenses web page.
+
+## Business Team Report - Kim
+
+Coordinators have been identified for the 3 beta pairs. Kick off calls
+planned for early May (likely 2nd week).
+
+Training materials in progress and will be finalized once beta spec is
+final.
+
+Three new discussion/action threads were identified at the Linux
+Collaboration Summit face-to-face
+
+  - connect with yocto project and possibly other build tools for
+    potential integration
+  - outreach to additional open source communities
+  - review/update SPDX website for ease-of-use by newly members, beta
+    participants and casual users
+
+## Legal Team Report - Rockett
+
+2 active discussions continue: metadata licensing and how to handle
+id'ing author/reviewer
+
+Metadata Licensing: Stil active discussion delving in aspects of:
+
+  - Confidentiality
+      - when exchanged between two parties
+      - when made public (how to avoid copyright issues)
+
+How to handle id'ing authors/reviewers
+
+  - There is value in this data
+  - Pedigree data creates concerns
+  - Making author/reviewing anonymous creates trust issues
+
+Related: Trying to determine beta approach for audit / revision history
+
+  - Change log has been proposed but there are timing and complexity
+    questions
+  - Working to put together straw man
+  - Team considers this is not required for beta but would like input
+    from beta participants
+  - This becomes more important as supply chain expands beyond two
+
+## Action Items
+
+Most of the action items belong with the Teams. So, in addition to
+statusing, we will dispatch them to the respective teams and will not
+continue to track in this meeting. Action items for this meeting will be
+cross functional.
+
+  - Kate- Beta collateral: Examples in XML and spreadsheet form. PENDING
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+      - spdx: 98
+      - spdz-biz: 17
+      - spdx-legal: 23
+      - spdx-tech: 21
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Esteban Rockett, Motorola
+  - Kate Stewart, Canonical
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Jillayne Lovejoy, OpenLogic
+  - Michael Herzog, NexB
+  - Kamal Hassin, Protecode
+  - Peter Wiliams, OpenLogic
+  - Richard Faulk, Black Duck
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-05-05.md
+++ b/general/2011/2011-05-05.md
@@ -1,0 +1,86 @@
+  - Attendance: 15
+  - Minutes accepted
+
+## Technical Team Report - Bill
+
+Good Progress
+
+One specific blocking item/for spec and tools. The issue is has to do
+with set of terms to describe situation where a concluded license is not
+named. Team had been working with terms such as: None, No Assertion, Not
+Analyzed, Blank. They are working on a final proposal but are leaning
+towards two values one indcating that there has been a conclusion that
+there is no license and one indicating that there is no conclusion one
+way or the other.
+
+Team is asking for some ratification from the legal team, but proceeding
+on the two value path.
+
+## Business Team Report - Kim
+
+Beta kickoffs are scheduled.
+
+Final field names are getting merged into the training and tool docs by
+Kim and Kirsten resepctively.
+
+## Legal Team Report - Rockett
+
+Metadata licensing issue still under discussion
+
+Team is reviewing the need for including change tracking of SPDX docs in
+the spec. This will not hold up the beta. There was a discussion about
+how major a requirement this would be, i.e. would it necessarily hold up
+V1.0 past LinuxCon in August. The general sense from members of the Tech
+Team (which has been contemplating the issue) was that it would not by
+itself.
+
+## Cross Functional Issues – Phil
+
+Website: A workign group of Kirsten, Pierre and Steve have been
+reviewing the website for usability. They are recommending the "three
+big buttons" approach to the home page for folks who are:
+
+  - New to SPDX and want to get up to speed
+  - Familar and looking for official information on the spec and how to
+    use
+  - Interested in participating in development of the spec
+
+Their other major recommendation was to have drop down menus to give
+more visibility into the various sections of the website from the home
+page.
+
+There was lots of spirited discussion and opinions, but general
+agreement on the direction.
+
+The team will be developing and circulating mockups for subsequent
+feedback.
+
+## Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+      - spdx: 98
+      - spdz-biz: 17
+      - spdx-legal: 23
+      - spdx-tech: 21
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kirsten Newcomer, Black Duck Software
+  - Esteban Rockett, Motorola
+  - Phil Koltun, Linux Foundation
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Jillayne Lovejoy, OpenLogic
+  - Michael Herzog, NexB
+  - Pierre Lapointe, NexB
+  - Martin Michlmayr, HP
+  - Bill Schineller, Black Duck Software
+  - Kim Weins, Open Logic
+  - Peter Williams, Open Logic
+  - Mark Gisi, Wind River
+  - Steve Cropper, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-05-19.md
+++ b/general/2011/2011-05-19.md
@@ -1,0 +1,68 @@
+  - Attendance: 14
+  - Minutes accepted
+
+## Technical Team Report - Kate
+
+New version up with RDF vocabulary appendix. Please review
+
+Tools are keeping up. Only one known oustanding issue at this point.
+
+## Legal Team Report - Rockett
+
+License State Discussion
+
+  - Centers on states for undetermined Discovered licenses: "None" and
+    "No Assertion"
+  - Several calls
+  - All seem to be aligned
+
+Going through latest spec version
+
+Licensing of Metadata
+
+  - Concluded that an existing license is a little too long but OK for
+    purpose
+  - Will circle back once more but will likely approve
+
+## Business Team Report
+
+Abreviated as Kim was unavailable
+
+## Cross Functional Issues – Phil
+
+Brief statuse on website. Team is working on a story board
+
+OSBC report- No formal presentation, but mentioned on a panel with very
+positive reception
+
+## Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+
+New
+
+  - Kirsten- Notify Kim of need to clean up business section of website.
+  - MartinM- Get master list of website pages to Kate
+  - Legal/Biz Teams- Review and update [Master
+    Schedule](General_Meeting/Master_Schedule "wikilink")
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kirsten Newcomer, Black Duck Software
+  - Esteban Rockett, Motorola
+  - Phil Koltun, Linux Foundation
+  - Gary O'Neall, Source Auditor
+  - Michael Herzog, NexB
+  - Pierre Lapointe, NexB
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Bill Schineller, Black Duck Software
+  - Scott Lamons, HP
+  - Adam Cohn, Cisco
+  - Victoria Mah, Cisco
+  - Brandon Robinson, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-06-02.md
+++ b/general/2011/2011-06-02.md
@@ -1,0 +1,111 @@
+  - Attendance: 13
+  - Minutes for 20110519 approved
+
+## Technical Team Report - Gary
+
+  - Tools: have received good feedback; addressed a few technical
+    issues; available for beta use
+  - Spec: final polishing has been largely completed; waiting for one
+    more review from legal which is expected by Friday am PT
+
+## Business Team Report - Kim
+
+  - 3 beta teams are working; target for beta completion & feedback is
+    end of June; request that all teams work toward this date
+      - HP/WindRiver & OL/Antelink are in progress
+      - Kickoff for Motorola/TI still to be scheduled, but there's been
+        activity. Rockett will work with Gary to get kickoff scheduled
+  - Website refresh subteam has been created. Details on this working
+    group can be found here:
+      - [Old/Website\_Refresh](Old/Website_Refresh "wikilink")
+  - GA launch process is next big thing to focus on
+      - Planned for LinuxCon in Vancouver
+      - Phil O. has a speaking slot
+      - Goal include press release and mention in keynote
+
+## Legal Team Report - Rockett
+
+  - Last scrub on 5/16 spec in progress. Final comments due by Friday am
+    PT time, 6/3
+  - Recommend Open Data Commons PDDL license for SPDX MetaData
+    (http://www.opendatacommons.org/licenses/pddl/); will send link to
+    broader group for final sign-off
+  - License templatizing is the next big focus
+  - Also noted that we'll need a process for adding licenses to SPDX
+    list very soon; Kim says Biz Team has a proposal for a process and
+    she'll plan to share more broadly
+
+## Cross Functional Issues – Discussion
+
+  - Website update- Steve
+      - Sandbox for testing new website structure in place
+      - Team plans to create storyboards for 3-4 personas using mind map
+        tools
+      - wiki pages for working group now available
+        [Old/Website\_Refresh](Old/Website_Refresh "wikilink")
+  - Questions/recommendations for presenting data for binaries and
+    archives such as jar files -- Kim
+      - There's been recent email about how to represent data for
+        binaries that are combinations of OSS, 3rd party, and
+        proprietary code in SPDX documents
+      - Issue has also come up for OL/Antelink beta partners;
+        OL/Antelink have decided to use compound licensing for jar files
+        when needed; should we recommend the same approach for binaries?
+      - There was a lively discussion on this topic with input from
+        Steve Cropper, Kim Weins, Michael Herzog, Kate Stewart
+      - Main conclusion: Recommendations for how to handle these use
+        cases need to be added to the draft FAQ
+          - Draft FAQ is available here:
+            [SPDX\_FAQ](SPDX_FAQ "wikilink")
+          - FAQ should address questions about proprietary and 3rd party
+            as well as OSS licenses
+          - Kim added a number of topics to the FAQ; need volunteers to
+            provide additional info on these topics
+      - A side issue regarding how best to connect package and SPDX
+        document was also discussed
+      - The topic of package hierarchy also came up
+          - Michael H. noted that the SPDX team made a conscious choice
+            not to tackle this for v1 of the specification
+          - v1 spec is intended to address lower level or sub-assembly
+            items and a BOM is not yet represented in the spec
+          - Recommended that a section on items specifically deferred be
+            added to the FAQ so that new users have visibility into
+            these decisions
+          - Michael also volunteered to pull together info on well
+            traveled routes for BOMs that we might want to leverage
+
+## Open Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+  - Kim -- share Biz Team proposed process for adding licenses to SPDX
+    list more broadly
+  - Michael H. -- provide info on existing BOM standards that should be
+    useful for future consideration
+  - Legal/Biz Teams- Review and update Master Schedule
+  - ?? -- volunteers needed to review and update the FAQ:
+    [SPDX\_FAQ](SPDX_FAQ "wikilink")
+
+## Closed Action Items
+
+  - Kirsten- Notify Kim of need to clean up business section of website.
+  - MartinM- Get master list of website pages to Kate
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Kamal Hassin, Protecode
+  - Kim Weins, OpenLogic
+  - Esteban Rockett, Motorola
+  - Gary O'Neall, Source Auditor
+  - Michael Herzog, NexB
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Peter Williams, OpenLogic
+  - Jillayne Lovejoy, OpenLogic
+  - Brandon Robinson, Cisco
+  - Steve Cropper, Cisco
+  - Tom Incorvia, Microfocus
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-06-16.md
+++ b/general/2011/2011-06-16.md
@@ -1,0 +1,72 @@
+  - Attendance: 11
+  - Minutes for 20110602 approved
+
+## Technical Team Report - Kate
+
+  - Tools: Updating tools as needed
+  - Spec: Working minor changes to June 5 version of the spec
+  - Spec: Have had interesting discussions with Cisco about mapping SPDX
+    to their current process. Expect that new fields and possibly new
+    models will come out of this discussion
+  - Beta feedback: Looking for place to collect/present feedback. Would
+    like to be sure we capture feedback even for items we've resolved.
+    Kim plans to create wiki page.
+
+## Business Team Report - Kim
+
+  - Beta program:
+      - HP/WindRiver & OL/Antelink continue to make progress
+      - Motorola/TI progress is not yet clear
+      - There's been some confusion over license fields at package
+        level. A wiki discussion on this topic can be found here:
+        [General\_Meeting/License\_Field\_Discussion](General_Meeting/License_Field_Discussion "wikilink")
+  - GA Launch:
+      - Continue to work to get ready for launch at LinuxCon NA in
+        mid-August
+
+## Legal Team Report - In absentia
+
+  - All legal team members are at a separate face-to-face meeting and
+    unable to attend this meeting
+
+## Cross Functional Issues – Discussion
+
+  - Website update- Kirsten
+      - Working on mind-maps for proposed flow; plan to present more
+        generally in next few weeks
+      - Logistical question from Kim: should we remove or archive older
+        content?
+          - Both options are available; deleting won't create orphaned
+            pages
+          - Will likely decide on case-by-case basis
+  - Package License fields - Postponed until next meeting since legal
+    team not present this week
+
+## Open Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+  - Kim -- share Biz Team proposed process for adding licenses to SPDX
+    list more broadly
+  - Michael H. -- provide info on existing BOM standards that should be
+    useful for future consideration
+  - Legal/Biz Teams- Review and update Master Schedule
+  - ?? -- volunteers needed to review and update the FAQ:
+    [SPDX\_FAQ](SPDX_FAQ "wikilink")
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Bill Schineller, Black Duck Software
+  - Gary O'Neall, Source Auditor
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Brandon Robinson, Cisco
+  - Tom Incorvia, Microfocus
+  - Phil Koltun, Linux Foundation
+  - Juergen Weigert, SuSE
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-06-30.md
+++ b/general/2011/2011-06-30.md
@@ -1,0 +1,82 @@
+  - Attendance: 12
+  - Minutes for 20110616 approved
+
+## Technical Team Report - Kate
+
+  - Tools- some issues have arisen in beta, but are being rapidly
+    resolved
+  - New spec and tool versions due next week
+  - FAQs need work- all pls review
+
+## Business Team Report - Kim
+
+  - Extended biz meeting on July 7 to focus on beta fb and website. All
+    invited
+      - Aim is to ID only showstopper items
+  - GA Launch:
+      - Stake in ground for mid-August
+      - Press release- to include endorsements
+      - Phil has speaking slot, JimZ should mention in Keynote,
+        Table/Booth of some sort
+
+## Legal Team Report - Rockett
+
+  - Maximizing adoption is the filter for all decisions
+  - Key current issue: Creator/Reviewer fields
+      - Some Member Counsel are concerned about having files wrongly
+        attributed to companies
+      - Team is working to understand and address concerns
+      - But don't want to casually drop fields that may be valuable to
+        others
+  - Question about rules for resolving- Concensus is ideal
+
+## Cross Functional Issues – Discussion
+
+  - Approach to convergence on V1.0
+      - Still open legal/biz issues.
+      - Driving for resolution by end of July
+      - Identify showstoppers in beta meeting and ID owners to sheppard
+        resolution of each
+      - Clean up spec and finaliz by 8/12, prior to 8/17 launch
+  - Website
+      - Shifted from mockups to mindmap
+      - To be presented at meeting on 7th
+      - Volunteers needed for sandbox
+  - BOM formats MichaelH
+      - Real BOMs can be very complex with unlimited depth and width
+      - Hierarchy is key
+      - There are two well-known existing models
+          - ERP BOM data model
+          - PDX - Product Data Exchange
+      - We don't need to deal with today, but need to consider in the
+        future
+      - Michael posting
+
+## Open Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+  - Kim -- share Biz Team proposed process for adding licenses to SPDX
+    list more broadly
+  - Michael H. -- Posting BOM info
+  - Kim- Creating FAQ strucdture and handing out pieces for review,
+    cleanup, additions
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kirsten Newcomer, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Peter Williams, OpenLogic
+  - Gary O'Neall, Source Auditor
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Brandon Robinson, Cisco
+  - Tom Incorvia, Microfocus
+  - Pierre LaPonte, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Esteban Rockett, Motorola
+  - Michael Herzog, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-07-13.md
+++ b/general/2011/2011-07-13.md
@@ -1,0 +1,62 @@
+  - Attendance: 10
+  - Minutes for 20110630 approved
+
+## Technical Team Report - Kate
+
+  - Added field for version of package
+  - Legal team is working on fields for data licensing
+  - Working thru bug list; looks like no big issues
+  - Tools on track
+
+## Business Team Report - Kim
+
+  - GA Launch:
+      - Press release- to include endorsements
+      - Phil has speaking slot, JimZ should mention in Keynote, 1 pg
+        handout, table
+
+## Legal Team Report - Rockett
+
+  - Working on clearing Creator/Reviewer field issue
+  - Templatizing has taken back seat; may only provide general
+    guidelines for v1.0 release.
+  - Adding some explanation to the concluded license field
+
+## Cross Functional Issues – Discussion
+
+  - LinuxCon
+      - Attendance- PhilO, Kate, PhilK, Daniel, Pierre, Kim, Rockett
+        will all attend.
+      - We'll have a table which we will man during breaks with above
+        folks
+  - Website
+      - Pierre/Steve working in Sandbox
+      - On track for launch
+      - Will open to SPDX list prior to
+
+## Open Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+  - Kim -- share Biz Team proposed process for adding licenses to SPDX
+    list more broadly
+  - Michael H. -- Posting BOM info
+  - Kim- Creating FAQ strucdture and handing out pieces for review,
+    cleanup, additions
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Pierre LaPonte, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Esteban Rockett, Motorola
+  - Michael Herzog, nexB
+  - Bill Schineller, Black Duck Software
+  - Daniel German, U. of Victoria
+  - Phil Koltun, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-08-11.md
+++ b/general/2011/2011-08-11.md
@@ -1,0 +1,86 @@
+  - Attendance: 16+
+  - NOTE: I believe many folks joined whose names I did not capture. Let
+    me know if your name is not here, and I'll be happy to add it.
+
+## Technical Team Report - Kate
+
+  - New draft of spec posted as of 8/10; no field changes, just
+    editorial
+  - Open issue on data license; need agreement between spec and RDF
+  - Deadline for feedback by early am 8/15
+  - Tools updated
+  - New example available
+
+## Business Team Report - Kim
+
+  - GA
+      - Press release shaping up; Kim reviewed list of names to be
+        included
+      - JimZ will mention in Keynote, Phil O. & Esteban R. have speaking
+        slot
+      - BOF session not yet on website; Thursday, 8/18 at 5:15 pm
+      - SPDX booth staffing in progress; John Ellis working schedule; 1
+        pg handout will be available
+  - SPDX Website update
+      - Don't believe we'll be ready to cutover from sandbox to live
+        site in time for launch
+      - Kim will update Home page on live site in prep for launch
+      - Kate will ensure spec is up to date on live site
+  - FAQs
+      - Asked all volunteers to get their contributions in by end of day
+        Tuesday
+
+## Legal Team Report - Rockett
+
+  - Circulated draft of revised trademark & compliance statements
+      - Deep discussion on this topic resulted in additional proposed
+        changes
+      - "Policing" policy concerns raised; recommendation is to follow
+        LF policy of community notification
+      - Concerns about requiring attribution/compliance statement inside
+        SPDX file requiring change to spec
+      - Decided that no attribution statement will be included in SPDX
+        file at this time; we will revisit post 1.0 GA
+      - Rockett has the action item to send final wording to Kate
+  - Data license discussion
+      - Some team members concerned that use of PDDL, even with language
+        about side-agreement re confidentially may affect adoption of
+        spec by those who are working with packages that contain
+        proprietary code
+      - Other team members believe that allowing data licenses other
+        than PDDL will affect adoption by open source community
+      - Noted that Karen Copenhaver discussed this use with the author
+        of PDDL and we have agreement that this use is compliant with
+        intent of license; current wording provided by Karen C. after
+        review with author
+      - Decided that v1.0 will stipulate PDDL as only license for data
+
+## Open Action Items
+
+  - MartinM- Report back on \# of people on respective mailing lists.
+    ONGOING
+  - Kim -- share Biz Team proposed process for adding licenses to SPDX
+    list more broadly
+  - Michael H. -- Posting BOM info
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Kamak Hassin, Protecode
+  - Kim Weins, OpenLogic
+  - Peter Williams, Open Logic
+  - Gary O'Neall, Source Auditor
+  - Martin Michlmayr, HP
+  - Kate Stewart, Canonical
+  - Jilayne Lovejoy, OpenLogic
+  - Esteban Rockett, Motorola
+  - Phil Koltun, Linux Foundation
+  - Tom Incorvia, Microfocus
+  - Adam , Cisco
+  - Mark Gisi, Wind River
+  - Branden Robinson, Cisco
+  - Jack Manbeck, TI
+  - Steve Cropper, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-12-01.md
+++ b/general/2011/2011-12-01.md
@@ -1,0 +1,56 @@
+  - Attendance: 7
+
+## Technical Team Report - Kate
+
+  - Bugzilla, the final piece of downed infrastracture up, so we are
+    finally fully functional
+  - Tech team has been meeting regularly thru the outtage.
+  - Minutes have been distributed through the mailing list and will be
+    posted
+  - Shortly a new draft will be available, either "1.1" or "1.0.1"
+  - EdW is still working on a proposal for handling hierarchy which will
+    be the basis for SPDX 2.0.
+  - There have been some good recent contributions to the SPDX tools
+    including a new verification tool
+
+## Business Team Report - Michael Herzog (in Kim's absence)
+
+  - Most of the recent discussion has been on our infrastructure plan in
+    the wake of the outtage.
+  - No update on new website.
+
+## Legal Team Report - Jilayne (in Rockett's absence)
+
+  - Data license issue
+      - Seems to be resolved to everyone's satisfaction.
+      - Rockett drafted a pre-amble to the CC0 license and got support
+        from Eben Moglen.
+  - Next Steps
+      - Templatizing work is resuming in the next Legal Team call.
+      - Jilayne is resuming some clean-up on the license list
+
+## Cross Functional Issues – Phil
+
+  - Infrastructure
+      - Discussed the LF's infrastructure issue. Phil's opinion is that
+        the new infrastructure meets our needs
+      - In the next couple weeks there will be a meeting with folks from
+        the Linux Foundation in which they will present an overview
+        what's been done, the idea being to make us comfortable.
+      - We don't want to group to be overly large, but if anyone is
+        interested in participating, email Phil.
+
+## Open Action Items
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kate Stewart, Canonical
+  - Jilayne Lovejoy, OpenLogic
+  - Michael Herzog, nexB
+  - Pierre Lapointe, nexB
+  - Adam Cohn, Cisco
+  - Brandon Robinson, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2011/2011-12-15.md
+++ b/general/2011/2011-12-15.md
@@ -1,0 +1,54 @@
+  - Attendance: 12
+  - Dec1 Minutes Approved
+
+## Technical Team Report - Kate
+
+  - Hierarchy is the focus; trade off is backward compatibility
+  - Aiming for August 2.0 with hierarchy being the big change.
+  - 1.1 targeted for Q1
+      - CC0 License and preamble
+      - Updated verification algorithm
+      - Bug fixes
+  - Cleanup in process on current website
+
+## Business Team Report - Kim
+
+  - New Website
+      - Sandbox is ready for updating as of next Monday
+      - Need voluteers for migrating/adding content to some sections
+        (see SPDX.org for sections that need help); contact Kim
+      - Pierre will send out instructions by Monday
+  - Kim updating list of conferences for next year; looking for
+    presenters to keep spreading the SPDX word
+  - Anticipating Face to Face Meetings at:
+      - Collaboration Summit, April 3-5 in San Francisco
+      - LinuxCon NA, Aug 29-31, San Diego
+
+## Legal Team Report - Adam/Jilayne (in Rockett's absence)
+
+  - License preamble is ready to run by anyone who was uncomfortable
+    (like Fedora folks)
+  - Still open for tweaks
+  - Templatizing will commence after the first of the year
+
+## Cross Functional Issues – Phil
+
+## Open Action Items
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kate Stewart, Canonical
+  - Jilayne Lovejoy, OpenLogic
+  - Michael Herzog, nexB
+  - Pierre Lapointe, nexB
+  - Adam Cohn, Cisco
+  - Brandon Robinson, Cisco
+  - Gary O'Neall, Source Auditor
+  - Mark Gisi, Wind River
+  - Kim Weins, OpenLogic
+  - Tom Incorvia, MicroFocus
+  - Kirsten Newcomer, Black Duck Software
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-01-12.md
+++ b/general/2012/2012-01-12.md
@@ -1,0 +1,64 @@
+## Attendees
+
+  - Kim Weins
+  - Gary O'Neall
+  - Michael Herzog
+  - Jilayne Lovejoy
+  - Mark Gisi
+  - Brandon Robinson
+  - Steve Cropper
+
+## Legal Update from Jilayne
+
+  - Talked about Legal To-Do's
+  - Legal team is working on templatizing -- they have a draft of
+    guidelines. There are some outstanding issues
+  - Need to get going on the license approval process. Biz team is
+    owning the process but legal will be participants as well.
+  - Jilayne and Adam finalized the last edits on the preamble for the
+    data license. Kim to send to community people for feedback
+  - Mark Gisi has updated "rationale doc" that explains why we selected
+    data license. That doc is not yet on website, but Mark to upload
+
+## Tech Team Update from Gary
+
+  - Work of tech team is focused on the 1.1 spec.
+  - They did a review of the draft 1.1 spec and there were a few follow
+    up items.
+  - Plan is to resolve those issues and update the RDF and the tools by
+    the end of Q1.
+  - 3 new tools are available that
+      - Convert between SPDX Tag and RDF format (both ways)
+      - Convert from SPDX to HTML
+  - 1.1 Features are:
+      - Updated data license to CC0
+      - Fix typos
+      - Fix the verification codes
+      - Add tracking of suppliers
+  - Tech team is also starting on the hierarchical/embedded design for
+    2.0.
+
+## Biz team update from Kim
+
+  - Website conversion is almost ready to start
+      - Web team had a meeting earlier in the week to review the work
+        that is done
+      - Steve Cropper to schedule a web training for next week to show
+        people how to convert content
+  - Discussed EclipseCon
+      - Protecode is taking the lead to organize a BOF
+  - Discussed Software Supply Chain Summit idea
+      - The idea is to have an in person 1 day meeting in Bay Area
+      - Target date is Fri April 6, right after Collab Summit
+      - Invite people from companies in the software supply chain --
+        including non-SPDX participants
+      - SPDX people could also invite supplychain partners
+      - We want to start to socialize and spread SPDX
+      - Agenda would need to be developed, but contect would include
+        SPDX Basics, End User talks, License info, tools as well as
+        discussions
+      - Steve Cropper said Cisco may be willing to host. HP may as well.
+      - Kim to follow up with LF and let them know.
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-01-26.md
+++ b/general/2012/2012-01-26.md
@@ -1,0 +1,67 @@
+  - Attendance: 9
+  - Minutes for 2011/12/15 approved
+
+## Technical Team Report - Gary
+
+  - Much focus on defining approach for 2.0 spec.
+  - Two key elements: Hierarchy and time element (revisions, supply
+    chain, approvals)
+  - Progress forward, but some concern that we are not converging
+    rapidly enough
+  - Key discussion about backwards compatibility and how important it is
+    for 2.0.
+
+## Business Team Report - Kim
+
+  - New website has been recent focus.
+      - There was a training meeting and an email went to voluteers for
+        content migration.
+      - Web team is implementing the new menu structure and will then
+        green light volunteers to move content.
+      - That will take two weeks, followed by cleanup.
+  - License List addition process
+      - Dusted off notes from previous discussion and concluded it
+        looked pretty good.
+      - Kim working with legal team to review
+      - Then we need to publish and implement
+  - Community outreach re: data license
+      - Kim reaching out to Gentoo, Fedora, Eclipse
+      - Thumbs up from Gentoo; waiting on Fedora and Eclipse
+      - Adding Gentoo licenses to license list
+  - SPDX outreach meeting
+      - Silicon Valley, April 6; plans in motion
+
+## Legal Team Report - Jilayne
+
+  - Preample to data license complete and will be published.
+  - License List
+      - License "Templatizing" is taking a new approach; better
+        described as "license list matching guidelines."
+      - Good progress; lots of concensus
+      - Discussion about best form or forms in which to publish (CSV,
+        Excel, HTML)
+
+## Cross Functional Issues – Phil
+
+  - Heads up- Potential for need for modest SPDX funding from
+    participating companies in the future. Probably a when, not if.
+
+## Open Action Items
+
+  - Phil- If it looks like 2.0 may have backward compatibility issues,
+    call broad meeting for community input.
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Gary O'Neall, Source Auditor
+  - Tom Incorvia, Microfocus
+  - Pierre LaPonte, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Jack Manbeck, TI
+  - Steve Cropper, Cisco
+  - Chuck Gaudreau, Protecode
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-02-09.md
+++ b/general/2012/2012-02-09.md
@@ -1,0 +1,63 @@
+  - Attendance: 10
+  - Minutes for 2011/1/26 approved
+
+## Technical Team Report - Gary
+
+  - 2.0 Spec
+      - Great progress on hierarchy issue.
+      - Gaining agreement on importance of backward compatibility. Goal
+        is 100%, but some openness to exceptions (which would have to be
+        run by Biz Team and General Meeting)
+      - Still concern about tightness of schedule (for August
+        completion) but progress is accelerating.
+  - 1.1 is very close. Gate is validating the verification algorithm.
+
+## Business Team Report - Kim
+
+  - Website conversion is underway. Aiming for end of month to flip
+    switch.
+  - End User Event - April 6 in San Jose (after Collab Summit)
+      - Cisco hosting.
+      - Aiming for 50-60 people.
+      - Idea is to bring in new supply chain partners.
+      - Educational agenda.
+      - 9-2 or 3pm
+
+## Legal Team Report - Jilayne
+
+  - License List Guidelines
+      - Guidelines for matching now posted on the web.
+      - Discussion going on about whether copyright is part of the
+        license.
+      - Down to 9-10 issues.
+  - License List Format
+      - Question is in what form is the "golden" list.
+      - Excel limiations on characters in field trucate license text for
+        some licenses.
+      - Possible solution is include, not text of license, but link to
+        text, in spreadasheet.
+
+## Cross Functional Issues – Phil
+
+  - Website Management and Hosting
+      - Martin M leading team.
+      - Need to define requirements first, solution second.
+  - Collab Summit
+      - Straw pole indicatd 10-15 participants from companies
+        represented in this meeting.
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Gary O'Neall, Source Auditor
+  - Pierre LaPonte, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Martin Michlmayr, HP
+  - Steve Cropper, Cisco
+  - Kate Stewart, Canonical
+  - Mark Gisi, WindRiver
+  - Michael Herzog, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-02-23.md
+++ b/general/2012/2012-02-23.md
@@ -1,0 +1,57 @@
+  - Attendance: 10
+  - Minutes for 2011/2/9 approved
+
+## Technical Team Report - Kate
+
+  - 2.0 Spec
+      - 3 proposals on the table under debate
+      - Schedule is in flux
+      - Team understands backward compaitibility issue.
+  - 1.1 Spec
+      - Needs feedback.
+      - Still verifying the new verification algorithm.
+
+## Business Team Report - Kim
+
+  - Website content is moving, albeit a little behind schedule. Still
+    believes we will flip switch this Q.
+  - End User Event - April 6, 9-3 in San Jose (after Collab Summit)
+      - Agenda in [minutes of Biz Team
+        meeting](Business_Team/Minutes/2012-02-16 "wikilink")
+      - Aiming for 50-60 people.
+      - Reaching out to local bar association.
+  - Collab Summit
+      - Looks like we will have a keynote and a presentation in the
+        Legal sessions on Wednesday
+      - Kim working on lining up rooms for a tech meeting.
+
+## Legal Team Report - Jilayne
+
+  - License List
+      - Pulled text our of golden spreadsheet due to truncation issue
+        and replaced with links to txt files.
+      - All posted on spdx.org including latest matching guidelines
+      - Jilayne recruiting volunteers to check txt files (where there
+        have been some translation errors)
+  - Forum
+      - Had some discussion about Forum. Concern that in the past tech
+        legal discussions in public forums scared some people off, so
+        team will act accordingly.
+
+## Cross Functional Issues – Phil
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Gary O'Neall, Source Auditor
+  - Jilayne Lovejoy, OpenLogic
+  - Kate Stewart, Canonical
+  - Mark Gisi, WindRiver
+  - Brandon Robinson, Cisco
+  - Adam Cohn, Cisco
+  - Freddy Munoz, Antelink
+  - Tom Incorvia, Microfocus
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-03-08.md
+++ b/general/2012/2012-03-08.md
@@ -1,0 +1,53 @@
+  - Attendance: 10
+  - Minutes for 2011/2/23 approved
+
+## Technical Team Report - Kate
+
+  - 2.0 Spec
+      - Focusing in 2 proposals for signing, then revisiting how to
+        handle hierarchy
+      - Hoping to reach final resolution at Collaboration Summit
+  - 1.1 Should be final before Collaboration Summit
+
+## Business Team Report - Phil (written input from Kim)
+
+  - Website conversion goes slow.
+  - SPDX participation in Collaboration Summit is on track.
+  - Forum is firming up as well
+
+## Legal Team Report - Jilayne
+
+  - Behind on updating Legal Section of new website
+  - License Text review needs volunteers (Phil volunteered...how about
+    you?)
+  - License List
+      - MPL 2.0 is up
+      - Issues with "or later" to be reviewed.
+      - Planning to hammer out several issues with tech team at
+        Collaboration Summit
+      - David Wheeler from a DC think tank wants to push government
+        adoption of the License List
+          - Needs a way to specially designate "US Govenment Works"
+          - Team needs to resolve if/how we will handle with License
+            List
+
+## Cross Functional Issues – Phil
+
+  - Martin reports slow progress in charting out the future of the
+    website.
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kim Weins, OpenLogic
+  - Pierre LaPonte, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Martin Michlmayr, HP
+  - Steve Cropper, Cisco
+  - Kate Stewart, Canonical
+  - Adam Cohn, Cisco
+  - Michael Herzog, nexB
+  - Scott Lamons, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-04-19.md
+++ b/general/2012/2012-04-19.md
@@ -1,0 +1,57 @@
+  - Attendance: 12
+  - Previous minutes not reviewed
+
+## Legal Team Report - Adam
+
+  - Discussing proposal for license list submissions. Goals
+      - evaluated proposal from business team; would like to makes it
+        easier / faster and take advantage of community
+      - will circulate proposal soon
+  - Discussion of issues on headers & notices led to broader discussion
+      - plan to review vision, direction, refine charter
+      - need to clarify problems we want to solve since we can't solve
+        every problem
+      - prioritizing problems is a cross-functional concern; plan to
+        discuss more broadly
+  - Starting to develop legal use cases
+
+## Technical Team Report - Kate
+
+  - 2.0 Spec
+      - Working through use cases; have extended deadline for capturing
+        use cases
+  - 1.1 Still in progress
+      - additional comment fields proposed: license level and file level
+      - as soon as ready, will announce for review and close 2 weeks
+        later
+      - rough timeframe: end of May
+
+## Business Team Report - Scott
+
+  - Jack & Scott have planned formal hand-off with Kim
+  - Call in \#s will change; check the webite
+  - Primary focus wil be follow-up on SPDX forum brainstorming on ways
+    to encourage adoption
+
+## Cross Functional Issues – Kirsten
+
+  - Kirsten & Pierre will work with Steve and Martin to create plan for
+    migrating to new web pages
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Kevin Fleming
+  - Pierre LaPonte, nexB
+  - Kate Stewart, Canonical
+  - Adam Cohn, Cisco
+  - Michael Herzog, nexB
+  - Scott Lamons, HP
+  - Tom Incorvia, Microfocus
+  - Chuck Gandreau, Protecode
+  - Gary O'Neall, Source Auditor
+  - Mark Gisi, Windriver
+  - Jack Manbeck, TI
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-05-03.md
+++ b/general/2012/2012-05-03.md
@@ -1,0 +1,103 @@
+  - Attendance: 11
+  - Meeting lead by Kate Stewart
+
+## Attendees
+
+  - Chuck - Protecode
+  - Michael Herzog - NexB
+  - Pierre La Point NextB
+  - Tom Incorvia - MIcrofocus
+  - Kate Stewart - Canonical
+  - Martin M - HP
+  - Scott -
+  - Mark Gisi - Windriver
+  - Jilyane Lovejoy - Openlogic
+  - Adam Cohn - Cisco
+  - Steve Cropper - Cisco
+
+## Technical - Kate
+
+  - sorting out the usecases/groupings for last 2 meetings
+  - SPEC 1.1 being readied for wider review.
+  - Roadmap for 2.0? timing is question, dependency on how quickly we
+    can gel on targets. hoping for Q4.
+  - need to tie in to business activities with structure to capture, and
+    forward looking activities.
+
+## Legal Team - Jilayne
+
+  - revised license addition process posted for review
+  - feedback received, URLs to be added.
+  - reality of situation, encouraging other to check out.
+  - Getting more documentation/explanation of vision/goals of subgroup.
+    (see meeting minutes)
+  - People working on drafts of what legal work group is in charge of.
+
+### License list
+
+  - Sense of to do list, what is still outstanding.
+  - Movement on OSI outstanding issues, clarification.
+  - License notices - lots of discussion, but no net change.
+  - Nothing further on templatizing front.
+
+## Business Team - Michael
+
+  - general topic, product planning and roadmap for SPDX
+  - combining concepts - validating, compliance, root attribution
+    information.
+  - Product Roadmap - 2.0, some vision of what it should be, review of
+    business team next week.
+  - Charter - is data exchange, how it is evolving... framework.
+  - Distinguishing between changes to SPEC and changes to software to
+    support SPEC. Foster adoption, help folks comply, SPEC and
+    implementation in software are different. Java community process...
+  - SPEC and licensing for implementation. Subset of issues change SPEC,
+    and enable others.
+  - Framework for discussing different ideas... revision to future plan.
+    Proposing a simple product management to planning. Constituencies,
+    coallescing. Purpose of version in business discussion.
+  - Current, Next, Future - approach. Product management function.
+    Difference between SPEC and related issues around implementing.
+  - Wanting to expand out the charter -
+
+## Steve/Pierre - Web
+
+  - pierre, martin, steve did survey - 30% of content in place, 70%
+    missing
+  - link on the front page of new site
+  - assignments, checked against all of the pages, pages, content added
+    and missing.
+  - requested Steve rebroadcast assignment page, mail out to everyone
+    else.
+  - Re-attach instruction of .pdf of instructions.
+  - End of May will be switch over...
+  - Business team, looking at reallocating page with Kim's name was
+    beside. Finish up.
+  - Status on assignments, guidelines to being done.
+
+## Martin - Web migration
+
+  - Wiki ideas, infrastructure is redundant, web site is maintained by
+    Martin, want to find better ways
+  - Good discussion with Ed Warnicke, moving to proper wiki, going to
+    hosted sites. Move WIKI and make site easier.
+  - Martin working on plan to do this. Discuss with others after
+    preliminary sketch - June/July time frame.
+  - Cost: really low, hosting instances cheap, couple $$ per month?
+
+## Steve Cropper - SPDX WEBEX site setup option
+
+  - Hostids to team members.
+  - Genearal agreement that this is a good direction to investigate, but
+    Linux system must work with it, or its a non starter. (Steve will
+    get together with Ed, and investigate if Linux problems can be
+    solved).
+  - Concern expressed desire to have calls recorded for convenience of
+    those in other timezones, and help with meeting minute writers.
+  - Phil: Can the phone recording option be turned on in future, and the
+    summaries be made available via the web, as interim until WEBEX like
+    capabilities can be make available with all participants, still able
+    to participate.
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-05-17.md
+++ b/general/2012/2012-05-17.md
@@ -1,0 +1,83 @@
+  - Attendance: 9
+  - May 3 minutes approved
+
+## Legal Team Report - Jilayne
+
+  - Working on explicitly defining the team's mission.
+      - Current Draft (feel free to provide feedback to team/Jilayne):
+        *"The SPDX Legal Team supports the SPDX working groups by
+        providing recommendations to the SPDX working groups regarding
+        licensing issues for the specification itself; providing input
+        that will result in increased legal certainty of the licensing
+        attributes of open source projects; maintain the SPDX License
+        List; and to promote the SPDX specification to the legal
+        community at-large."*
+  - Similarly working on defining purpose of the License List.
+      - Current draft (also open for feedback):*"The SPDX License List
+        is a list of commonly found open source software licenses for
+        the purposes of being able to easily and efficiently identify
+        such licenses in an SPDX document. The SPDX License List
+        includes a standardized short identifier and full name for each
+        license, as well as other basic information. By providing a
+        short identifier, SPDX creators (as well as others beyond SPDX)
+        can efficiently refer to a license without having to redundantly
+        reproduce the full license. The SPDX website (spdx.org)
+        maintains the full text of each license on the SPDX License
+        List. In keeping with the overall goal of the SPDX project, no
+        interpretation of the licenses has been made and the SPDX
+        Licenses List endeavors to only provide a factual list of
+        licenses and short identifiers that can be consistently relied
+        upon by users of the list."*
+  - Reviewed and updated longer term to do list
+  - Posted process for adding licenses to License List in Specification
+    section of current website.
+
+## Business Team Report - Scott/Jack
+
+  - Mission/Vision Discussion
+      - To support the Tech Team's work in sorting through 2.0, the team
+        is raising a conversation that will go cross team, revisiting
+        mission/vision/strategy/etc.
+      - Want to ensure that we are all in sync and that make sure that
+        our vision remains aligned with what we are trying to do.
+      - Expect to share initial thoughts more broadly across teams next
+        week.
+
+## Technical Team Report - Kate
+
+  - 2.0 work
+      - Continue to work on use cases. Have put into logical groupings.
+      - Need help in getting use cases fleshed out.
+      - IMPORTANT: If you want to be sure a use case gets attention,
+        make sure the template is fleshed out.
+      - [Technical\_Team/Use\_Cases/2.0](Technical_Team/Use_Cases/2.0 "wikilink")
+  - 1.1 work
+      - Working out last kinks.
+      - Should be out and available in weeks
+      - Available in Tech Team section (in .doc format) for comment
+
+## Cross Functional Issues – Phil
+
+  - Website Update
+      - As per May 3 memo, need all content updated by May 31.
+      - Content remains a bit sparse. Please make sure you are working
+        on any parts for which you are responsible for.
+      - Pierre (will assist from Phil, Steve, Kirsten) will make sure
+        individuals are assigned, aware of their responsibilities, and
+        on track
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck Software
+  - Phil Odence, Black Duck Software
+  - Pierre LaPonte, nexB
+  - Kate Stewart, Canonical
+  - Michael Herzog, nexB
+  - Scott Lamons, HP
+  - Tom Incorvia, Microfocus
+  - Brandan Robinson, Cisco
+  - Jack Manbeck, TI
+  - Jilayne Lovejoy, OpenLogic
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-05-31.md
+++ b/general/2012/2012-05-31.md
@@ -1,0 +1,80 @@
+  - Attendance: 10
+  - May 17 minutes approved
+
+## Legal Team Report - Jilayne
+
+  - Finalizing work defining the team's mission purpose of License List
+    that were published two weeks ago. Please comment now or hold your
+    peace. Latest draft:
+      - **Legal Work Group description:***"The SPDX Legal Team supports
+        and provides recommendations to the SPDX working groups
+        regarding licensing issues for the specification itself;
+        maintains the SPDX License List; and promotes the SPDX
+        specification to the legal community at-large."*
+      - **SPDX License List description:***"The SPDX License List is a
+        list of commonly found open source software licenses for the
+        purposes of being able to easily and efficiently identify such
+        licenses in an SPDX document. The SPDX License List includes a
+        standardized short identifier, full name for each license,
+        vetted license text, other basic information, and a canonical
+        permanent URL. By providing a short identifier, users can
+        efficiently refer to a license without having to redundantly
+        reproduce the full license."*
+  - Have been providing input to 1.1 spec to incorporate latest thinking
+    on License List and to ensure consistent vocabulary.
+  - Working to make sure new website content is up to date.
+  - Turning attention back to matching guidelines. Aiming to reach
+    closure with 1.1 release (about a month)
+
+## Business Team Report - Scott/Jack
+
+  - Business Team is eager for feedback from other team's on
+    Mission/Vision. Looking to come to closure in the next few weeks.
+    Expectation is that this will help with prioritization of use cases
+    for the 2.0 effort. Latest version (embedded in a set of slides):
+    ![Spdx-mission-review-may-2012-v2.pdf](Spdx-mission-review-may-2012-v2.pdf
+    "Spdx-mission-review-may-2012-v2.pdf")
+  - Also, pulling together a description of Business Team's function.
+    Scott has drafted and will be working on this in the next Business
+    Team meeting.
+
+## Technical Team Report - Kate
+
+  - 2.0 work
+      - A little over half the use cases have been fleshed out. Others
+        are considering in a "graveyard" unless more work gets done on
+        them.
+      - [Technical\_Team/Use\_Cases/2.0](Technical_Team/Use_Cases/2.0 "wikilink")
+  - 1.1 work
+      - Hoping to bring to closure in the next few weeks.
+      - Near final draft to be posted next week, then open for two weeks
+        of comment.
+
+## Cross Functional Issues – Phil
+
+  - Website Update - Pierre
+      - The effort has been rejuvinated. Content is moving to the new
+        staging area.
+      - Web team is ready to flip the switch when content is set. No
+        date set.
+      - Pierre is confirming that Steve is prepared to move wholesale
+        sections (past meeting minutes, License List, etc.)
+  - LinuxCon Papers
+      - Scott submitting 1.1 update proposal
+      - Gary has submitted a proposal for talking about the OSS tools
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Pierre LaPonte, nexB
+  - Kate Stewart, Canonical
+  - Michael Herzog, nexB
+  - Scott Lamons, HP
+  - Jack Manbeck, TI
+  - Jilayne Lovejoy, OpenLogic
+  - Chuck Gaudreau, Protecode
+  - Gary O'Neall, SourceAuditor
+  - Mark Gisi, WindRiver
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-07-12.md
+++ b/general/2012/2012-07-12.md
@@ -1,0 +1,53 @@
+  - Attendance: 7
+
+## Technical Team Report - Kate
+
+  - 2.0 work
+      - Still working through use cases
+  - 1.1 work
+      - Still under revision but near completion
+  - LinuxCon
+      - Looks like there will be strong participation from the Tech Team
+        in the Face to Face meeting at LinuxCon (Tues, Aug 28,
+        afternoon, San Diego)
+
+## Legal Team Report - Jilayne
+
+  - There will be light attendance at LinuxCon, so not anticipating
+    having formal Legal Team meeting per se.
+  - License list
+      - Discussion continues
+      - Suprisingly after all the recent discussion on the General
+        Meerting list about expanding the list, no one has submitted any
+        more licenses.
+      - There is now available a spreadsheet template for requesting
+        multiple licenses to be added.
+  - There's interest in outreach to various FOSS communities about
+    incorporating licenses, but little resource to do so.
+
+## Business Team Report - Scott/Jack
+
+  - Solicited feedback on SPDX Mission and Vision statements. Some
+    feedback incorporated. Both now ready for publishing on new website.
+  - Discussions are going on between FOSSology team and Univ of Nebraska
+    about incorporating SPDX output capability into FOSSology.
+
+## Cross Functional Issues – Phil
+
+  - Panel discussion has been accepted for LinuxCon.
+  - Website Update - No update
+  - The Linux Foundation is exploring the possibility of providing some
+    program management support for SPDX.
+
+## Attendees
+
+  - Phil Odence, Black Duck Software
+  - Kate Stewart, Canonical
+  - Michael Herzog, nexB
+  - Scott Lamons, HP
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neall, SourceAuditor
+  - Jason Buttura, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-07-26.md
+++ b/general/2012/2012-07-26.md
@@ -1,0 +1,44 @@
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Ibrahim Haddad, Linux Foudnation
+  - Pierre Lapointe, nexB
+  - Kirsten Newcomer, Black Duck
+  - Scott Lamons, HP
+  - Adam Cohn, Cisco
+  - Kamyer Emami, Protecode
+  - Steve Cropper, Cisco
+
+Ibrahim joined for the first time. He is in charge of technical and
+legal initiatives for the Linux Foundation and taken on the role of LF
+project coordinator for SPDX. He should be a big help.
+
+## Business Team Report
+
+The panel discussion for LinuxCon will be lead by Scott and will include
+Kate, Jilayne and Jack representing respective teams. He's also
+recruited Matt Germonprez from U Nebraska to talk about his
+FOSSology/SPDX work.
+
+Scott is working with LF on a press release about V1.1 to be released at
+LinuxCon.
+
+## Tech Team
+
+Still working 2.0 use cases and trying to wrap up 1.1.
+
+Face to Face will continue use case discussion.
+
+## Legal Team
+
+There has been discussion about how to recruit companies to get
+involved. And there's a sense that companies are concerned about
+commitment required to be involved with SPDX.
+
+## Website
+
+Plan was to cut over to new site as of the 28th (and it was subsequently
+executed).
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-08-09.md
+++ b/general/2012/2012-08-09.md
@@ -1,0 +1,83 @@
+  - Attendance: 11
+  - Meeting lead by Jack Manbeck.
+
+## Technical Team Report - Kate
+
+  - 2.0 work
+      - Still working through use cases. May have them complete before
+        LinuxCon.
+  - 1.1 work
+      - Close to completion. Looking to get the document finalized
+        before LinuxCon 2012 at the end of August. The press release for
+        1.1 is being worked on and a draft needs to be sent in to the
+        Linux Foundation soon. Kate will finalize the approval status
+        for 1.1 at the next tech team meeting.
+
+## Legal Team Report - Jilayne
+
+  - License list
+      - Legal team is working through expanding the list with new
+        licenses. There is a spreadsheet of proposed licenses in their
+        work area and the status.
+  - Other
+      - Tech team had asked the legal team for their input on mandatory
+        vs. optional fields and the spdx 2.0 use case for spdx-lite.
+
+## Business Team Report - Jack
+
+  - Discussed web site and business tem pages. Ibrahim had mentioned
+    they used a contractor to do the open momo pages. Business team
+    wants to explore that as an option for the SPDX site. Ibrahim and
+    Steve will work on getting preliminary costs.
+  - Ibrahim has been attending the different work group meetings and
+    meeting and talking with people for the past three weeks. He has a
+    number of proposals that he would like to make.
+  - Press Release for 1.1 – Scott has a set of bullet points up on the
+    site. Kate is working on giving him input with respect to1.0 vs.
+    .1.1. Jilayne has provided some wording on the reason for the move
+    from PDDL to CC0 for the license. She will also talk with Karen to
+    get either some background on why the change was done or a quote.
+    Scott asked whether we should have tools vendors and open source
+    projects starting to use SPDX give quotes for the release. Sounded
+    like a good idea and he will move ahead with that.
+
+## Cross Functional Issues – All
+
+  - Discussed status of website and the issues. Jack Manbeck will create
+    a wiki page to track the web site issues and closure of items.
+  - Ibrahim from the Linux Foundation has started working on a number of
+    proposals to help SPDX, including one around Governance. Looking for
+    a good time to discuss his input with the thinking that a F2F is the
+    best. There was some talk about starting to have discussions at
+    LinuxCon and then also at a proposed face to face in either
+    September or October of this year, location TBD. For LinuxCon, Scott
+    will see if the HP room is available. If not, he will work with
+    Ibrahim and the LF to see if we can get another conference room one
+    night.
+  - Still not clear how many people are going to LinxCon. Scott will
+    re-forward the link on the SPDX site so we can see a list of who is
+    going.
+  - Steve stated that we should publish a list of face to face meetings
+    for SPDX every year along with agendas. There was general consensus
+    that was a good idea.
+  - Jilayne brought up a discussion she had with a developer who put out
+    a favorable blog about SPDX. As a team we discussed whether we
+    should have links from the SPDX website to items like this. Sounded
+    like a good idea.
+
+## Attendees
+
+  - Kate Stewart, Canonical
+  - Michael Herzog, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neall, SourceAuditor
+  - Jack Manbeck, Texas Instruments
+  - Ibrahim Haddad, Linux Foundation
+  - Kamyer Emami, Protecode
+  - Adam Cohn, Cisco
+  - Steve Cropper, Cisco
+  - Mark Gisi, Windriver
+  - Scott Lamons, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-08-23.md
+++ b/general/2012/2012-08-23.md
@@ -1,0 +1,83 @@
+  - Attendance: 15
+  - Minutes of August 9 meeting approved.
+  - Lead by Phil Odence
+
+## Technical Team Report - Kate
+
+  - 1.1 work
+      - Just finalizing a few typos.
+      - Tech team is signed off.
+      - General meeting attendees all agreed to call the doc final after
+        typos corrected.
+
+## Legal Team Report - Jilayne
+
+  - License list
+      - The focus of the last meeting was working through the FSF
+        license list with an eye towards adding most items on the list
+        to the current SPDX standard list.
+      - Work is still in process.
+  - Data license
+      - Karen wrote up an excellent position statement on why we changed
+        the data license in 1.1.
+      - Jiilayne will get it up on the website and Scott is looking into
+        providing the link in the 1.1 press release.
+
+## Business Team Report - Jack & Scott
+
+  - 1.1 Press Release
+      - Working with Linux Foudation PR group to finalize.
+      - There's a desire to get a list of companies that are using SPDX,
+        but this will likely ge difficult in the time available.
+        Possible alternatives:
+          - Quotes from one or two companies
+          - List of companies that have been involved in the development
+            (which is already more or less public)
+  - Survey
+      - The team has started a discussion about sending out a survey to
+        understand attitudes towards, interest in, and adoption of SPDX
+        to help drive adoption efforts.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update
+      - New site is up and running.
+      - Still working through some minor issues; a team will focus on
+        this at LinuxCon
+  - Face 2 Face
+      - Ibrahim is proposing a face to face meeting outside the context
+        of a conference in late Sept/early Oct
+      - We took a straw poll of who could make it. Some can, but several
+        team leads are questionable.
+      - Looking into range of possiblities from full physical meeting to
+        full virtual event
+      - Ibrahim is asking folks who have indicated they could come to
+        add their physical locations to help target a venue.
+  - Linux Foundation website help
+      - The LF has generously offered to assign a web consutant to
+        rebuild the website from scratch using LF templates. (see Open
+        Mama site for example)
+      - Work could commence in October 15
+      - Steve Cropper, Martin Michlmayr and Jack Manback are evaluating
+        benefits v. staying with our already recently overhauled site.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Canonical
+  - Michael Herzog, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neall, SourceAuditor
+  - Jack Manbeck, Texas Instruments
+  - Ibrahim Haddad, Linux Foundation
+  - Jason Buttura, Cisco
+  - Steve Cropper, Cisco
+  - Mark Gisi, Windriver
+  - Scott Lamons, HP
+  - Kirsten Newcomer, Black Duck
+  - Tom Incorvia, MicroFocus
+  - Brandon Robinson, Cisco
+  - Martin Michlmayr, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-09-06.md
+++ b/general/2012/2012-09-06.md
@@ -1,0 +1,77 @@
+  - Attendance: 13
+  - Minutes of August 23 meeting approved.
+  - Lead by Phil Odence
+
+## Technical Team Report - Jack standing in for Kate
+
+  - Ed Warnicke has introduced an interesting new scheme for
+    "watermarking" files
+  - The idea is that a developer combines a small bit of code into their
+    file that preserves license and copyright information through
+    compilation so that information can be extracted from the binary
+  - He's currently running experiements to determine what kind of
+    overhead this introduces
+  - Could have intersting positive implications for future SPDX
+    versions.
+
+## Legal Team Report - Jilayne
+
+  - License list
+      - Finished scrubbing through the FSF list and have plan in place
+        for adding deltas to the SPDX list; pending licenses or on a
+        spreadsheet that Jilayne has posted.
+      - She's also putting up a mage to mention other groups we are
+        coordinating with.
+      - Next discussion with be to try to agree on a high level
+        statement about the scope of the license list; how broad and
+        deep are we trying to go? The legal team will kick off the
+        discussion and may need input from the other teams.
+
+## Business Team Report - Jack & Scott
+
+  - Little to update as last week's meeting was cancelled for LinuxCon.
+    In its stead was a face to face with about a dozen people that
+    focused mostly on technical discussion.
+  - 1.1 Press Release was issued at LinuxCon and looked great.
+  - The panel discussion at LinuxCon was well received by about 25
+    attendees; kudos to Scott for coordinating a very interesting
+    session.
+  - Ibrahim from Linux Foundation is devoting significant time to SPDX
+    and focusing on driving adoption. There's a possiblity of his
+    leading a meeting on this topic (phys/virt/hybrid?) in the next
+    couple months.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update
+      - Jack has been leading a debug effort.
+      - Much work got done at LinuxCon fixing bad links, wrong pages,
+        etc and it's substantially cleaned up. That work will continue
+        over the next couple weeks.
+      - In parallel, the team leads are working on standardizing the
+        different team sections
+      - Linux Foundation has offered (and we will likely accept) to have
+        their contractor re-implement the website on a firmer, more
+        modern foundation. Work would begin in mid-October. MartinM is
+        working with the rest of the web team to understand
+        stability/recoverability implications. Expections are that this
+        will be a great step forward on all dimensions.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Michael Herzog, nexB
+  - Jilayne Lovejoy, OpenLogic
+  - Jack Manbeck, Texas Instruments
+  - Ibrahim Haddad, Linux Foundation
+  - Jason Buttura, Cisco
+  - Steve Cropper, Cisco
+  - Scott Lamons, HP
+  - Brandon Robinson, Cisco
+  - Tom Incorvia, Microfocus
+  - Kamyar Emami, Protecode
+  - Adam Cohn, Cisco
+  - Pierre Lapointe, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-09-20.md
+++ b/general/2012/2012-09-20.md
@@ -1,0 +1,76 @@
+  - Attendance: 10
+  - Minutes of Sept 6 meeting approved.
+  - Lead by Phil Odence
+
+## Technical Team Report - Kate
+
+  - Continuing to work through use cases.
+  - Peter Williams has left Openlogic. The tech team as well as the
+    whole SPDX community officially thank him for his commitment and
+    huge contributions to the project.
+  - Peter is replaced by Jeff Gran.
+
+## Legal Team Report - Jilayne
+
+  - License list
+      - Wrapped up FSF list work
+      - In process of defining what new license will go in the next
+        version. Researching other lists with we'd like to to cover,
+        Fedora is on the radar next
+      - Version 1.17 is adding 42 licenses to the previous 165
+      - Newly agreed to princple: If there is a version of a license on
+        the list, we should also have all previous versions. (and
+        future, presumably- Editor's Note)
+      - Question came up about Freeware/Shareware license. Tabled for
+        future meeting with larger group.
+
+## Business Team Report - Jack & Scott
+
+  - Matt Germonprez of U of Neb and a grad student are making progress
+    working with FOSSology and SPDX
+  - Barriers to Adoption
+      - Adoption remains a key focus of the business team.
+      - Working on a survey
+      - Plan to roll out to SPDX-involved companies as well as other
+        companies from FOSSBazaar and LinuxF communites.
+  - Ibrahim has come up with some great recruiting ideas.
+      - Blocking issues: Need a govenance document (Phil is drafting)
+      - Other needs: Roadmap (Jack working), Defined onboarding process.
+      - Need a slide deck targeted at recruiting (Phil and Ibrahim
+        working)
+      - Michael lead discussion about how to work with Linux Foundation.
+          - They are happy to help, but don't want to hand over mailing
+            lists wholesale.
+          - Feels it's important that we track recruiting efforts like a
+            sales pipeline; Is looking into using a CRM system to track.
+            It is important to recognize that some companies will not
+            want recruiting discussion details to be public
+      - Need to put some special thought into working with Asian
+        companies.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update
+      - Lots of progress on clean up. Now in reasonably credible state,
+        though still tweaking
+      - Bad links and dead pages are for the most part gone.
+      - Tech Team section now consistent with others.
+      - Some URLs are confusing/inconsistent, but not worth worrying
+        about as Linux Foundation will be revamping site for us shortly.
+      - Jack is looking into adding a Contact Us tab.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Michael Herzog, nexB
+  - Kate Stewart, Canonical
+  - Jilayne Lovejoy, OpenLogic
+  - Jack Manbeck, Texas Instruments
+  - Jason Buttura, Cisco
+  - Scott Lamons, HP
+  - Tom Incorvia, Microfocus
+  - Kamyar Emami, Protecode
+  - Pierre Lapointe, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-10-04.md
+++ b/general/2012/2012-10-04.md
@@ -1,0 +1,62 @@
+  - Attendance: 8
+  - Minutes of Sept 20 meeting approved.
+  - Lead by Phil Odence
+
+## Technical Team Report - Kate
+
+  - Continuing to work through use cases. Slow but steady progress
+  - Matt Germonprez (U of Neb) has gotten as far as mocking up SPDX
+    output from FOSSology and has gone to a handful of people for
+    feedback.
+  - Team has reviewed Daniel German's new reference pages.
+      - They provide results of DG's using his tool to scan Debian
+      - It's a good resource and sanity check for someone creating SPDX
+        of Debian
+      - Ulitmate intent is to translate to SPDX
+
+## Legal Team Report - Jilayne
+
+  - License list
+      - Still working on 1.17
+      - Plan to publish a roadmap, targeting quarterly releases
+      - Receiving virtually no specific license requests (albeit getting
+        occasional complaints)
+      - Future considerations
+          - Michael suggested we log any rejected license (with
+            rationale)
+          - Tom suggested making the list more visible on the home page.
+
+## Business Team Report - Jack
+
+  - Recruitment
+      - Continuing to actions to execute.
+          - Roadmap
+          - Presentiton
+          - On boarding document
+          - CRM instance for tracking
+              - Pierre is experimenting with free hosted solutions
+              - Some limitations on \# users, but should be OK
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update
+      - In stable condition. Some tweaks still
+      - Need to start to get ready for Linux Foundation conversion
+          - Phil to contact Ibrahim
+              - Set up kickoff meeting
+              - Understand what webmaster requirements are (based on
+                other WGs' experience)
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Michael Herzog, nexB
+  - Kate Stewart, Canonical
+  - Jilayne Lovejoy, OpenLogic
+  - Jack Manbeck, Texas Instruments
+  - Jason Buttura, Cisco
+  - Tom Incorvia, Microfocus
+  - Adam Cohn, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-10-18.md
+++ b/general/2012/2012-10-18.md
@@ -1,0 +1,67 @@
+  - Attendance: 7
+  - Minutes of Oct 4 meeting approved.
+  - Led by Kirsten Newcomer
+
+## Technical Team Report - Gary
+
+  - Completed review of use cases.
+  - Have started modeling phase
+      - Will create model of v1.1 and review so that everyone has the
+        same baseline to work from
+      - Then will start building model for 2.0 and vet against use cases
+        for 2.0
+
+## Legal Team Report - Tom
+
+  - Last two meetings have been lightly attended. Only 4 folks this
+    week.
+  - Some issues have surfaced with the GPL exceptions on the SPDX
+    license list
+      - Legal team is looking for a volunteer to review for correctness
+  - Team discussed potential policy around licenses in different
+    languages. Some initial thoughts from the team
+      - Official language of the license list site is English
+      - A small number of licenses have been originally published in a
+        different language; for those cases, may make sense to publish
+        in the original language
+      - Policy is still under discussion
+
+## Business Team Report - Jack
+
+  - No meeting last week. Current activities include
+  - Recruitment
+      - Continuing to work on recruitment plan & roadmap
+      - Team thinks this will be ready for review soon
+      - Team is looking for a volunteer to write the On Boarding
+        document
+      - Pierre has downloaded the free version of KarmaCRM which might
+        be useful for tracking recruitment efforts
+          - Free version is limited to two users. One option might be to
+            create a shared email address for SPDX team use. Business
+            team wil discuss at next meeting.
+
+## Cross Functional Issues – Team
+
+  - Web Site Update
+      - It's time to get ready for Linux Foundation conversion
+          - Need two SPDX team members to work with webmasters from the
+            Linux Foundation
+          - Recommendation is that Martin Michlymeyer be one and that
+            the other team member be someone who contributed to the
+            previous web-site revamp for continuinty.
+  - SPDX plugin for Fossology
+      - Matt Germonprez (U of Neb) is making good progress and hopes to
+        be able to share more broadly in about a month.
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck
+  - Pierre Lapointe, nexB
+  - Jack Manbeck, Texas Instruments
+  - Kamyar Emami, Protecode
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Scott Lamons, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-11-01.md
+++ b/general/2012/2012-11-01.md
@@ -1,0 +1,49 @@
+  - Attendance: 8
+  - Minutes of Oct 18 meeting approved.
+  - Lead by Phil Odence
+
+## Technical Team Report - Kate
+
+  - Following update is from Kate via email as she could not attend:
+  - Technical team has been looking at the data model for 1.1, with the
+    view of reviewing it so we can discuss the 2.0 proposed changesWent
+    through a review of the specification with Liang and Matt (UNO),
+    prep for explaining fieldsWorking on an overview presentation of
+    SPDX and some examples right now for orientation, when draft is
+    ready - will pass by biz team to review whether to include in the
+    collateral or not.
+
+## Legal Team Report - Jilayne
+
+  - Need to agree on a "filter" to defvine what gets included or not in
+    license list.
+  - Consensus has been to stay focused on OSS licenses
+  - This discussion has been prompted by a particular license associated
+    with Tizen project
+  - Draft of filter language will be circulated.
+
+## Business Team Report - Gary
+
+  - Jack has drafted and circulated a Road Map for comment; impacts all
+    teams.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update
+      - LF developer has laid out a new structure
+      - Martin and Jack are interfaces to LF for this project
+      - It looks like SPDX team will be reponsible for moving contents.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Ibrahim Haddad, Linux Foundation
+  - Jilayne Lovejoy, OpenLogic
+  - Kamyar Emami, Protecode
+  - Gary O'Neill, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Jason Buttura, Cisco
+  - Tom Incorvia, Microfocus
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2012/2012-11-29.md
+++ b/general/2012/2012-11-29.md
@@ -1,0 +1,112 @@
+  - Attendance: 11
+  - Minutes of Nov 1 meeting approved.
+  - Lead by Phil Odence
+
+## Special Report on Open Compliance Summit, Japan - Adam
+
+  - Overview
+      - End of October. Great Event in General.
+      - Surprising amount of awareness/interest in SPDX to help with
+        recruitment
+      - Adam/Mark Gisi (Windriver) pulled together a come all SPDX info
+        meeting to help with recruitment
+      - Chatham House rules, so sharing but no attribution of comments
+  - Unscheduled Roundtable
+      - Pulled together at last minute for end of first day
+      - 12 participants (surprisingly high)
+      - Lots of interest and awareness. According to Adam, "the concept
+        of SPDX sold itself)
+      - Continued discussion with a number of participants the next day
+  - Flavor of discussion/inquiry
+      - Caution/Concern
+      - Fear of Unknown
+      - Language Issue
+      - Fear of obligation- Worry that signing up is somehow a big
+        commitment
+  - Concerns
+      - Language Issue
+          - More written materials would really help
+          - English is OK (for written stuff) but looking for "User
+            Manual" level documentation
+          - The language of the Spec itself is difficult for non-English
+            speakers
+      - Seems Complicated
+          - But MarkG was able to make folks understand it's not really
+          - So a simple, written explanation would really help
+          - Specific interest in understanding mandatory v. optional;
+            what's the minimum
+          - Kate had similar experience at U of Nebraska - Concern about
+            complexity that went away after simple explanation.
+          - So, all this is s general issue, but answer for Japan has to
+            be written doc due to language.
+      - Obligation
+          - Concern that if you touch SPDX, you have to overhaul your
+            entire compliance operation
+          - Need to help folks understand, it's just a format and can
+            fit your processes; it's a spec, not a business method
+  - Current State
+      - A number of companies we didn't even know were aware are
+        piloting internally
+      - Some of these are not even on any mailing lists
+  - How we can help
+      - Written, user level doc
+      - Help people understand how to dip a toe in
+      - Lots of interest in understanding how to be just a consumer
+      - 
+## Business Team Report - Jack
+
+  - Met with Matt and team at U of Nebraska
+      - Good progress with adding SPDX output capability to FOSSology
+      - Turned up some issues with the existing tools which Gary is
+        looking into
+      - Discussion about creating tools for consuming SPDX
+      - Looking at integrating with Git and Jack envisions an
+        Eclipse-like plug-in framework
+  - Team understands need for a consumer guide- we need a resource to
+    take that on
+  - After first of year need to start planning F2F at Collboartion
+    Summit
+  - Steve Cropper is driving the idea of creating a model supply chain
+    with different participants exchanging and compiling SPDX files.
+
+## Tech Team Report - Kate
+
+  - Working on Modeling different approaches
+  - Testing against use cases
+  - Anticipated slowness due to holiday and as well as Ed's being
+    somewhat tied up
+
+## Legal Team Report - Jilayne
+
+  - Anticipating downtime over holidays.
+  - Finishing up FSF license list additions to be included in LL 1.17
+      - Should be by end of year
+      - Represents 30-40 new licenses
+  - Recent discussion has been about criteria or "filter" for license
+    adds wiht a small group; needs broader input
+  - Next meeting will discuss 2013 priorities
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Framework is in place
+      - Getting feedback from Core Team
+      - WE NEED SOME VOLUNTEERS TO WORK ON THE TRANSITION AND ONGOING.
+        HELP
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Kamyar Emami, Protecode
+  - Gary O'Neill, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Jason Buttura, Cisco
+  - Pierre Laponte, nexB
+  - Kate Stewart
+  - Jack Manbeck, TI
+  - Adam Cohn, Cisco
+  - Scott Lamons, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-01-10.md
+++ b/general/2013/2013-01-10.md
@@ -1,0 +1,63 @@
+  - Attendance: 9
+  - Minutes of Nov 29 meeting approved.
+  - Lead by Phil Odence
+
+## Tech Team Report - Jack/Gary
+
+  - Reviewing outstading bug list for inclusion in 2.0
+  - Modeling 3 different proposals, 2 are similar. Both targeted at
+    accommodating hierarchy
+      - Clean slate, very abstract, very flexible
+      - Extending current model, easier to implement, more detailed
+  - Use cases are nailed down. Testing models agains use cases.
+
+## Legal Team Report - Jilayne
+
+  - Had not yet met for year.
+  - New Meeting time
+      - Looking at picking a time to alternate weeks with Business Team
+        meeting
+      - Gathering input
+  - License List
+      - Good progress on guidelines for licenses to be included;
+        expecting to wrap in January
+      - New version near posting
+  - Organizational
+      - Updated current projects and issues page
+        [Legal\_Team/Current\_Projects\_and\_Issues](Legal_Team/Current_Projects_and_Issues "wikilink")
+      - Looking to assign owners to sheppard and report out in meetings
+
+## Business Team Report - Jack
+
+  - Schedule- Issuing survey to find convenient new day/time
+  - Save the date for the Linux Collab Summit F2F - April 15-17, San
+    Francisco
+  - Working with Steve Cropper on setting up mock supply chain to model
+    exchange of SPDX files
+  - U of Nebraska team is building SPDX consumption tools.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Positive feedback on Linux Foundation funded revamped framework
+      - Good look/feel/ease of use
+      - Team is developing conversion plan; aim is to cutover before
+        Collab Summmit
+      - Need to assign Admins for SPDX.org and Wiki
+          - Jack developing "job descriptions"
+          - Phil to help recruit
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neill, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Michael Herzog, nexB
+  - Jack Manbeck, TI
+  - Adam Cohn, Cisco
+  - Tom Incorvia, Microfocus
+  - Scott Lamons, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-02-07.md
+++ b/general/2013/2013-02-07.md
@@ -1,0 +1,73 @@
+  - Attendance: 10
+  - Minutes of Jan 10 meeting approved.
+  - Lead by Phil Odence
+
+## Business Team Report - Jack/Scott
+
+  - Just had first meeting of year
+  - Finalized and posted SPDX roadmap doc
+    [Business\_Team/Roadmap/2013](Business_Team/Roadmap/2013 "wikilink")
+  - Planning for Collab Summit
+      - Reserviing SPDX room for at least one day
+      - Working to mesh with Summit agenda which is still a little fluid
+      - Planing on a 'plug and play' session involving SPDX, open source
+        and commercial tools.
+      - Several presentations submitted for Summit including a tools
+        presentation from Mark and Gary
+  - Trying to get more direct involvement from Matt Germonprez. Jack
+    will invite him to speak at the next General Meeting.
+
+## Tech Team Report - Kate
+
+  - Working through 2.0 use cases.
+      - Looking at how many could be handled in a 1.2 release.
+      - Down to 12 use cases that still require discussion
+      - Progress, but slow
+      - Link to use cases:
+        [Technical\_Team/Use\_Cases/2.0](Technical_Team/Use_Cases/2.0 "wikilink")
+
+## Legal Team Report - Jilayne
+
+  - Good organizational progress with assigning individuals (other than
+    just Jilayne) to shepard various projects.
+      - Still need someone to own matching guidelines, key project.
+  - License list
+      - Going through exercise of comparing to Fedora list (as we did
+        with FSF), identifying gaps and closing as appropriate/possible.
+  - The discussion of Public Domain being included in the license list
+    keeps coming up. Jilayne is in the process of posting the logic
+    behind the decision.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Still planning to cut over to new site by Collab Summit
+      - Wiki conversion remains unknown.
+          - MartinM is researching
+          - Jack is not too worried and has backup plans if it can't be
+            completely automated
+      - Feeling is that current structure lends itself to move to new
+        structure and Wiki.
+          - Jack is reviewing architectural work that we did when LF
+            first constructed
+      - Matt Germonprez has offered to help with site in general.
+      - Jack still wants to identify admins; still needs to create job
+        descriptions
+      - Question came up as to whether one can subscribe to pages in the
+        new Wiki...yes
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neill, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Michael Herzog, nexB
+  - Jack Manbeck, TI
+  - Adam Cohn, Cisco
+  - Scott Lamons, HP
+  - Kate Stewart, Linaro
+  - Steve Cropper, Cisco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-03-07.md
+++ b/general/2013/2013-03-07.md
@@ -1,0 +1,63 @@
+  - Attendance: 12
+  - Minutes of Feb 7 meeting approved.
+  - Lead by Phil Odence
+
+## Legal Team Report - Jilayne
+
+  - CollabSummit Plan
+      - 2 hour Face to Face Tuesday afternoon
+      - Focus on matching guidelines (she sent out a set of links to
+        review prior to and will resend)
+      - Tech team members encouraged to attend.
+  - Two new licenses have been submitted and approved for list
+
+## Business Team Report - Jack & Scott
+
+  - Recent focus has been on agenda for the CollabSummit
+      - Highlight will be "Bake Off"
+          - Open source and commercial tools working together
+          - Will compare results on three packages (Time, Busybox and
+            the Kernal)
+          - Will have two projectors for comparison
+          - All are welcome
+  - U Nebraska Tool Development
+      - FOSSology-SPDX
+      - Consumption tool- Browse, download, comment on SPDX files
+      - Comparison tool
+  - SourceAuditor and Black Duck have also developed an open source
+    licensed SPDX comparison tool
+      - Back end can handle companring more than 2 files, but UI limited
+        to two currently
+
+## Tech Team Report -Jack
+
+  - Continueing work on different 2.0 models.
+  - Recent discussion on distinguishing file usage (linking, etc)
+  - Also, discussion on handling snippet level license (vs.package/file
+    level today)
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Still working thru conversion
+      - There will be a separate SPDX.org site and wiki
+      - Martin is working on wiki migration and is making great strides
+      - Still looking possible to have converted over by the Collsb
+        Summit
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neill, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Michael Herzog, nexB
+  - Jack Manbeck, TI
+  - Tom Incorvia, Microfocus
+  - Scott Lamons, HP
+  - Martin Michlmayr, HP
+  - Pierre Lapoint, nexB
+  - Matt Germonprez and Liang, U of Nebraska
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-04-04.md
+++ b/general/2013/2013-04-04.md
@@ -1,0 +1,79 @@
+  - Attendance: 17
+  - Minutes of March 7 meeting approved.
+  - Lead by Phil Odence
+
+## Tech Team Report - Kate
+
+  - Continuing work on models and use cases
+  - Planning on substatial progress at Collab Summit
+
+## Legal Team Report - Jilayne
+
+  - LOOKING FOR FEEDBACK
+      - Re: Guidelines for what licenses should be included on the list.
+      - Plan is to pull together and put in single place on the website.
+      - Email went to General Meeting list on March 28 requesting
+        feedback w/in two weeks.
+      - Deadline: April 11
+  - At Collab Summit, Tues afternoon
+      - Will focus on license matching guidelines.
+      - Impacts all teams, so all are invited.
+
+## Business Team Report - Jack & Scott
+
+  - Focus is on developing three docs:
+      - Umbrella, simple description of SPDX
+      - Producing SPDX guide
+      - Consuming SPDX guide
+  - Feedback organization
+      - Another key project is systemtizing/organizing the mechanisms
+        for feedback on SPDX
+      - Survey
+          - An element will be a survey that will be launched at the
+            Collab Summit
+          - All involved should fill out and solicit others
+          - Covers: SPDX awareness, orgnazations' plans, ways the people
+            are hearing about/learning about SPDX, impediments to
+            adoption, etc
+  - Collab Summit
+      - Bake Off
+      - Comparing tools
+      - Scott sending out info/solicitation to General List shortly
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - New site turning up next week, if all goes well
+      - Dependent upon Martin successfully converting the Wiki, looking
+        good
+  - UNO Presentation
+      - Matt Germonprez went through the great work that is going on
+        there with hosted FOSSology and SPDX
+      - Slides attached.
+      - Useful links:
+          - <https://github.com/spdx-tools>
+          - <https://fossology-demo.ist.unomaha.edu/>
+          - <http://spdxhub.ist.unomaha.edu/>
+          - <https://gomockingbird.com/mockingbird/#jnczpip/jzIywP>
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neall, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Michael Herzog, nexB
+  - Jack Manbeck, TI
+  - Tom Incorvia, Microfocus
+  - Scott Lamons, HP
+  - Pierre Lapoint, nexB
+  - Matt Germonprez and Liang, U of Nebraska Omaha
+  - Philippe Ombredanne, nexB
+  - Mark Gisi, Wind River
+  - Scott Humlicek, U of Nebraska Omaha
+  - Bob Gobeille, HP
+  - Denis Clark, Protecode
+  - Winfried Seidel, Daimler
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-04-CollabSummit.md
+++ b/general/2013/2013-04-CollabSummit.md
@@ -1,0 +1,100 @@
+**COLLABORATION SUMMIT SUMMARY**
+
+For those of you who didn’t make it to the Collaboration Summit, below
+is a summary of the different components of the event. It was pretty
+inspiring in a number of ways…for me, it felt like the rubber is finally
+meeting the road seeing real tools—our own, from academia, and
+commercial—putting out real live SPDX docs. The every positive KarenC
+summed it up as “The discussions have much more of a feeling that this
+has to happen – the only questions are around how.” And I agree.
+
+All the team leads did an outstanding job organizing our ever expanding
+involvement in Linux event. (Now we even get our own track.) Gary, MarkG
+and Adam were also key in pulling this off.
+
+## Tech Team Working Session
+
+In this session we went through the current model proposal for 2.0, and
+discussed options that would simplify the model, and still meet the use
+cases we're targeting. We were also able to start off the relationship
+and element usage enumerations. Full details can be found at:
+[Technical\_Team/Minutes/2013-04-16](Technical_Team/Minutes/2013-04-16 "wikilink").
+
+## Legal Team Working Session
+
+The SPDX Legal Team met at the LF Collab Summit to hash out the
+remaining bits of the License Matching guidelines. Namely whether SPDX
+should provide "guidelines only" in regards to what is to be considered
+substantive text of a license for matching purposes or whether SPDX
+should go further and provide some kind of actual markup or examples in
+regards to text than can be ignored or considered "replaceable" for
+matching purposes. And, if the latter, to what extent and in what format
+to provide such markup or examples. The legal team, with good
+representation from various tool makers and tech team members, decided
+that markup was needed to avoid potential differences in interpretation
+by tool makers. It was decided to use simple markup that could be
+illustrated within a .txt file, as that is the (mostly) preferred
+download format for the licenses. The exact details of the markup are
+being worked out and the Legal Team (with help from anyone else in the
+SPDX Workgroup) will manage getting the markup created for the entire
+current SPDX License List.
+
+## Open SPDX Discussion
+
+Mark Gisi from Windriver and Adam Cohn from Cisco held this session on
+Tuesday afternoon. It was held under Chatham House Rules which means
+“When a meeting, or part thereof, is held under the Chatham House
+Rule, participants are free to use the information received, but neither
+the identity nor the affiliation of the speaker(s), nor that of any
+other participant, may be revealed.”. Now before you say hey you just
+said you weren’t supposed to mention names, these two were the chairs as
+listed on the SPDX schedule.There was a lot of good discussion. One
+individual talked about how they are fully integrating SPDX into what
+they their company delivers and how they are shipping, and I believe the
+number was, over 500 SPDX documents with each release. They also had a
+website for generating SPDX documents. Others talked about how they have
+started to integrate SPDX into their compliance process using it for
+reviews but not yet quite shipping. The reasons seemed to vary for that
+but they appeared to be more procedural than SPDX related. One
+individual did raise a concern on the amount of time that it might take
+to generate SPDX documents adding that it increased the cost of their
+compliance it was not something they could do. A few individuals talked
+about the adoption of SPDX among open source projects. There was some
+discussion on how this could be done now as there are a few open source
+tools that have appeared to generate SPDX documents. One individual
+talked about how they would like to see SPDX become more fully
+integrated into the community meaning that practices normally associated
+with an open source project such as peer review and so forth were used
+and considered part of the process of generating, reviewing and editing
+SPDX documents.
+
+## SPDX Morning Sessions
+
+Mark Gisi (the man that Scott calls “the spiritual leader of SPDX
+adoption”) kicked off the morning with License to Kill…You Code, a very
+cogent treatise on why it’s important for copyright holders to get it
+right if they want their projects to thrive. Then Gary “the Toolman”
+O’Neall lead a panel on Tooling up for SPDX. He gave an over view of
+group, community and commercial tools that are now compatible with SPDX.
+Gary was joined by Matt Germonprez of the University of Nebraska Omaha
+and Sameer Ahmed from Wind River Systems who both talked in some detail
+about work their groups have done to “tool up.” Conclusion: This stuff
+is real\! And to prove it…
+
+## SPDX Bakeoff
+
+The SPDX Bakeoff was held Wednesday afternoon. Our main objective was to
+compare SPDX output from different tools in order to identify bugs and
+resolve different interpretations of the specification. We had great
+representation from the various tool providers, members of the SPDX
+working group, and a number of other interested parties. Gary O’Neall’s
+excellent spreadsheet comparison tool was used as the basis for
+comparison of the various SPDX files. Per the agenda, we first stepped
+through the complete Time package on a file by file basis. Following
+that we dove into Busybox but only at the package level. There was a lot
+good discussion and yes we did find some bugs in the tools and areas
+where the specification needs to be improved. All in all it was a very
+productive session and should serve to advance the adoption of SPDX. The
+spreadsheet along with notes from the session are captured on in this
+Google doc folder:
+<https://drive.google.com/?tab=mo&authuser=0#folders/0BxKdX878M2HCTlZIbkZSMXN6SGc>

--- a/general/2013/2013-05-02.md
+++ b/general/2013/2013-05-02.md
@@ -1,0 +1,67 @@
+  - Attendance: 12
+  - Minutes of April 4 meeting approved.
+  - Lead by Phil Odence
+
+## Business Team Report - Jack/Scott
+
+  - Focus has been on Summit
+  - Themes for the year are:
+      - Farming for input
+          - Survey was launched at LinuxCon, Phil driving
+          - First step in gathering data
+      - Improving documentation
+  - Also some good work going on in reaching out to projects:
+      - Apache
+      - Yocto
+
+## Legal Team Report - Jack
+
+  - Last meeting mostly focused on the action item list and getting
+    updates
+
+## Tech Team Report - Gary
+
+  - Two meetings since Collab Summit have involved
+      - Sifting through the good inputs from the Bake Off
+          - All ideas gleaned have been input into Bugzilla for tracking
+      - Reviewing a proposal for 1.2
+      - Discussing Daniel German's proposal for text matching
+          - Overall positive discussion
+          - Some concern about technical complexity of regular
+            expressions
+          - May be ways to simplify
+          - Needs to be discussed cross functionally with Legal Team.
+              - Jilayne to set up, perhaps using upcoming legal call
+                time.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Up with new Wiki
+      - Discussion about how to field and address questions about using
+        the Wiki
+          - Some thoughts of a new mailing list, but there wasn't a lot
+            of appetite for the idea.
+  - Survey
+      - Big push at Collab Summit and to all mailing lists
+      - 24 responses to date
+      - Discussion about how to get more responses.
+          - Mike Dolan took action to get into the LF newsletter
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Gary O'Neall, SourceAuditor
+  - Kirsten Newcomer, Black Duck
+  - Michael Herzog, nexB
+  - Jack Manbeck, TI
+  - Tom Incorvia, Microfocus
+  - Scott Lamons, HP
+  - Pierre Lapoint, nexB
+  - Matt Germonprez, U of Nebraska Omaha
+  - Mark Gisi, Wind River
+  - Mike Dolan, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-06-06.md
+++ b/general/2013/2013-06-06.md
@@ -1,0 +1,59 @@
+  - Most of the team leads were not able to join, so we curtailed the
+    meeting
+  - These 'virtual minutes' compile status reports from each team.
+
+## Business Team Report - Jack/Scott
+
+  - The SPDX Survey was closed and the results were compiled. A few of
+    the highlights:
+      - Over 100 people responded
+      - Punchline was that more than 75% thought it was important/very
+        important to have a standard for exchanging license information.
+      - Good representation world wide.
+      - Good mix of big and small companies.
+      - You can view the results here:
+        <http://wiki.spdx.org/view/Business_Team/Surveys>
+  - The next step with the Survey results is to see what can be
+    actionable and what to do.
+  - The University of Omaha Nebraska is working with Yocto and SPDX to
+    integrate their Fossology + SPDX instance into the Yocto build
+    process.
+  - Phil Odence and Scott Lamons submitted an article to IFOSSLR on he
+    state of SPDX.
+
+## Legal Team Report - Jilayne
+
+  - 5/23 meeting was a joint call with tech team to discuss specifics
+    and implementation of license matching guidelines
+      - we will use regular expression language for mark-up; Daniel
+        German offered to take on mark-up task with guidance on what to
+        mark-up from legal team
+      - Legal team to track what licenses have been done and progress,
+        etc.
+      - Gary and Daniel to sort out other implementation specifics
+
+<!-- end list -->
+
+  - 6/6 meeting – mostly back to regular programming. Went over the new
+    license tracking page and made updates
+      - had request for Artistic Perl license to be added: this is an
+        outstanding OSI issue. Email to OSI was resent to try and get
+        this resolved
+      - Need volunteers to do research on a few other specific licenses
+      - GPL exceptions research progressing – Tom V. to report on next
+        call
+
+## Tech Team Report - Kate
+
+  - Bugzilla now has 1.2 Specification target.
+  - Tech group has spent last 2 weeks identifying selected set of bugs
+    from prior input (Collab, bugzilla, etc.) that will be targetted for
+    1.2
+  - UNO making good progress getting command line version of spdx
+    generator available for YOCTO. Request is to get it moved up to
+    public repository now.
+  - CFP for LinuxCon is June 17. Gary to discuss with Matt about
+    possible paper collaboration.
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-07-03.md
+++ b/general/2013/2013-07-03.md
@@ -1,0 +1,65 @@
+  - Attendance: 7
+  - Minutes of May 2 meeting and June 6 virtual meeting approved.
+  - Lead by Phil Odence
+
+## Tech Team Report - Kate
+
+  - Team will be using a googledoc as the working copy of the 1.2 spec
+      - Contact Kate if you would like to be added to the doc
+  - Requirements for 1.2 are stable and are in Bugzilla
+  - The goal of releasing 1.2 by LinuxCon looks achievable in the
+    absence of any major changes.
+
+## Legal Team Report - Jilayne
+
+  - Main focus is on creating license templates
+      - Have been testing
+          - It's been a little trial and error with some confusion
+          - Jilayne will be puttying out a clarification
+      - Daniel German will take formated inputs from legal team and
+        implement markups
+      - May be complete by LinuxCon
+  - Have started looking at the Fedora license list to determine
+    coverage
+
+## Business Team Report - Jack/Scott
+
+  - Team is looking at our participation in LinuxCon
+      - Some papers have been submitted
+      - Thoughts of a Welcome to SPDX session
+  - Working on guidelines for developers; could be a LinuxCon session
+  - Survey results are available
+    <http://wiki.spdx.org/view/Business_Team/Minutes/2013-05-30>
+      - Note that there is a bug in Drupal. To download docs, you need
+        to be logged in and you need to hit the file cabinet icon all
+        the way on the right first, and then download.
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Will be adding Blog; Phil will make sure at least one update per
+        month
+      - Will be adding some pictures; Phil is driving and could use any
+        relevant pics.
+  - Linux Foundation feedback - Mike Dolan
+      - Good interest in SPDX from Yocto and Open Daylight
+      - Several member companies have expressed interest in accelerating
+        2.0 release
+          - We are constrained by Tech Team resources to single
+            threading 1.2
+          - Mike thinks he may be able to come up with some resources
+          - Kate believes that 3-4 more people willing to work outside
+            meetings would make a dramatic difference
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Kirsten Newcomer, Black Duck
+  - Tom Incorvia, Microfocus
+  - Kate Stewart, Linaro
+  - Mike Dolan, Linux Foundation
+  - Jack Manbeck, TI
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-08-01.md
+++ b/general/2013/2013-08-01.md
@@ -1,0 +1,62 @@
+  - Attendance: 6
+  - Minutes of July meeting approved
+  - Lead by Phil Odence
+
+## Business Team Report - Jack/Scott
+
+  - Uboot
+      - Popular project- boot loader for embedded devices
+      - Approached us about defining a standard way to include
+        SPDX-based license data in source code
+      - The one challenge seems to be with handling non-standard license
+  - Linuxcon
+      - Great news that we were able to get a room for Tuesday. (we had
+        had one for Monday, but there are a lot of general and legal
+        track sections on that day we didn't want to overlap with.
+      - Working on agenda, but will include a discussion with the guy
+        from Samsung presenting on SPDX.
+
+## Legal Team Report - Jilayne
+
+  - Main focus is on creating marked up license templates
+      - Daniel German has started taking formatted inputs from legal
+        team and implement markups
+      - Have been working out the process; seems very clear now.
+      - Now just executing; should be at least well into it by LinuxCon
+  - New licenses submitted:
+      - Uboot
+      - Unlicense
+
+## Tech Team Report - Jack
+
+  - Spec 1.2
+      - Should be released by LinuxCon
+      - Tools will lag slightly. Could use more resources on tools,
+        particularly tag value versions
+      - May include a description of how to reference licenses in code
+        (e.g. Uboot)
+  - Jack has documented the spec release process. (Kudos to Jack\!)
+      - Team agreed that for minor releases a tool lag is OK; for major
+        releases, it should be simultaneous.
+      - Would be good to have a 'diff' doc of some sort between releases
+
+## Cross Functional Issues – Phil
+
+  - Web Site Update - Jack
+      - Put out call for tool submissions
+      - Added blog and pictures to several sections
+  - IFOSSLR paper
+      - Phil, Scott, Jilayne working on it
+      - Has basically been accepted pending some revision
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, OpenLogic
+  - Kirsten Newcomer, Black Duck
+  - Tom Incorvia, Microfocus
+  - Scott Lamons, HP
+  - Jack Manbeck, TI
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-09-04.md
+++ b/general/2013/2013-09-04.md
@@ -1,0 +1,58 @@
+  - Attendance: 7
+  - Minutes of Aug meeting approved
+  - Lead by Phil Odence
+
+## Business Team Report - Jack/Scott
+
+  - Much of recent focus has been on LinuxCon. All organized for
+    meetings at this point.
+  - Team has recently started up a page to track adoption along 3
+    dimensions
+      - <http://wiki.spdx.org/view/Business_Team/Adoption>
+          - License List
+          - Consuming / Producing SPDX Docs
+          - Using Meta-tags
+              - Also trying to gather best practices for this area in
+                particular
+  - Goals
+      - The team is also working on laying out longer term goals, plans
+        and metrics
+  - Press Release
+      - Phil is coordinating a press release to announce 1.2 at LinuxCon
+      - Kate and Jack providing input to Phil; LF marketing resources
+        helping to write/release
+
+## Legal Team Report - ScottL
+
+  - Continuing to focus on creating marked up license templates
+      - Discussion the use of general guidelines vs. license-specific
+        markups.
+      - We are relying on guidelines when possible, markups for cases
+        not handled
+      - Recent discussion on extra/optional language included at the end
+        of some license
+      - All this will be a topic for a joint tech/legal discussion at
+        LinuxCon
+
+## Tech Team Report - Gary
+
+  - Complete attention of the team has been on Spec 1.2
+      - Should be released or very close by LinuxCon
+      - Tech team will finish review Tuesday and will put the
+        penultimate version out for broader input.
+      - Tools will lag by a week.
+
+## Cross Functional Issues – Phil
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Gary O'Neall, Source Auditor
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Scott Lamons, HP
+  - Jack Manbeck, TI
+  - Pierre Lapointe, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-10-03.md
+++ b/general/2013/2013-10-03.md
@@ -1,0 +1,81 @@
+  - Attendance: 11
+  - Minutes of Sept meeting approved
+  - Lead by Jack Manbeck (Phil at a conference)
+
+## Tech Team Report - Gary
+
+  - LinuxCon Update:
+      - Samsung had comments. Incorporated some of their feedback into
+        the 1.2 specification and others written up as IRs in Bugzilla
+        as they are best handled in the 2.0 specification.
+      - Talked about SPDX 2.0 and new models for handling hierarchy and
+        relationships. Walked through a few examples to see how they
+        would be represented in 2.0. Discussions will be picked up again
+        once 1.2 Specification is done.
+  - Specification Update
+      - New target was set for LinuxCon Europe.
+      - Review draft to tech team this Friday 4 October.
+      - Best and Final review copy to community the following week.
+        Normally we have a two week review period but these are minor
+        changes so hopefully we can close by LinuxCon Europe which is 21
+        October.
+  - Meta Tagging:
+      - Would be good to standardize that at some point. Maybe a best
+        practice at first.
+      - More socialization needed. Will meet with Legal team.
+  - Other
+      - OMG Session on Open Source practices. Gary and Mark will attend
+        from SPDX. It is an open meeting if others are interested in
+        attending.
+
+## Legal Team Report - Jilayne
+
+  - Focus on what happened at LinuxCon.
+      - Discussed license matching guidelines. How the license
+        guidelines and templates match up. Wanted to be clear on where
+        you could find mark up for a license and where you would not.
+      - How to release the templates. Will release 1.20 of the license
+        list with the templates. Did not want to release a partial set
+        so not included in 1.19.
+      - Working through the fedora license list.
+      - Will have some discussion about GPL identifiers like GPL-2.0 and
+        GP-2.0+ based on list email traffic. Team will look at.
+
+## Business Team Report - Jack/Scott
+
+  - LinuxCon Update:
+      - Business team call that week was cancelled since we are at
+        LinuxCon with sessions.
+      - Started a strawman Best Practice’s Document. Outline generated.
+        Need to find an owner to drive.
+
+## Cross Functional Issues – Jack
+
+  - Some frustration heard on progress on 2.0. Specification 1.2 delayed
+    some. Team is trying to be complete so there was a length use case
+    phase prior to 2.0 starting. More people participating would be
+    good. Better messaging on 2.0 as to what is, where it’s going and
+    what people can do. Need a link from main web site. Perhaps takes
+    you to a landing page with an overview and further links. A solid
+    roadmap.
+  - More how to tutorials needed as feedback from Samsung.
+  - Simple tasks for getting people involved if they are starting from
+    ground zero. Have a web page of unassigned items that people could
+    volunteer for? Will set one up.
+
+## Attendees
+
+  - Tom Incorvia
+  - Jilayne Lovejoy
+  - Pierre Lapointe
+  - Mark Gisi
+  - Norm Glaude
+  - Scott Lamons
+  - Mike Dolan
+  - Gary O’Neill
+  - Matt Germonprez
+  - Steve Cropper
+  - Jack Manbeck
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-11-05.md
+++ b/general/2013/2013-11-05.md
@@ -1,0 +1,69 @@
+  - Attendance: 9
+  - Minutes of Oct meeting approved
+  - Lead by Phil Odence
+
+## Tech Team Report - Kate
+
+  - 1.2 has shipped
+      - Some of our OSS tools have been upgraded
+      - Wind River at 1.2
+      - Yocto not yet at 1.2
+  - 2.0
+      - Full steam on 2.0
+      - Now is the time to get re-involved
+      - Get bugs in now
+  - Meta-tag discussion with Kernel guys
+      - Greg KH said they would accept a patch
+      - Kate starting work and working guidelines in parallel on page
+        that Jack created
+  - JimZ mentioned SPDX in his Keynote at Connect
+
+## Business Team Report - Jack/Scott
+
+  - Overview of requirements for 2.0
+      - Kate creating comparison between two models
+      - Kirsten volunteered to draft a \<5 page doc; targeting before
+        Thanksgiving
+      - Gary has written up an email that captures some thoughts;
+        included in last biz team notes
+  - Mark created page to track creation of tech notes and SPDX
+    collateral
+  - Jack created a 2.0 overview page
+      - Also need public-facing summary of 2.0
+  - Ideas for on-boarding - Biz team to take
+      - Page defining where we need volunteers
+      - Forum page for asking questions
+      - User mailing list - may be too many lists
+
+## Legal Team Report - Jilayne
+
+  - Finalizing license list guideline
+  - License Exceptions/+ etc
+      - Re-evaluating the way we handle
+      - MarkG setting up dedicated meeting to discuss
+      - Looking at use cases that we have a hard time handling today
+        with current approach
+      - Anyone interested in discussion should contact Mark
+  - Fedora license list review
+      - Working to be as consistent as possible with our short term
+        identifies
+  - Could use more lawyers on Legal Team calls
+
+## Cross Functional Issues – Phil
+
+  - OMG is hosting a meeting in Santa Clara in December
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Scott Lamons, HP
+  - Jack Manbeck, TI
+  - Pierre Lapointe, nexB
+  - Mike Dolan, Linux Foundation
+  - Kate Stewart, Linaro
+  - Jilanyne Lovejoy, SPDX
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2013/2013-12-05.md
+++ b/general/2013/2013-12-05.md
@@ -1,0 +1,54 @@
+  - Attendance: 10
+  - Minutes of Nov meeting approved
+  - Lead by Phil Odence
+
+## Biz Team Report - Scott
+
+  - Focus remains adoption
+  - Documentation- Working with Mark Gisi's process for developing new
+    documentation
+  - Tagging- Looking for more input on the page Jack created
+    <http://wiki.spdx.org/view/Technical_Team/SPDX_Meta_Tags>
+
+## Legal Team Report - Jilayne
+
+  - License Exceptions
+      - Mark G still has the action to call a cross-team meeting to
+        discuss possibly revamping the way we handle common license
+        exceptions.
+      - Tom Vitale had done a great job assembling a collection (large)
+        of GPL exceptions.
+  - License LIst
+      - Fedora List- continuing to work through to identify possible
+        adds to the SPDX License List
+      - Will likely push next rev of license list to after first of the
+        year.
+
+## Tech Team Report - Kate
+
+  - V2.0
+      - Complete focus of team.
+      - No more meetings until January
+
+## Cross Functional Issues – Phil
+
+  - OMG meeting, Dec 11 (on standardizing OSS license mgmt business
+    practices) looks to be attracting two dozen people. Phil to speak.
+    Several others from SPDX to attend.
+  - Kirsten has started to share a 2.0 requirements doc for feedbcak.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Tom Incorvia, Microfocus
+  - Scott Sterling, Palamida
+  - Scott Lamons, HP
+  - Pierre Lapointe, nexB
+  - Kirsten Newcomer, Black Duck
+  - Gary O'Neill, Source Auditor
+  - Kate Stewart, Linaro
+  - Jilanyne Lovejoy, SPDX
+  - Matt Germonprez
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-01-02.md
+++ b/general/2014/2014-01-02.md
@@ -1,0 +1,81 @@
+Because of the timing with respect to holidays, this is a VIRTUAL
+meeting. That is, Team Leads reported by email. Next meeting will be
+back to normal.
+
+## Biz Team Report - Jack
+
+Looking for new Co-Chair Scott Lamons needs to step down as business
+team co-lead. He's done a great job and will still be well involved with
+SPDX, just not in this role. We are currently looking for a new co-chair
+and an email soliciting such was out on the Business team mailing list.
+We are looking to receive all requests for co-chair by January 10th and
+will make the selection by January 17th.
+
+SPDX 2.0 Requirements Overview Kirsten Newcomer volunteered to do a
+Requirements overview for SPDX 2.0 in collaboration with the Technical
+team. The idea was to summarize what 2.0 will do at a level higher than
+the current use cases. A draft was reviewed at our last meeting in
+December and we hope to finalize it in early January. Once this is done,
+we will create a brief of 2.0 and a SPDX 2.0 Project Page. Theproject
+page will list milestones for 2.0, have the brief and include links to
+all relevant wok.
+
+Technical Report Process and Framework Mark Gisi has been doing a lot of
+work on the Technical Report Process and Framework. Basically, the
+objective of the SPDX Tech Report program is to create a repository of
+articles to capture and share community knowledge about everything and
+anything SPDX. This knowledge base covers a diverse collection of topics
+including (but not limited to): technical issues, best practices,
+relevant legal topics, tool proposals, adoption strategies and analysis,
+license compliance considerations, position papers and so forth. We are
+looking to start implementation of this program in early 2014.
+
+Adoption Page An adoption page was created by the Business Team to help
+track the adoption of SPDX. It looks at adoption within three key areas:
+
+  - SPDX License List
+  - Generating or consuming SPDX Documents
+  - Using SPDX meta tags in software
+
+You can view or update the page on the wiki here:
+<http://wiki.spdx.org/view/Business_Team/Adoption> Roadmap for 2014 The
+roadmap is being updated for 2014.
+
+## Legal Team Report - Jilayne
+
+Not much new to report since December; however, the current work and
+priorities page has been updated (preliminary) for 2014 -
+<http://wiki.spdx.org/view/Legal_Team/Current_Projects_and_Issues>
+
+Of note: Goal of releasing next version of the SPDX License List by end
+of January including license matching templates/markup. Will also
+include any new licenses from review of Fedora list up to the point in
+time (review of Fedora list is an on-going project). Thus, the first
+meeting (or two) will focus on whatever needs to be done to facilitate
+release of version 1.20 of the license list.
+
+Mark Gisi will be scheduling a special cross-functional meeting to
+discuss license expression - more details on that to come. This
+discussion will also incorporate revisiting the issue of how to best
+express “or later” or “only” versions of licenses and the (GPL)
+exceptions.
+
+## Tech Team Report - Kate
+
+Team did not meet in December, due to vacation and travel conflicts.
+
+There were some very interesting talks at the Open Compliance Summit on
+SPDX in December. Samsung presented on how they plan on using SPDX in
+their infrastructure and contribution plans. Matt Germonprez presented
+on the plugin work with FOSSology. Most of the attendees there had heard
+of SPDX and were interested in it. From discussions, reasons why some
+are not adopting right now is waiting for others to adopt first, better
+tooling to be available, or 2.0 to be released.
+
+On that note, now that its 2014 - 2.0 is a key focus for the technical
+team. We've got a preliminary model that we're assessing the use-cases
+against. We'll be starting off the draft document for 2.0, and 1.2 to
+2.0 translation/mappings in the next few months.
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-02-13.md
+++ b/general/2014/2014-02-13.md
@@ -1,0 +1,71 @@
+  - Attendance: 7
+  - Minutes of Jan meeting approved
+  - Lead by Phil Odence
+
+## Biz Team Report - Jack
+
+  - v2.0 overview and requirements are near final
+      - Still open to comments
+      - Will run through our [tech doc process](Tech_Reports "wikilink")
+  - Working on agenda for Collaboration Summit
+      - Tech Team will have a full day meeting on v2.0 at the venue on
+        the Tuesday before
+      - We will have a track during the conference
+          - Mix of presentations and working sessions
+  - The search for a new co-lead is nearing completion
+
+## Legal Team Report - Jilayne
+
+  - On going
+      - Some new license requests
+      - Marking up licenses
+  - Fedora list resolution is somewhat stalled and needs a jumpstart
+  - FOSDEM report
+      - There was a presentation on SPDX in the legal track
+          - The presenter showed up late
+          - Conference organizers were not happy with that and there
+            were some issues with content
+          - Did not reflect well on SPDX, so we need some quality
+            control for conference presence.
+
+## Tech Team Report - Jack/ScottS
+
+  - Testing data model
+      - Working through real examples in 1.2 and 2.0
+
+## Cross Functional Issues – Phil
+
+  - OSI
+      - Phil has reached out to initiate more collaboration
+      - Hoping to initiate a meeting to discuss how we might cooperate
+        in the OSI projects
+          - License Chooser
+          - License Compatibility Tools
+          - Machine readable license text
+      - Aiming for a small joint meeting to kick off
+  - Phil posted [language describing direction in 2.0 spec section of
+    SPDX.org](http://spdx.org/SPDX-specifications/spdx-version-2.0)
+  - [License Expression
+    Syntax](Legal_Team/License_Expression_Review_1 "wikilink") - MarkG
+      - Cross functional effort between Tech and Legal Teams to define
+        formal but simple and flexible mechanism for expressing complex
+        licensing of some packages (multiple licensing, exceptions, etc)
+      - Will essentially use Boolean operators and parentheses.
+      - Productive kick off meeting yesterday; agreement on the issue
+        and reasonable alignment on the approach
+      - One more meeting before Collab Summit with the goal of having a
+        draft for discussion at the Summit
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jack Manbeck, TI
+  - Scott Sterling, Palamida
+  - Pierre Lapointe, nexB
+  - Kirsten Newcomer, Black Duck
+  - Jilanyne Lovejoy, ARM
+  - Mike Dolan, Linux Foundation
+  - Mark Gisi, Wind River
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-03-06.md
+++ b/general/2014/2014-03-06.md
@@ -1,0 +1,72 @@
+  - Attendance: 10
+  - Minutes of Feb meeting approved
+  - Lead by Phil Odence
+
+## Biz Team Report - Jack (unable to attend, but provided written summary)
+
+  - Agenda is fixed for Linux Collab and posted on the SPDX web site. LF
+    will publish as well.
+  - Tech Report Framework is almost complete. Will be ready to go by
+    Collab.
+  - We have a new co-chair, Mikael Söderberg from Pelagicore
+  - We are looking at documenting an SPDX ecosystem and generating
+    vertical specific whitepapers on using SPDX.
+
+## Legal Team Report - Jilayne
+
+  - Calendar Invite
+      - Some issues with old ones; light attendance at last meeting as a
+        consequence
+      - Please delete. Everyone on the LT should have a new one from
+        Mike Dolan.
+  - Fedora List
+      - Still pushing to get through by CollabSummit
+      - Goal is to cover as much as possible of the Fedora "good list"
+        on SPDX License List
+      - Jilayne doing lots of work herself; appreciating any help.
+  - CollabSummit- Focus for legal meeting with be on the expression
+    language.
+
+## Tech Team Report - Gary
+
+  - Two main threads of late:
+      - Applying real examples to the 2.0 model
+      - Working out how to upgrade Tag Value format to handle new model
+          - Sorting through three proposals: Extending current approach,
+            JSON, RDF
+  - Model
+      - There had been two models, one more evolutionary, one more
+        revolutionary
+      - Now focused on one based on the more evolutionary approach.
+      - Tech team will present model at the next General Meeting, April
+        3
+
+## Cross Functional Issues – Phil
+
+  - OSI Collaboration Update
+      - We have had some interaction, but have not yet set up a joint
+        meeting
+  - 2.0 Language on SPDX.org
+      - No feedback
+      - Need to review post CollabSummit
+  - [License Expression
+    Syntax](Legal_Team/License_Expression_Review_1 "wikilink") - MarkG
+      - One more meeting planned prior to CollabSummit
+      - Aiming for draft and examples for face to face discussion
+      - Hoping for closure at CollabSummit
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Pierre Lapointe, nexB
+  - Kirsten Newcomer, Black Duck
+  - Jilanyne Lovejoy, ARM
+  - Mike Dolan, Linux Foundation
+  - Mark Gisi, Wind River
+  - Mary Hardy, Qualcomm
+  - Gary O'Neill, Source Auditor
+  - Tom Incorvia, MicroFocus
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-05-01.md
+++ b/general/2014/2014-05-01.md
@@ -1,0 +1,60 @@
+  - Attendance: 9
+  - Minutes of April meeting not yet complete/approved
+  - Lead by Phil Odence
+
+## Tech Team Report - Kate
+
+  - Following up on discussions from CollabSummit
+      - Clarifying relationships between elements
+      - Working big list
+          - Includes features
+          - Making sure everything designated for 2.0 is covered.
+  - Still on track for LinuxCon
+
+## Biz Team Report - Jack (unable to attend, but provided written summary)
+
+  - Focus on LinuxCon(s) and 2.0 Promotion
+      - Aiming to support 2.0 announcement at LinuxCon NA
+          - Phil/Jack and Gary/Jilayne submitting talks. Not sure of
+            others.
+      - Out reach through presentations, BoF, etc at LinuxCon Europe
+  - Promoting 2 SPDX Reports to spdx.org
+      - 2.0 Requirements Doc (Kirsten's)
+      - Accessing the License List (Gary's)
+  - Mikael will be presenting on SPDX at the GENIVI (automotive OSS
+    community) All Members Meeting in Europe
+  - Whitepapers are in process on automotive and embedded
+
+## Legal Team Report - Jilayne
+
+  - License Expression Language went our for comment; a few received and
+    incorporate, so it's final.
+      - Templates and guidelines need to be updated to reflect
+      - Exceptions list work is in process
+      - In process of review spec to incorporate references to LL
+  - Fedora list work continues and a special meeting is scheduled to
+    target
+  - Next License List release will be coincident with 2.0
+
+## Cross Functional Issues – Phil
+
+  - Google Summer of Code
+      - 4 project accepted
+      - Phil working with Matt/Linux Foundation to promote via blogs
+      - Biz team is updating the wiki and website with info (and a
+        University participation section).
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Kirsten Newcomer, Black Duck
+  - Jilanyne Lovejoy, ARM
+  - Mark Gisi, Wind River
+  - Matt Germonprez, UNO
+  - Jack Manbeck, TI
+  - Kate Stewart, Lenaro
+  - Paul Madick, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-06-05.md
+++ b/general/2014/2014-06-05.md
@@ -1,0 +1,65 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of May meeting approved
+
+## Biz Team Report - Jack
+
+  - Summer of Code- Lots of discussion on the Tech Team mailing list
+  - Website- Jack and Matt are adding a page regarding University
+    participation
+  - LinuxCon- Working on getting a room
+  - Website Statistics- Scott Lamons has volunteered to analyze on an
+    ongoing basis and report to the Business Team
+  - Vertical whitepapers in progress
+  - Europe
+      - Mikael delivered a workshop at Siemens
+          - They didn't understand license request process
+          - Mikael encouraged them to participate in SPDX
+      - GENIVI- Mikael also promoted SPDX at the GENIVI All Members
+        Meeting
+
+## Legal Team Report - Jilayne
+
+  - Focus is on 2.0 deliverables
+      - Fedora list
+          - Worked through the list completely
+          - Just a few remaining questions
+      - New exceptions list is in process
+      - In process of reviewing the website for how to present all the
+        new developments
+
+## Tech Team Report - Gary
+
+  - Very productive month
+      - Kate heavily into spec drafting
+      - Bug reports all combed through and assigned
+      - All big issues addressed
+  - Gary and Mark agreed that we are "on track" for delivery at LinuxCon
+  - No clear due date for a draft from Kate
+
+## Cross Functional Issues – Phil
+
+  - Working with Apache
+      - Gary developed a Maven plugin to auto-generate an SPDX file
+      - Getting some help from ASF members, but not a lot of pull
+      - Now looking to attached to another group within Maven
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Jilanyne Lovejoy, ARM
+  - Mark Gisi, Wind River
+  - Matt Germonprez, UNO
+  - Jack Manbeck, TI
+  - Paul Madick, HP
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Mikael Söderberg, Pelagicore
+  - Scott Lamons, HP
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-07-03.md
+++ b/general/2014/2014-07-03.md
@@ -1,0 +1,66 @@
+  - Attendance: 8
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of June meeting approved
+
+## Biz Team Report - Jack
+
+  - Still working on University participation
+  - Still working on white papers
+  - Website
+      - What would you like to do with SPDX today website
+      - Help wanted section
+      - Wiki Meeting minutes summary pages- will file bug report
+      - No update on website statistics
+  - Still need to pick a date for the face to face at LinuxCon
+
+## Legal Team Report - Jilayne
+
+  - Based on 2.0 being release being pushed to LC Europe
+      - Decided to do interim LL is release
+      - 80 new licenses
+  - Exceptions will wait for 2.0
+  - Make splash on SPDX list
+      - Exploring announcemtn about Fedora list harmonization
+  - Paul has taken a pass 2.0 changes for Website
+
+## Tech Team Report - Kate (wrote in)
+
+  - work continues on spec. Have resolved the file types, file usage
+    portions
+      - Can describe how a file is used (Static/dynamic)
+      - And file type
+  - decision made to not include the RDF vocabulary in the SPEC going
+    forward, Gary was having issues regenerating it in form suitable for
+    inclusion, and prefers to go with a different tool in future. Spec
+    will be the master and refer to a static version, that will be on
+    web site.
+      - SPDX.org/RDFterms
+      - Previously copied into appendix
+      - So will just link to from spec, remove appendix
+      - RDF terms and licenses pages can’t change.
+      - Jack will create wikipage that has ground rules for changing the
+        website.
+
+## Cross Functional Issues – Phil
+
+  - Working with Apache
+      - Gary developed a Maven plugin to auto-generate an SPDX file
+      - Getting some help from ASF members, but not a lot of pull
+      - Now looking to attached to another group within Maven
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Jilanyne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Paul Madick, HP
+  - Tom Incorvia, Microfocus
+  - Gary O'Neall, Source Auditor
+  - Pierre LaPonte, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-08-07.md
+++ b/general/2014/2014-08-07.md
@@ -1,0 +1,53 @@
+  - Attendance: 7
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of June meeting approved
+
+## Biz Team Report - Jack
+
+  - No meeting last week due to vacations
+
+## Legal Team Report - Jilayne
+
+  - V1.20 is done
+      - Should be posted within a couple days
+      - Email will go out to describe changes
+          - Large release with most of Fedora list added
+          - 306 licenses, 91 new licenses including 81 from Fedora list
+      - More uniformity in display
+  - The is a question about the value of the Standard Header Field
+      - Team will be floating question of whether we should deprecate
+
+## Tech Team Report - Gary
+
+  - 2.0 Progress
+      - Kate continuing drafting 2.0 spec
+      - Gary has drafted the RDF-specific language, which has raised
+        some issues.
+
+## Cross Functional Issues – Phil
+
+  - LinuxCon
+      - Looks like a solid group of 10 folks will meet in Chicago
+      - Meetings will be Wedneday 9:30-3:30
+  - Working with Apache
+      - Slow progress
+      - Trying to attach to group at Apache that would work with Gary on
+        plugin for creating SPDX docs for Apache projects
+      - Looks like the best path is to start up the plugin as an
+        incubator project; we need to confirm a sponsor
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Jilanyne Lovejoy, ARM
+  - Gary O'Neall, Source Auditor
+  - Pierre LaPonte, nexB
+  - Scott Lamons, HP
+  - Mark Gisi, Wind River
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-09-04.md
+++ b/general/2014/2014-09-04.md
@@ -1,0 +1,52 @@
+  - Attendance: 6
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Aug meeting approved
+
+## Tech Team Report - Kate
+
+  - LinuxCon
+      - Productive session
+          - Resolve how to handle mapping between model and tag value
+            for SPDX elements
+          - ID’ed issues with relationship types and file types
+              - Subsequently addressed in tech team meetings
+              - May need to drop some use cases when things were not
+                neat to represent
+          - All recorded in GoogleDoc
+      - Just as productive hallway conversations
+          - About relationship issues
+          - Fedora
+              - Session on FOSS governance; TomC said that Red Hat was
+                on hold for now
+              - TC says they are aligned with unifying license names
+              - Adoption waiting for upsteams
+      - Interest in SPDX participation
+
+## Biz Team Report - Jack
+
+  - Meeting last week
+      - Mostly recapping LinuxCon
+      - Open Chain participation
+      - Need to get quotes for press release; will address at next
+        week’s meeting
+
+## Legal Team Report - Jilayne
+
+  - No update
+
+## Cross Functional Issues – Phil
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Kate Stewart, Linaro
+  - Jack Manbeck, TI
+  - Michael Herzog, nexB
+  - Mark Gisi, Wind River
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-10-02.md
+++ b/general/2014/2014-10-02.md
@@ -1,0 +1,52 @@
+  - Attendance: 7
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Sept meeting approved
+
+## Cross Functional Issues – Phil
+
+  - 2.0 Schedule
+      - Proposed reset of phased release to be ratified by Tech Team -
+        roughly:
+          - Release candidate targeted early Nov
+          - Presentations to and feedback for OpenChain group- Dec
+          - RC 2 January; tooling development in parallel
+          - Final Release at CollabSummit in Feb
+
+## Biz Team Report - Jack
+
+  - Website
+      - University Participation page is up
+      - Looking at Google Analytics
+          - Pointed to need to revamping front page to make it
+            roll-based
+          - Continuing to look for improvements for website
+  - 2.0 Press Release on hold
+
+## Legal Team Report - Jilayne
+
+  - Call today agenda
+  - Focus is what’s needed for 2.0
+      - Need to work out license list release timing implications
+      - How do we have pre-release version of LL?
+
+## Tech Team Report - Kate
+
+  - No meeting this week
+  - Still cleaning up relationship types, license types
+  - Email discussion about new release schedule and approach.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Scott Sterling, Palamida
+  - Jack Manbeck, TI
+  - Pierre LaPonte, nexB
+  - Scott Lamons, HP
+  - Matt Germonprez, UNO
+  - Jilayne Lovejoy, ARM
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-11-06.md
+++ b/general/2014/2014-11-06.md
@@ -1,0 +1,68 @@
+  - Attendance: 15+
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of October meeting approved
+
+## Cross Functional Issues, Special Presentation from Polarsys – Phil
+
+  - Presentation from Polarsys COTSAQ project
+    <http://polarsys.org/proposals/cotsaq>
+      - OSS tool for managing software BoMs
+      - SPDX connections
+          - First will use SPDX License List
+          - Connecting with code scanners through SPDX
+
+## Biz Team Report - Jack
+
+  - Last call cancelled. Call in an hour.
+  - Current focus is revamping the website homepage to guide new users
+
+## Legal Team Report - Jilayne
+
+  - Working through 2.0 task list
+  - Syncing with tech team schedule for release
+  - Cross team topic- Standard Header field in list that applies to a
+    subset of licenses (e.g. GPL, Apache)
+      - Proposal is to remove the field as it becomes problematic with
+        2.0
+      - Notice will go out to tech team/legal team
+
+## Tech Team Report - Kate
+
+  - Fleshed out external SPDX document reference syntax. (currently sec
+    3.5, but may spin off to own section) and working on self reference
+    (2.4)
+  - Finishing off clarifying examples for relationship references (sec
+    8)
+  - Extended the recognized checksums to include SHA256, MD5 (sec. 4.9,
+    6.4)
+  - Decided to start off separate spec for inline references rather than
+    include it in Appendix.
+  - What's up for this month...
+      - Gluing it all together and making available for other reviewers
+      - Near term schedule: Draft Nov 14, feedback by Dec 1.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kirsten Newcomer, Black Duck
+  - Pierre Lapointe, nexB
+  - Gary O’Neill, SourceA
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Matt Germonprez, UNO
+  - Jilayne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Mike Dolan, Linux Foundation
+  - Paul Maddick, HP
+  - Michael Herzog, nexB
+
+<!-- end list -->
+
+  - Pierre G, AirBus
+  - Others from project COTSAQ
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2014/2014-12-04.md
+++ b/general/2014/2014-12-04.md
@@ -1,0 +1,50 @@
+  - Attendance: 6
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Nov meeting approved
+
+## Cross Functional Issues – Phil
+
+  - Postponed presentation from Valeo to January 8
+
+## Biz Team Report - Phil
+
+  - Mostly focused on Collab Summit agenda
+      - Need to have rough agenda before holidays
+      - Coordinating with Open Chain who will share our room for 1/2 day
+      - Plugfest will likely take different form
+          - Anticipating tooling will not be fully in place
+          - More manual testing
+      - Discussion: Ideas for sessions
+          - SPDX 101 and 102 (the latter being update on 2.0)
+          - Update on License List
+          - 2.0 Tooling
+
+## Legal Team Report - Paul
+
+  - Beta LL list (targeting Dec 18) to include
+      - Continuing to add new licenses
+      - Deprecated licenses
+      - Exceptions list & some FAQs
+      - Templates
+
+## Tech Team Report - Scott
+
+  - Heads down reviewing 2.0 spec
+      - Cleaning up
+      - Adding/improving examples
+  - In pretty good shape
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Paul Maddick, HP
+  - Mike Dolan, Linux Foundation
+  - Pierre LaPointe, nexB
+  - Scott Sterling, Palamida
+  - Mark Gisi, Wind River
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-01-08.md
+++ b/general/2015/2015-01-08.md
@@ -1,0 +1,70 @@
+  - Attendance: 6
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of December meeting approved
+
+## Cross Functional Issues – Phil
+
+  - Great Presentation from Bruno Grasset
+  - He opened and closed with thanks to everyone involved with SPDX for
+    providing something so useful to the industry
+      - Valeo
+          - Supplier to Automotive Industry- Autonomous Cars, Connected
+            Car, Intuitive Control
+          - Middle of complex supply chain
+      - Why they think SPDX is important
+          - Industry is “likes” standards, procedures, rules
+          - Have an explicit program to ensure respecting licenses and
+            meeting obligations in all products
+          - Bruno is in charge of OSS compliance
+      - How they use
+          - License List
+              - Internal policy started with the SPDX list
+              - They use the SPDX license IDs in all of their documents
+                and databases (including promoting publicly)
+              - And they check any licenses anyone supplies against our
+                standard text
+          - Document Spec
+              - Prototyped use internally
+              - Have been looking for hierarchy, so 2.0 is important;
+                evaluating in 2015
+      - Future Intent
+          - Large OEMs (car companies) are starting to require
+          - Customer requirements are making this a priority in 2015
+          - Will need to require from their own suppliers
+          - Integration with Yocto is critical
+          - Aiming for chain of trust, based on SPDX
+      - Questions
+          - When you evaluated SPDX, any features beyond hierarchy that
+            they require?
+              - Not yet mature enough to completely evaluate
+          - How did you hear of? How can we promote?
+              - LinuxCon Europe session- Bruno came then promoted
+                internally.
+              - He expects that in his space that SPDX will catch on
+                quickly because of car makers requirements
+          - SPDX and Yocto- Is there only interest in Yocto integration
+            or more general integration?
+              - Broader interest in integrating into process
+
+## General Status - Phil
+
+  - On track for 2.0 release at CollabSummit
+  - Jack has been working hard to get a good agenda together
+  - We will be sharing a room with OpenChain so that folks can
+    participate in both
+  - Looking forward to seeing everyone
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kirsten Newcomer, Black Duck
+  - Matt Germonprez, UNO
+  - Scott Sterling, Palamida
+  - Gary O’Neill, SourceA
+  - Bruno Grasset, Valeo
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-02-05.md
+++ b/general/2015/2015-02-05.md
@@ -1,0 +1,44 @@
+  - Attendance: 5
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of January meeting approved
+
+## Biz Team Report - Jack
+
+  - Collab Summit
+      - Agenda set
+      - Tech Team will meet on Wed
+      - Friday afternoon meeting
+      - Jack will post
+  - Looking like 2.0 spec won’t be finalized
+      - Likely to be the subject for Friday afternoon
+  - Starting to gear up for another Google Summer of Code
+
+## Tech Team Report - Jack
+
+  - Some delay in finalizing due to last minute issues arising
+  - Has gotten very good detailed review by Tech Team
+  - 2.0 will go out for community review prior to Collab
+
+## Legal Team Report - Jilayne
+
+  - Beta LL list posted, feedback welcome
+
+## Cross Functional Topics - Phil
+
+  - Future Presentations for General Meeting
+      - TI would be happy to after Collab
+      - Would love to get other companies to share
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jack Manbeck, TI
+  - Hassib Khanafer, Protecode
+  - Pierre LaPointe, nexB
+  - Kirsten Newcomer, Black Duck
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-04-02.md
+++ b/general/2015/2015-04-02.md
@@ -1,0 +1,68 @@
+  - Attendance: 10
+  - Lead by Jilayne
+
+## Biz Team Report - Jack
+
+  - Working with Linux Foundation to get press release for 2.0 together;
+    need to come up with better way to represent increase in number of
+    licenses in a meaningful way
+      - timing for press release: perhaps around ApacheCon, which is in
+        two weeks. Jack to check with Jennifer
+  - Google Summer of Code - no spots for Linux Foundation due to Google
+    rotating foundations instead of annual representation. Some other LF
+    projects are doing fund-raising to pay for interns.
+  - Starting next call: think about and plan some re-vamping of spdx.org
+    website; have some ideas, but want to get it going so that it’s more
+    interactive or by roles.
+
+## Legal Team Report - Jilayne
+
+  - 2.0 is live now and Git repository is tagged\!
+  - No legal call today, next call on April 16 - will discuss what’s up
+    next after 2.0, priorities and projects to tackle for rest of 2015
+
+## Tech Team Report - Kate
+
+  - Re: License expression syntax - some discrepancy - Mark to look at
+  - Comments cleaned out of spec now for most part, a few have moved to
+    Bugzilla
+  - Jilayne to look through templates section
+  - Review window for 2.0 is mostly over and as soon as last issue is
+    resolved, will have check-point at next tech team call on Tuesday
+  - Once published, Jack to update website
+  - update from Gary on tools: He’s doing some unit tests and hope to
+    have something on the website in a week or so. The tools will be
+    "beta quality" and any volunteers to help test would be greatly
+    appreciated. I'll send out an email once I have the tools posted.
+
+## Cross Functional Topics - Phil
+
+  - Mike from LF: may be some funding that could be put towards
+    compliance related help for the community. One idea: for various
+    build tools out there, are there things that can be done to make
+    SPDX output easier? If so, what needs to be done, where to apply
+    resources, etc. to help drive SPDX adoption at build time.
+      - Kate’s thoughts were maybe Android (and ecosystem, working with
+        AOSP), Debian (in order to go into Ubuntu eco-system)
+      - need: maybe 2 interns with mentor, then planning for long-term
+        ownership?? more discussions needed
+  - Had a call with Github re: SPDX License List adoption of full names
+    and short identifiers, etc. and how they might leverage license list
+    for their work. More coming hopefully
+  - Future Presentations for General Meeting:
+      - TI would be happy to after Collab - Jack is working on it and
+        will follow-up with Phil
+      - General call out to keep an ear out for people to present
+
+## Attendees
+
+  - Jilayne Lovejoy, ARM
+  - Hassib Khanafer, Protecode
+  - Michael Herzog, NexB
+  - Pierre, NexB
+  - Jack Manbeck, TI
+  - Bill Schillner, B
+  - Scott Sterling, Palamida
+  - Mike Dolan, Linux Foundation
+  - Paul Madick, HP
+  - Kate Stewart, Linaro

--- a/general/2015/2015-05-07.md
+++ b/general/2015/2015-05-07.md
@@ -1,0 +1,74 @@
+  - Attendance: 9
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of April meeting approved
+
+## Tech Team Report - Kate
+
+  - 2.0 spec is out after some last minute tweaks
+  - Already some ideas for next rev
+  - Next foci
+      - License classified as None and No Assertion
+          - Needs coordination with the Legal Team, targeting Tech Team
+            meeting on May 26
+      - Snippets
+      - Requirements of other communities
+      - Apache tooling
+  - Recent requests for on line tools
+      - MikeD looking at facilities for running hosted tools on site
+      - Need a java appserver
+
+## Legal Team Report - Jilayne
+
+  - Working on consistency in None and No Assertion language
+  - Post 2.0- A number of issues pushed out waiting for 2.0
+      - Updated priorities page on the Wiki
+      - Starting to get people signed up to drive
+      - Topics
+          - Standard Headers, some issues that have arisen with new
+            expression language approach
+          - “Composite licenses” on list and how to handle
+          - Cadence of versions, targeting quarterly
+
+## Biz Team Report - Jack
+
+  - New version an associated materials up on site
+      - Press release going out today
+      - Blog from Phil and linking to press release
+  - Linuxcon- mid August
+      - Plugfest
+      - 2.0 talk
+  - Could really use examples, best practices
+  - Biz team putting together a straw man for vision for messaging and
+    collateral
+      - Will dedicate a meeting to the discussion
+      - Targeting revamping site to include/revlews before Linux
+
+## Cross Functional Topics - Phil
+
+  - Future Presentations for General Meeting
+      - TI
+      - UNO
+      - Would love to get other companies to share
+          - GitHub? Gary pursuing next week
+          - Samsung, Windriver?
+          - Malcolm Bates, attorney in Barcelona running a local
+            interest group
+          - Possibly record
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, ARM
+  - Mike Dolan, Linux Foundation
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Scott Sterling, Palamida
+  - Gary O’Neill, SourceA
+  - Kate Stewart, Linaro
+  - Hassib Khanafer, Protecode
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-06-04.md
+++ b/general/2015/2015-06-04.md
@@ -1,0 +1,85 @@
+  - Attendance: 13
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of May meeting approved
+
+<!-- end list -->
+
+  - Announcement- Kate Stewart has officially started at the Linux
+    Foundation running compliance programs.
+
+\== Special Presentation - Gary =
+
+  - Kyle Mitchell, a lawyer/developer has equipped to popular package
+    managers to support SPDX
+      - NPM for JavaScript
+      - Ruby Grems for Ruby
+      - Capabilities
+          - Check license for ID package metadata and flag issues
+          - Supporting both SPDX Short IDs and expression language
+          - Checks live current SPDX license list
+          - Similar to UBoot syntax but extended to include expressions
+  - GitHub new mirrors our tools repo hosted by LF
+      - This has started to increase visibility and awareness
+      - Enabled Kyle to contribute to tools
+  - JSON format has been added to the license formats
+      - Not officially supported...yet, but should be
+  - Other community news
+      - Poco projects and Linaro open dataplane now including SPDX short
+        IDs
+      - OpenChain adopted as part of best practices doc
+
+## Tech Team Report - Kate
+
+  - Focus is on snippets
+      - Alternatives have been described and are under discussion
+      - Good time to get involved with Tech Team if you are interested
+        in snippets
+  - Wiki now maintains a list of upcoming topics
+
+## Legal Team Report - Paul
+
+  - License list
+      - Now quarterly releases
+      - end of June, Sept, Dec
+      - June to include an expanded Exceptions List
+  - Joint Tech/Legal Meeting upcoming
+      - None/NoAssertion Discussion
+      - June 16, 9am PDT
+  - Also into discussion of standard headers
+
+## Biz Team Report - Jack
+
+  - Website
+      - Working on Getting Started Pages
+      - Framework established
+      - Seeking volunteers to help flesh out
+  - LinuxCon NA
+      - Gary's paper has been accepted
+      - Jack to secure room for plugfest
+      - Kate/Gary driving plugfest content
+
+## Cross Functional Topics - Phil
+
+  - Future Presentations for General Meeting
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Jilayne Lovejoy, ARM
+  - Mike Dolan, Linux Foundation
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Scott Sterling, Palamida
+  - Gary O’Neill, SourceA
+  - Kate Stewart, Linaro
+  - Michael Herzog, nexB
+  - Paul Madick, HP
+  - Henry Yandell, Apache
+  - Pierre Lapointe, nexB
+  - Scott Lamons, Lamansco
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-07-02.md
+++ b/general/2015/2015-07-02.md
@@ -1,0 +1,98 @@
+  - Attendance: 15
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of May meeting approved
+
+## UNO - Matt Germonprez
+
+  - Tools
+      - DoSOCS - evolved from Yacto tool
+          - Generalized to create ways of generating SPDX docs from
+            various dev processes
+          - Resulted DoSOCS- Ways to scan packages and repos (now
+            source, but in theory binary) to generate SPDX
+              - Main use case is generating SPDX 2.0 docs
+              - Store in a relational database - trick was mapping
+                obj-oriented SPDX to rel database
+              - Very generic. Even on the back end; developed with
+                FOSSology, but could plug in commercial scanners
+              - Future- intake of SPDX
+              - Idea is that this will eventually pull in all tools Git,
+                Yacto, etc
+              - And, can be tied into Jenkins
+              - Ultimately will support an enterprise process to
+                maintain a inventory of SPDX docs that come out of their
+                processes
+          - Also exploring production of security vulnerability info
+              - Looking for where vulnerability info could be stored.
+              - Need a spot for CPE (and other common ID standards)
+              - Which would allow for vulnerability info
+              - Tech team has been pursuing this idea
+              - Group needs to address the mission creep issue
+      - Git Scanner
+          - Analyzes branch and contributes SPDX doc
+      - Eclipse Plug In
+
+## Tech Team Report - Kate & Gary
+
+  - Proposal for wording on Snippets
+      - Up as a Googledoc and available for review
+  - Also one for None/No Assertion
+  - Some discussion of best practices as well
+      - Looking for folks to sign up on the wiki page to write up parts
+  - Kicked of discussion Bake Off and what examples to use
+  - BillS writing up proposal for including external component
+    identifiers (GAV, CPE, others)
+      - General agreement with concept
+  - Tools
+      - Discussion has been going for a couple months about
+        mapping/reconciling various sources of tools (SPDX group, UNO)
+      - Bakeoff at LinuxCon NA (Monday, 8-noon)
+          - Will have 2-3 examples
+              - Candidates are examples on best practices page
+          - Tool providers will provide SPDX docs
+          - Should learn a lot from comparisons
+
+## Legal Team Report - Paul
+
+  - Putting together rev License List (2.1) including exceptions
+      - Lots of new exceptions
+  - Mark Gisi is leading exploration of standard headers
+
+## Biz Team Report - Jack
+
+  - Working on new guidance pages
+      - Phil and Jack have been prototyping
+  - LinuxCon
+      - Back off Monday
+      - Aiming for BoF on Tuesday
+      - SPDX talk from Gary (Tues am)
+      - Mark will be giving a more general talk that will relate to SPDX
+        (Tues pm)
+
+## Cross Functional Topics - Phil
+
+  - Continually looking for presenters for General Meeting
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Mike Dolan, Linux Foundation
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Gary O’Neill, SourceA
+  - Kate Stewart, LF
+  - Hassib Khanafer, Protecode
+  - Paul Maddick, HP
+  - Scott Lamons
+  - Jack Manbeck, TI
+  - Matt Germonprez, UNO
+  - Tom Gurney, UNO
+  - Uday Shankar, UNO
+  - Michael H- nexB
+  - Kirsten Newcomer, Black Duck
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-08-06.md
+++ b/general/2015/2015-08-06.md
@@ -1,0 +1,73 @@
+  - Attendance: 10
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of June meeting approved
+
+## Tech Team Report - Kate & Gary
+
+  - Focus has been on how to add external identifiers
+      - Packages (for which there is no SPDX file)
+      - Security
+  - Planning to get back to snippets in the next month
+  - Folder is up for the [LinuxCon NA bake
+    off](https://drive.google.com/drive/folders/0Bx7GoSv9AWpQfkV6czJ3V041NGpOS2o5VVpPS256R0xSQlpEdnlkejRIczBRZWRfU2NWY0k)
+      - Prep is already generating good feedback and conversation
+      - Please sign up if you're interested in participating: [signup
+        form](https://docs.google.com/forms/d/1gRZe7vymgliCJMrELfJCso8o0WcOpPHZtgTVfO4K8eM/viewform?usp=send_form)
+  - Tooling
+      - Tools should be ready to go for bakeoff
+          - Try out new ‘verify’ command
+          - Bugs can go to the Tools mailing list or get logged in the
+            bug systerm
+      - FOSSology now has a beta release generating SPDX RDF directly
+          - They are looking for testers
+
+## Legal Team Report - Jilayne
+
+  - Activity on Fedora mailing list about using SPDX identifiers
+      - Kate has been responding to straighten out some misunderstanding
+  - Working on standard headers
+      - Mark G keeping up draft
+      - For license that have no prescribed header, discussing whether
+        we will recommend
+  - Jilayne’s talk accepted to LinuxCon Europe
+
+## Biz Team Report - Jack
+
+  - Slow progress on revamp of website
+      - Moving company logos to Participation menu
+      - Adding Adoption section and links
+
+## Cross Functional Topics - Phil
+
+  - Linux Foundation is rebranding Open Compliance Program, which may
+    impact SPDX brand.
+      - Logos may change and trying to tie into new initiatives
+  - LinuxCon Europe
+      - Will likely be more of a focus on Compliance
+      - Adding a Thursday session on Supply Chain / OpenChain (details
+        forthcoming)
+  - Mailing List
+      - Lost admin for mailing lists and wiki
+      - Mailing lists will be handled by team chairs
+      - Still need someone to manage the Wiki; Kate raised hand (once
+        trained).
+  - Always looking for special presentations for the General Meeting
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Gary O’Neill, SourceAuditor
+  - Kate Stewart, Linux Foundation
+  - Jack Manbeck, TI
+  - Michael Herzog, nexB
+  - Pierre LaPointe, nexB
+  - Yev Bronshteyn, Black Duck
+  - Jilayne Lovejoy, ARM
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-09-03.md
+++ b/general/2015/2015-09-03.md
@@ -1,0 +1,110 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of August meeting approved
+
+## Open Compliance Program - Kate
+
+  - Motivations for relaunch:
+      - Information on the web site is stale. (FOSSbazaar community
+        isn't active anymore, etc.)
+      - Recognition we need to make useful information more accessible
+        to developers
+      - The OSS world is changing- cybersecurity for example
+      - FOSSology is coming into LF as a project
+  - What’s happening
+      - New look, new content
+      - Highlighting open standards that help with compliance
+      - Funneling people to projects and workgroups
+      - Highlighting OSS and commercial tools that support SPDX
+          - FOSSology will help with upstream adoption
+          - Hope is to attract developers
+      - Updating educational materials
+          - Currently only targeted at large organizations
+          - Putting the focus on what the developers need to know and
+            will find useful.
+  - Will be rolled out and announced in first part of Q4
+      - New logos and branding for compliance
+      - Target to get SPDX pages lined up to take advantage by start of
+        October.
+      - Current pillar approach will persist, but details under will
+        change/consolidate
+  - New Logo for SPDX
+      - Group preference is for Option 2
+  - Kate is looking for help in identifying companies and products using
+    SPDX and the License List
+      - Please send Kate pointer to any projects you're aware of that
+        consume or produce SPDX
+      - Jack suggested starting with what's on the SPDX page, and
+        building up from there.
+
+<!-- end list -->
+
+  - Would like to get 2.0 spec rendered as a web page
+      - Jack has starting point, Kate volunteers to help clean up
+      - Discussion as to future representations of spec.
+  - LF will help with other aspects of branding now that logo decision
+    made.
+      - Powerpoint templates, etc.
+      - Style guide, fonts, etc?
+  - LC Europe Add on Event
+      - Supply chain mini summit on October 8
+      - Stefano will present on Debsource DB work
+      - Also presenting will be Uday from UNO
+      - Rough agenda and signup sheet will be going up soon
+
+## Tech Team Report - Kate
+
+  - New development over the summer
+      - Debsources DB now generating SPDX. work done as GSOC project by
+        Orestis advised by Stefano Zacchiroli
+      - some discussion about adding sha256 as alternative to sha1 for
+        manditory field.
+  - 2.1 Progress
+      - External package proposal from Yev reviewed and is slated to be
+        included.
+      - External ID proposal has some feedback on Debian Repository
+        aspect which will be discussed on spdx-tech list
+      - Some further work on Security inclusion for 2.1
+      - Snippet work coming back to the fore of active discussions.
+
+## Legal Team Report - Jilayne
+
+  - Some bug reports on template markups
+      - Maintenance is getting burdensome
+      - Triggered discussion about how to set License List up for
+        multiple contributions
+      - Somewhat like an open source project
+      - Active work going on to define how it would work
+  - Other discussions
+      - MarkG working on proposal for handling standard headers
+          - Mark up existing
+          - Concept of suggested header for licenses that don’t have
+            standard
+
+## Biz Team Report - Jack
+
+  - Mostly focused on website changes
+
+## Cross Functional Topics - Phil
+
+  - 
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Kate Stewart, Linux Foundation
+  - Jack Manbeck, TI
+  - Michael Herzog- nexB
+  - Pierre LaPointe, nexB
+  - Yev Bronshteyn, Black Duck
+  - Jilayne Lovejoy, ARM
+  - Hassib Khanafer, Protecode
+  - Matt Germonprez, UNO
+  - Brian Gartner, SuSE
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-10-01.md
+++ b/general/2015/2015-10-01.md
@@ -1,0 +1,65 @@
+  - Attendance: 5
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of August meeting approved
+
+## searchcode presentation - Nuno Brito
+
+  - Background
+      - Has been working with SPDX for two years and it’s been a good
+        experience
+      - Hard to get engineers to use SPDX with out good examples for
+        them to examine
+      - seachdcode seemed to be a good solution
+  - searchcode
+      - Started by a developer in Austrailia
+      - Seemed like a great place to make SPDX available
+  - Questions / Discussions
+      - Interest in having link from SPDX
+      - Files seem to have some extra fields so won’t validate
+          - Nuno is very open and suggests filing bugs
+      - Adoption in Europe
+          - Everyone that Nuno is working with is using SPDX
+          - He’s found little resistance
+          - Some people are more comfortable with tag value, but bigger
+            projects are find with RDF
+          - Still there is some difficulty for adoption.
+
+## Biz Team Report - Jack
+
+  - Website
+      - Working with LF, migrating to new website/new templates
+      - In parallel will be implementing the new ideas for ease of use
+
+## Tech Team Report - Kate/Gary
+
+  - No official update
+  - Main foci have been
+      - External references
+          - Balance between specificity and handling broad cases
+          - Specific discussion of vulnerabilities
+      - Snippets
+
+## Legal Team Report - Jilayne
+
+  - No official update
+  - Have been processing more licenses with an eye to getting next
+    release out
+
+## Cross Functional Topics - Phil
+
+  - LinuxCon Europe
+  - SW Supply Chain Summit
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Mark Gisi, Wind River
+  - Scott Sterling, Palamida
+  - Nuno Brito, TripleCheck
+  - Jack Manbeck, TI
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-11-05.md
+++ b/general/2015/2015-11-05.md
@@ -1,0 +1,109 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Oct meeting approved/
+
+## Siemens - Oliver Fendt
+
+  - Open Source Group
+      - Deals with compliance issues
+      - Made up of members from all parts of the company
+      - Has been going for 2.5 years
+      - Recognized SPDX early in their existence
+          - Took a close look
+          - First interest was in the license list
+              - Requested some license for list; some successful, some
+                not
+              - Participated in discussion about how to handle license
+                exceptions
+      - SPDX 2.0 was coming on line
+          - Voted internally to adopt SPDX
+          - And to start requiring SPDX docs from their suppliers
+      - Got involved with FOSSology
+          - Implemented initial SPDX 2.0 in FOSSology
+              - Just RDF, not yet Tag Value
+      - Became aware of process of development of standard
+          -   - Concerned about the direction, specifically snippet
+                discussion
+              - Concerns that it contradicts vision/mission
+              - Minimizing costs across the supply chain
+              - Concerned that granularity of snippets and that it’s
+                hard to say, unless you are the developer
+              - So, worries about usability
+              - And that it adds interpretation, for example, Black Duck
+                Protex requires the human to interpret
+              - Also, since there is no open source tool that does
+                snippets, adoption may be limited
+        
+          - Would be interested in adding other sorts of information
+            like ECC info
+      - They are currently using the latest/greatest FOSSology and
+        encouraging suppliers to do same
+      - Starting to see projects using SPDX short IDs in files
+      - Suppliers normally don’t deliver source code; Siemens requires
+        that they assert that the comply w/copyrights
+          - So they typically don’t scan source.
+          - They use FOSSo
+          - And they encourage SPDX to supply the info
+
+## Tech Team Report - Kate/Gary
+
+  - Busy refining external identifiers proposal
+      - Aim was a single field
+      - Thought is to break into multiple fields, source of identifier
+        and the domain
+      - Wrestling with the difference between security IDs (NVD/CPE) and
+        repos (e.g. Debian)
+  - Also, recently revisited snippets proposal
+      - Now is a good time to weigh in.
+  - Tools
+      - Active; Sebastian Schubert has been a big contributor recently
+          - Mostly fixes
+          - 2.1 will add some work
+          - UNO repos also very active
+
+## Legal Team Report - Jilayne
+
+  - Cross functional work with tech team on templates and matching
+      - recent joint call, apologies for 10 person limit on call; will
+        address
+      - Looking to change maintenance process
+      - Lots of good discussion about implementing matching guidelines
+      - plan is for another joint call in early December
+
+## Biz Team Report - Jack
+
+  - Working with LF on a new look feel for website
+      - In parallel, changing some of the navigation.
+      - Looks like it’s been delayed, so probably 2-3 weeks before
+        rollout
+      - Some progress already; looking good so far
+  - In process of changing name of team to Outreach Team
+      - Will roll out with new website
+  - Eclipse Foundation
+      - Might be interesting group to speak with about SPDX
+
+## Cross Functional Topics - Phil
+
+  - See Jack’s brief blog on SPDX.org pointing must read blog by Eric
+    Raymond on SPDX
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Oliver Fendt, Siemens
+  - Tarek Jomaa. ARM
+  - Gary O’Neill, SourceAuditor
+  - Jilayne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Richard Christie, ARM
+  - Pierre LaPointe, nexB
+  - Sami Atabani, ARM
+  - Kate Stewart, Linux Foundation
+  - Michael Herzog- nexB
+  - Scott Sterling, Palamida
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2015/2015-12-03.md
+++ b/general/2015/2015-12-03.md
@@ -1,0 +1,77 @@
+  - Attendance: 7
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Nov meeting approved
+
+## Tech Team Report - Gary
+
+  - Only 2 tech meetings due to Thanksgiving
+  - Code Snippets
+      - Candidate proposal in GoogleDocs for Review
+      - Background
+          - A bit controversial due to legit concern that it adds a lot
+            of effort
+          - Identification at the line level requires substantial extra
+            work
+      - So, snippets are optional
+      - Decision driven by important use case- Java script files
+          - As they tend to bundle together a number of downloadable
+            chunks in one file
+      - For many other use cases, it may not be used much
+      - Implementation
+          - Just added snippet level similar to Package and File
+              - Additionally adds byte range
+              - Snippets relate to files analogously to how files relate
+                to packages
+  - External ID discussion is back on the table with snippet work
+    starting to wind down
+  - Tools
+      - A lot of good community contribution
+          - individuals from a variety of organizations- Linux, other
+            open source (eg NPM community), some users (e.g. Black Duck)
+      - Should be releasing a new rev of the SPDX tools in the next few
+        weeks
+      - Question: relation to Stefano’s work with Debian tooling
+        described at LinuxCon Europe
+          - Enabling Debian copyright files to auto-gen SPDX files
+          - Gary will discuss with Kate
+
+## Legal Team Report - Jilayne/Paul
+
+  -   - Went over the list of license and exceptions list
+      - Added 2 or 3 licenses and some exceptions
+      - Entertaining new proposal for mark up format
+          - involved Tech Team as well
+          - needs to be resurrected
+
+## Outreach Team Report - Jack
+
+  - New Website
+      - Work was put on hold by LF for some higher priority work
+      - Should have something staged before the end of the year
+      - Front page will be a big improvement
+      - Early 2016 launch is targeted, but we will need to evaluate with
+  - Working on outreach plan
+      - targeting groups and conferences
+
+## Cross Functional Topics - Phil
+
+  - Always interested in guest speakers for upcoming meetings
+      - Please come to Phil with ideas about organizations who are
+        willing to do short/informal presentations on what they are
+        doing with SPDX
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Gary O’Neill, SourceAuditor
+  - Jack Manbeck, TI
+  - Dave Marr, Qualcomm
+  - Dave McLaughlin, Rogue Wave
+  - Jilayne Lovejoy, ARM
+  - Paul Madick, Dimension Data
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-01-07.md
+++ b/general/2016/2016-01-07.md
@@ -1,0 +1,74 @@
+  - Attendance: 9
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Dec meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Good progress on spec
+      - Settled on approaches for both
+          - Snippets
+          - External References
+      - Jilayne assured consistency None/Assertion
+  - Now working on
+      - Making sure that external identifiers support security
+  - Joint call upcoming with Legal Team on template language
+      - Have pushed a couple of issues/ to Legal Team
+  - Re-examining native from of spec under dev
+      - Notion is to make it better accessible in Git Hub
+      - Plan for full walk through at Collab Summit
+  - Tools
+      - Did maintenance release over the last week or so
+      - Addressed reported bugs
+      - Some other bug fixes
+      - Gary will go back to the bug reporter to see if they might speak
+        at a future General Meeting.
+
+## Outreach Team Report - Phil (Jack supplied notes in absentia)
+
+  - Haven’t had our first meeting of the year, that will be next week.
+  - I also haven’t heard from the LF yet on the new website. Im going to
+    ping them this week to see where they are.
+      - Talked to Craig.
+          - Working on some technical issues with generated license list
+          - Next week we should be able to review and update
+  - Were still hammering out an outreach plan on the wiki. Id like to to
+    be done with it by the end of January and then we can share plans.
+
+## Legal Team Report - Jilayne
+
+  - License List 2.3 is now live
+      - 3 new licenses
+      - 1 new exception
+      - Now starting to see markup on some of the headers; rest are in
+        process
+  - Call today
+      - Continuing to look at markup
+          - Form
+          - Maintenance Process
+
+## Cross Functional Topics - Phil
+
+  - Save the date for Collab Summit in Lake Tahoe- March 29-31
+      - Will be meeting
+      - <http://events.linuxfoundation.org/events/collaboration-summit/program/about>
+      - Call for Papers is out- Best practices would be great
+  - Lined up speakers for next 1-2 meetings
+      - Still looking for more- easy, little prep required, low-key
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Gary O’Neill, SourceAuditor
+  - Scott Sterling, Palamida
+  - Yev Bronshteyn, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Pierre LaPointe, nexB
+  - Jilayne Lovejoy, ARM
+  - Kirsten Newcomer, Black Duck
+  - Mark Gisi, Wind River
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-02-04.md
+++ b/general/2016/2016-02-04.md
@@ -1,0 +1,172 @@
+  - Attendance: 11
+  - Lead by Kirsten Newcomer
+
+<!-- end list -->
+
+  - Minutes of previous meeting were not reviewed
+
+## Special Presentation - Jack Manbeck
+
+  - Jack spoke about Texas Instrument’s (TI) process for generating and
+    content of the manifest (attribution) file. Below are my notes from
+    the presentation. Jack, please send corrections as needed\!\!
+
+<!-- end list -->
+
+  - Jack shared an example file in HTML format. There is a section for
+    licenses and TI is considering replacing this section with an SPDX
+    document showing file-level data.
+
+<!-- end list -->
+
+  - TI considered using the yocto integration to generate SPDX files,
+    but the output was too big. They decided to scale back and start
+    with the project and a more narrow scope.
+
+<!-- end list -->
+
+  - The goal is for any engineer to be able to generate an SPDX
+    document. Which means tooling that is easy to use and integrated
+    with multiple build tools and / or CI tools. It also needs to run on
+    multiple platforms.
+
+<!-- end list -->
+
+  - There are a series of steps in the TI process
+      - Grab OSS and evaluate for use. It doesn’t make sense to generate
+        SPDX at this time although you need some of that info to
+        evaluate the open source. But things that SPDX requires change
+        too quickly, such as location of the file, checksum (bug fixes
+        to file).
+      - So, it makes more sense to generate the SPDX file when you’re
+        ready to ship
+      - Then you have to edit the doc; it’s not usable as is, in part
+        due to incomplete copyright strings, or possibly extracted
+        license text
+      - If files need to be edited, or the code needs to be re-built,
+        the SPDX file needs to be re-generated and then re-edited. So, a
+        tool that retains and re-applies previous edits that still apply
+        is very much needed.
+      - Would like to share / re-use generated SPDX docs, but the best
+        way to share isn’t clear.
+      - TI is looking at SPDX 2.0 and considering whether relationships
+        between generated SPDX docs can help
+      - Don’t want to have to use multiple tools for compliance and SPDX
+      - Consider SPDX to be a good supplement to their manifest file but
+        doesn’t replace it.
+      - They still need to vet the process and polish
+      - Jack mentioned a copyright snippet example where the output was
+        not good enough. They’re evaluating different tools to use. They
+        like the SPDX tools from UNO.
+      - They’d like, in some cases, to provide file by file list which
+        could be done through a link to SPDX doc.
+      - They’re looking at Fossology and SPDX plugin. Also mentioned
+        that it would be nice to get an idea of license spread at the
+        beginning.
+
+<!-- end list -->
+
+  - Matt mentioned additional tools built by UNO, including DoSocks
+    (spelling?) and Gary’s maven plugin which generates SPDX docs based
+    on maven POM content.
+
+<!-- end list -->
+
+  - Kate mentioned Fossology 3.0 and Deb sources as well as FOSDEM and
+    notion of a shared database of SPDX documents.
+
+<!-- end list -->
+
+  - Matt said that the UNO tools don’t store SPDX docs but instead store
+    the data so the docs can be generated when required. Jack sees this
+    as the right approach.
+
+<!-- end list -->
+
+  - TI’s plan is to first build a repeatable process and then they can
+    do more to enhance it. The checksum in SPDX documents is a challenge
+    because files change right up to the last minute.
+
+<!-- end list -->
+
+  - Dave Marr commented that the model he’s interested in is having SPDX
+    perpetuate through a development cycle with minimum impact on the
+    team. Would like to be able to check code in with meta-data so that
+    the meta-data travels with the file.
+
+<!-- end list -->
+
+  - Gary said that he’s seen this approach both work and not work. Tried
+    an integration with IDEs but there was too much change for it to
+    work. Says the Maven plugin seems to be pretty effective in
+    maintaining the meta-data and the integration recalculates the
+    checksum. Solution does assume that the data in the POM is correct.
+    POMs are stored in the repository and the SPDX is generated at build
+    time. Developers are used to editing POM files.
+
+<!-- end list -->
+
+  - Jack commented that in a structured environment that works, but TI
+    needs a solution that works across multiple environments.
+
+<!-- end list -->
+
+  - Dave commented that training for engineering is needed — when you
+    add or subtract content, here’s what you need to do.
+
+<!-- end list -->
+
+  - Jilayne would like engineering training for lawyers, with graphs,
+    not just text.
+
+<!-- end list -->
+
+  - Everyone thought this would be a good overall topic for Collab
+    Summit.
+
+## Tech Team Report - Kate/Gary
+
+  - Team is continuing discussions on External References. The work is
+    close to being ready for a broader review.
+  - Joint tech / legal call on license markup planned for 2/9.
+  - Discussions happening with Richard Fontana at OSI
+
+## Outreach Team Report - Jack/Kate
+
+  - Planning for Collab Summit: 1/2 day Tech team and 1/2 day Legal,
+    with SPDX “Office Hours” for folks to bring questions, issues.
+  - Good mentions of SPDX @ FOSDEM
+  - LF says new website is close to being staged for review; Jack hopes
+    it will be up for Collab Summit
+  - Planning webinars in first quarter. Pierre has volunteered and the
+    first will be on the license list.
+
+## Legal Team Report - Jilayne/Paul
+
+  - Working on proposal for license matching
+  - Working on tighter communication with OSI
+
+## Cross Functional Topics - Kate
+
+  - Save the date for Collab Summit in Lake Tahoe- March 29-31
+      - <http://events.linuxfoundation.org/events/collaboration-summit/program/about>
+  - Google Summer of Code: Gary will be coordinating for the SPDX team.
+    We’re looking for ideas for good projects.
+
+## Attendees
+
+  - Kirsten Newcomer, Black Duck
+  - Gary O’Neall, SourceAuditor
+  - Scott Sterling, Palamida
+  - Kate Stewart, Linux Foundation
+  - Pierre LaPointe, nexB
+  - Jilayne Lovejoy, ARM
+  - Kirsten Newcomer, Black Duck
+  - Jack Manbeck, TI
+  - Dave Marr, Qualcomm
+  - Eric Weddington
+  - Hassib Khanafer, Protecode
+  - Matt Germonprez, UNO
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-03-05.md
+++ b/general/2016/2016-03-05.md
@@ -1,0 +1,105 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of Feb meeting approved
+
+## Special Guest Star - Camille Moulin, Inno3
+
+  - SPDX license list and expressions
+      - Most dependency management solutions include licensing info
+          - So you can extract and process the information
+          - Most clients aren’t using this approach, rather they use
+            scanners like Black Duck, Palamida, Protecode
+      - The dependency manager approach
+          - This approach is not as accurate as code scanners
+          - No information at the sub level package
+          - Depends on quality metadata
+      - Metadata quality
+          - 30% of all packages have no license data
+      - SPDX Maturity
+          - Still a young project
+          - License expressions were a key addition
+          - Need to be clear on license version numbers
+          - SPDX is already adopted by most package manager,
+            particularly newer ones
+          - Some useful tools are available
+      - Q\&A
+          - What improvements in SPDX are required?
+              - He suggest separating License name from version number
+                as separate attributes
+
+## Tech Team Report - Kate/Gary
+
+  - Specification Update:
+      - meetings over last month spent continuing to refine the External
+        Reference proposal from Bill and Yev.
+      - Its been refactored a couple of couple of time, and active
+        discussion is ongoing.
+      - Introduced Draft version of Appendix on how to specify
+        "SPDX-License-Expression:" in file comments.
+      - Summarized information on WIKI and input received from mail
+        list. Team wants to make sure wording
+      - at top makes it clear that if a license has a standard header,
+        that header should be used.
+  - Tools Update:
+      - None this month
+
+## Outreach Team Report - Jack
+
+  - Website
+      - Still waiting on LF to update
+  - Webinars
+      - Just starting a regular series of Webinars
+      - Jilayne was “volunteered” talk about the license list as the
+        initial one
+      - Talking to LF about hosting
+
+## Legal Team Report - Jilayne
+
+  - Big Update: Templates Rehab
+      - Have reviewed guidelines and mark-up method and implementation
+          - Guidelines were human-friendly, not machine
+          - Fairly major overhaul back end
+          - Much better handling of single source than was possible with
+            spreadsheet
+      - Better for machines
+      - Enabling others to contribute
+      - Easier to maintain
+  - OSI
+      - Have synced up our new license process
+      - Our heads up had been coming late, after their URLs were set up
+      - Now we can pick short ID first
+
+## Cross Functional Topics - Phil
+
+  - Collab meeting: Walk through of the 2.1 SPEC changes in a combined
+    document.
+      - All Day Wednesday
+      - Thursday
+          - Morning OpenChain- Trying to wrap up specification effort
+          - Afternoon- FOSSology- Working through what’s working/what’s
+            not and infrastructure
+      - <http://events.linuxfoundation.org/events/collaboration-summit/program/about>
+  - Google SoC
+      - SPDX along was not accepted
+      - LF was, so we may be able to piggyback
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Yev Bronshteyn, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Pierre LaPointe, nexB
+  - Jilayne Lovejoy, ARM
+  - Kirsten Newcomer, Black Duck
+  - Mark Gisi, Wind River
+  - Michael Herzog- nexB
+  - Dave Marr, Qualcomm
+  - Jack Manbeck, TI
+  - Camille Moulin, Inno3
+  - Scott Sterling, Palamida
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-04-07.md
+++ b/general/2016/2016-04-07.md
@@ -1,0 +1,122 @@
+  - Attendance: 14
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - Minutes of March meeting approved
+
+## Special Guest Star - Kris Reeves
+
+  - Background
+      - Working with the team over the past few months
+      - Focused on improving templates and matching process
+      - Has been building tools for his NodeJS environment to discover
+        licenses to meet client needs
+      - Created a tool that makes a binary decision about whether there
+        are any problematic licenses, yes or no
+      - Wasn’t working well initially because of “naive” approach in the
+        package he was using Node License Finder
+      - Found 3 packages that were trying to do this
+          - Node Packet Manager used SPDX short names
+          - Which got Kris onto SPDX
+          - Tool was not using matching guidelines properly
+      - So Kris got onto trying to trying to fix
+  - SPDX Work
+      - Felt there needed to be some changes
+      - Started submitted bug reports
+      - Conclusion:
+          - The templates were the right place to address issues he was
+            running into
+          - Developed tool in parallel to working on:
+              - More Mark Up
+                  - A big jump
+                  - XML files that contain all info about a license
+                  - Obsoleting spreadsheet
+              - Better Mark Up
+                  - XML is familiar and available
+                  - Self-contained
+                  - Better to have the matching info in the data for
+                    tool consistency
+              - Easier Contribution
+                  - Separate GIt repo, bugzilla, etc system make
+                    contribution awkward
+                  - Feels GitHub web interface streamlines all that, so
+                    advocating we migrate in that direction
+          - Ideally all this reduces workload on Jilayne
+          - Status
+              - Has taken passes at converting licenses and submitted
+                pull request
+              - Still some issues he’ll work on this weekend.
+              - Getting very close
+
+## Tech Team Report - Kate/Gary
+
+  - Specification Update:
+      - Good Collab Summit
+          - Office hours talk kicked off with some good brainstorming on
+            aggregating SPDX docs
+              - Package referring to other packages and best ways to
+                refer to and store relationships
+          - Gary and Kris’ prevention was well received.
+          - Spec review went very well
+              - Bill and Yev are looking at adding some new classes
+              - Helpful input from Robin Gandi
+          - Looking for wider feedback in May and new release in June.
+              - Possible August plug fest
+          - FOSSology team did a talk that included SPDX
+  - This week’s call
+      - Addressed all open items from Collab Summit
+  - Tools Update:
+      - Bracing for spec to be finished to update tools
+      - Kris has contributed some great tooling as well
+
+## Outreach Team Report - Jack
+
+  - Website
+      - New site is now staged
+      - Reviewed at Collab Summit
+          - Some limitations we will need to work around
+          - Navigation really needs sorting out
+      - Still hoping for April launch
+  - Webinars
+      - Met with LF Marketing Team
+      - Will help us with a webinar as a trial
+      - Jack creating one pager to advertise
+      - Suggested piggy backing on a new initiative being launched in
+        July- Professional Open Source
+
+## Legal Team Report - Jilayne/Paul
+
+  - License list v2.4 is up
+  - Lots of work on new format that Kris talked about
+      - Legal team needs to review how the output looks
+      - And to take another pass at the licenses
+  - Special legal team meeting today immediately following
+
+## Cross Functional Topics - Phil
+
+  - Google SoC
+      - We are on the list of LF projects
+      - No requests yet, but expecting some
+  - Still looking for special guest stars to speak at General Meetings
+      - Jilayne has an idea for July.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Pierre LaPointe, nexB
+  - Jilayne Lovejoy, ARM
+  - Mark Gisi, Wind River
+  - Michael Herzog- nexB
+  - Dave Marr, Qualcomm
+  - Jack Manbeck, TI
+  - Kris Reeves
+  - Scott Sterling, Palamida
+  - Josiah Krutz, UNO
+  - Matt Germonprez, UNO
+  - Gary O’Neill, SourceAuditor
+  - Paul Madick, Dimension Data
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-05-05.md
+++ b/general/2016/2016-05-05.md
@@ -1,0 +1,65 @@
+  - Attendance: 9
+  - Lead by Phil Odence
+  - Minutes of April meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - Getting to final stages
+      - Collab Summit issues have been addressed
+      - People working on the spec have reviewed
+      - Then will go out for broader review in a couple weeks
+      - Transitioning documentation to Git
+  - 2.1 Tools
+      - Tool dev is finding some inconsistencies in tool
+          - e.g. No license, no assertion
+
+## Outreach Team Report - Jack
+
+  - Website
+      - Still trying to finish off
+      - Important call today
+
+## Legal Team Report - Jilayne/Paul
+
+  - Special Call today
+      - Working on XML files today
+      - What review will look like
+      - So work can be easily divided
+  - License review tasks at hand-
+      - 300 license need review (no more than 30 person-hours)
+      - This is a rough look to make sure machine conversion hasn’t made
+        obvious mistakes
+      - Hoping to have done for next release of license list, end of Jun
+      - Will make the call early in June.
+  - Regular business of Legal Team
+      - Some normal license approvals
+      - Issue of Public Domain re-raised and discussed
+          - Back burnered for future discussion
+          - May involve a standard govt header
+
+## Cross Functional Topics - Phil
+
+  - Google SoC
+      - Will not participate this year
+  - Uber Conf
+      - Need to find how our account was originally created
+      - Kate building new one
+  - Guest stars
+      - Sam Ellis, Dave Marr, one more in pipeline
+  - OSI Meeting
+      - 
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Scott Sterling, Palamida
+  - Gary O’Neill, SourceAuditor
+  - Paul Madick, Dimension Data
+  - Robin Gandhi, UNO
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-06-02.md
+++ b/general/2016/2016-06-02.md
@@ -1,0 +1,110 @@
+  - Attendance: 14
+  - Lead by Phil Odence
+  - Minutes of May meeting approved
+
+## Special Guest - Dave Marr, Qualcomm
+
+  - SPDX is a critical piece of getting well and getting good at
+    managing open source
+  - Open source overall
+      - Requires cross functional participation
+      - Some very intellectual interesting aspects
+      - Management
+          - really requires a lot of uninteresting, rote work
+          - Necessary to get it right
+      - Opportunity for automation
+          - Requires standard practices
+              - Open Chain
+              - SPDX
+              - SIPOC model (https://en.wikipedia.org/wiki/SIPOC)
+          - Customer focus required
+              - Focus on internal customers too, requires mindset shift
+              - Delivering code with compliance problems is like
+                delivering bad code
+              - Qualcomm engineers all take Dave’s training
+                  - The more specific instructions the better
+          - SPDX connection
+              - Information must be in a factorable form
+              - Standardization is key
+          - Process required to yield the output
+              - That’s the hard part
+              - Can’t have drag on engineering processes
+              - So need automation and “plumbing”
+          - Direction
+              - Aiming for seamlessness
+              - Suppliers need to be brought into this
+              - If everyone provides SPDX, there’s still the need to
+                efficiently consume and manage through the dev process
+              - Solution needs to handle version control and compilation
+              - The dream is a way to move the SPDX files along with the
+                code and to handle refactoring to the ultimately the
+                SPDX files for products the ship are available and
+                largely accurate.
+          - How to get there?
+              - Tricky to improve the plane while still flying
+          - Does annotation in SPDX help?
+              - So far they struggle with achieving behavioral change in
+                engineering
+              - Works best when product managers drive
+              - Annotations are good for simple use case
+          - Looking at hooks into version control systems?
+              - Yes, and this might be the ultimate approach
+              - At least part of the solution
+              - One source of truth is required -- and as contained
+                within the version control system
+
+## Tech Team Report - Kate
+
+  - Spec
+      - 2.1 very close to getting pushed out
+          - two appendices need a little work, but that’s it
+          - Kate can provide link to review for everyone
+          - Somewhat waiting for Gary’s return from vaca
+      - Live on the new website
+  - Tools
+      - Starting to update for 2.1
+
+## Outreach Team Report - Jack
+
+  - Website
+      - Still working it through
+      - Lots to talk about in team call today
+      - Still a few functional issues, need to resolve with LF folks
+
+## Legal Team Report - Paul
+
+  - Primary focus getting all the licenses into GitHub
+      -   - for maintenance
+          - and more future utility
+    
+      - all license have been converted
+        
+          - going thru manually
+  - New licenses
+      - knocking them down as they come in
+      - little backlog at this point
+
+## Cross Functional Topics - Phil
+
+  - Guest stars
+      - Sam Ellis, Dave Marr, one more in pipeline
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Scott Sterling, Palamida
+  - Paul Madick, Dimension Data
+  - Robin Gandhi, UNO
+  - Alexios Zavras, Intel
+  - Pierre LaPointe, nexB
+  - Michael Herzog- nexB
+  - Mike Dolan, Linux Foundation
+  - Matt Germonprez, UNO
+  - Yev Bronshteyn, Black Duck
+  - Matija Suklje, FSFE
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-07-07.md
+++ b/general/2016/2016-07-07.md
@@ -1,0 +1,116 @@
+  - Attendance: 13
+  - Lead by Phil Odence
+  - Minutes of June meeting approved
+
+## Special Guest - Sam Ellis, ARM
+
+  - Sam works in ARM’s Cambridge HQ
+      - SW Engineer/Mgr
+      - No legal training
+      - Has gotten involved just as part as his job
+      - Now acts as bridge between dev and legal teams
+  - They use a license scanning tool
+      - That’s the implementation of SPDX
+      - Keen on the license list for name consistency
+      - And using SPDX basis of repository of data about open source in
+        products
+  - Dev process
+      - Similar to most
+      - Are careful to separate out open source archive
+          - Basis of license scanning
+          - Develop an SPDX tag format report for each product
+  - Legal Approval Process
+      - They use a custom tool internally
+      - When open source comes into the company, they assess risk
+      - Recently put a new system in place
+          - Asks the type of questions that SPDX captures
+              - Package name, licenses, copyright notices, where
+                downloaded, etc.
+          - Goal is to to eventually import/export SPDX for this
+            purposes
+      - Tracks OSS use cases
+  - Two systems using
+      - Approval process
+      - Data from the build
+      - Will eventually try to compare to ensure sync
+          - Can be hard to maintain, particularly when removing stuff.
+  - Sam’s projects use and exceptionally large amount of OSS
+      - Need to explain to customers
+      - Ideally would like to auto-gen the list of licenses they publish
+          - Practical Problem: They don’t want to declare all
+              - For example, disjunctive license, may only want declare
+                one
+  - Would like to ship SPDX
+      - Need to work out how much to declare
+      - They get a lot of queries
+          - Concern is does providing more info, generate more queries
+      - \* Certainly they feel that SPDX is the right format
+  - Observations
+      - Tag file is large - 130 MB for one product
+          - Too large to ship, but could include on website
+          - Too much info to be comprehensible
+      - People who need to use, don’t have the tools
+          - Need something that can open and filter/summarize
+  - Learning
+      - In the past have developed one big SPDX file
+      - Probably a mistake, should have broken it down
+  - Discussion
+      - Tooling- perhaps the convertor to spreadsheet
+      - Supply chain partners are really interested in use cases, not
+        just what’s in product
+      - Any sharing SPDX docs within company yet? - No, not yet.
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - 2.1 draft is out for review
+          - open until the end of the month
+          - assuming no show stoppers, that should be it
+  - Tooling
+      - Started updating for 2.1 last week
+      - External references implementation taking more time than
+        anticipated
+      - Tooling first pass should be ready with 2.1 release timeframe
+      - Gary is keen for feedback on our tools and any issues in
+        implementing other tools
+
+## Outreach Team Report - Jack
+
+  - Website
+      - Very close to wrapping up
+      - Looking at final review next week
+
+## Legal Team Report - Jilayne
+
+  - XML templates
+      - Review continuing
+      - Call today will checkpoint where we are and remaining work
+  - 2.5 list release
+      - Should be live in the next day or two
+      - Not too many new licenses
+
+## Cross Functional Topics - Phil
+
+  - Guest stars
+      - Always looking for more
+  - LinuxCon
+      - Looks light nothing official
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Scott Sterling, Palamida
+  - Robin Gandhi, UNO
+  - Jack Manbeck, TI
+  - Yev Bronshteyn, Black Duck
+  - Gary O’Neill, SourceAuditor
+  - Mark Gisi, Wind River
+  - Dave Marr, Qualcomm
+  - Matt Germonprez, UNO
+  - Michael Herzog- nexB
+  - Sam Ellis, ARM
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-08-04.md
+++ b/general/2016/2016-08-04.md
@@ -1,0 +1,135 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+  - Minutes of July meeting approved
+
+## Special Guest - Alexios Zavras, Intel
+
+  - His role is open source compliance at Intel, based in Munich
+      - Now at open source tech center
+      - Will be talking about his previous role with Intel Mobile Comms
+  - Mobile Comms
+      - Based in Germany
+      - Germans are very process-oriented, well-documented
+  - His role was SW legal compliance.
+      - Ensuring all software legally compliant across all kinds of
+        software
+      - They treat all compliance issues as a bug, just like any problem
+        in the software
+      - Alexis learned of SPDX and was very pleased and excited about it
+          - Didn’t manage to get everything SPDX based
+          - Started slowly
+          - SPDX is very valuable at many levels
+              - Even just the license list and standard way of
+                expressing was very helpful
+              - Quickly standardized on SPDX notations and it started
+                appearing in their documentation etc
+          - Included in training that was mandatory for SW devs and
+            later extended to marketing, legal, biz dev
+              - Everyone who touches software had to take on-line course
+                with a deeper course available for some
+          - Have developed number of tools, tightly coupled with dev
+            environment
+              - All developed internally
+              - very tightly controlled, eg can’t check out code without
+                a ticket
+              - Tool chain includes license compliance
+          - Central team provides compliance services to dev
+              - too much for all devs to worry about
+              - Fits with org structure
+              - Internal teams reviews all code
+          - Started small, then more widespread and more automated
+              - Today every release goes though this license compliance
+                check
+              - Requires ‘stamp of approval’ from central team
+          - To make the central team more efficient
+              - Save all results
+              - Including many of the SPDX fields
+              - Saved in database
+          - Last step, not yet taken, is to generate an SPDX doc for
+            each release
+              - Just held up by organizational issues, technically
+                feasible
+              - Being worked on
+              - Have started getting the request from customers
+                  - Not mentioning SPDX by name, have not seen that yet,
+                  - but asking for data that SPDX covers, files,
+                    license, etc
+                  - (both are with Euro customers)
+          - When they generate SPDX
+              - Permissive license require attribution
+              - They’ve had an issue with that going back 5 years
+              - Their policy to handle is to deliver all OSS in source
+                form
+              - So, therefore include attribution in comments
+              - They include a list of open source and model licenses,
+                but the attribution is all in source code
+          - Example- Modem company
+              - Intel provides chips and software in binary form
+              - Packaging: With binary they include
+                  - all source for open source in binary
+                  - And, list of conditions for any 3td party
+                    proprietary code
+          - Are they being asked for security vulnerabilities associated
+            with components
+              - Not yet, but they are thinking about it with respect to
+                naming (CPEs, etc)
+  - AZ- “Thanks for the wonderful work. It’s really helpful.”
+
+## Tech Team Report - Kate
+
+  - Spec
+      - Collecting feedback
+      - Addressing as it comes it
+  - Gary has taken a pass at updating tools
+  - In the polishing stage
+      - One more round of feedback
+      - Into publishing mode as of Tuesday
+  - Bake Offs
+      - Possible SF 9/27 and Europe at LCon
+      - Needs to be nailed down in the next couple week.
+
+## Outreach Team Report - Jack
+
+  - Website
+      - Still working this week
+      - Will review at next week’s meeting
+      - Should be close with go live; shooting for Linux Con NA
+      - Still looking for some improvements that will require work from
+        the Linux Foundation team
+          - No show stoppers
+      - Will send out link for review
+
+## Legal Team Report - Jilayne
+
+  - XML review
+      - Still plugging away
+      - Timeline set
+  - 2.5 release
+      - Just a few licenses
+      - Aiming for end of Oct
+      - See Legal Team meeting mins for detail
+      - Could use all the help they can get; lots to do
+          - To review new XML master format for every license
+
+## Cross Functional Topics - Phil
+
+  - Guest stars
+      - Always looking for more
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Alexios Zavras, Intel
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Scott Sterling, Palamida
+  - Robin Gandhi, UNO
+  - Jack Manbeck, TI
+  - Yev Bronshteyn, Black Duck
+  - Matt Germonprez, UNO
+  - Michael Herzog- nexB
+  - Georg Link, UNO
+  - Mike Dolan, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-09-01.md
+++ b/general/2016/2016-09-01.md
@@ -1,0 +1,59 @@
+  - Attendance: 6
+  - Lead by Gary O'Neall
+  - Minutes of August meeting approved
+
+## Tech Team Report - Kate
+
+  - SPDX 2.1 all comment incorporated
+  - PDF should be available today
+  - Will follow-on with HTML later
+  - 1 1/2 month feedback cycle
+  - Tech office hours - should publish to general
+  - There will be a tools bake-off in Berlin on 6 Oct
+      - All tools providers are encouraged to attend or send in SPDX
+        documents
+  - There will not be a west coast bake-off - the West Coast tools
+    providers are encouraged to submit SPDX documents to the Berlin
+    bake-off
+
+## Outreach Team Report - Jack
+
+  - Getting reading to go live with the new site
+  - Jack is working with the Linux Foundation to schedule a go-live date
+  - All updates to the new site have been completed
+
+## Legal Team Report - Jilayne
+
+  - Going through the XML conversion of the license list
+  - Action items for closing on the XML conversion is published
+  - Decided to do the next license list update around the end of Oct.
+    which will use the new XML file format
+
+## Cross Functional Topics - Gary
+
+  - Discussion on whether the new XML license master list format is
+    intended for external tools or to be used internal only to the Legal
+    Team in producing the license list
+      - Gary recalled a discussion where we decided the first release of
+        the XML format would be internal only
+      - Consensus that one of the overall goal of the XML format is to
+        enable better tooling - the issue is only related to the phasing
+        of the XML format implementation
+      - Some of the issues to external tool use would be the
+        inconsistency in the element and property names with the SPDX
+        specification
+      - Request that the technical team be involved if the XML format is
+        to be used externally
+      - Will be discussed on the legal call
+
+## Attendees
+
+  - Gary O'Neall
+  - Kate Stewart
+  - Jilayne Lovejoy
+  - Michael Stair
+  - Scott Sterling
+  - Paul Madick
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-11-03.md
+++ b/general/2016/2016-11-03.md
@@ -1,0 +1,126 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+  - Minutes of Sept meeting approved (Oct meeting was cancelled due to
+    LinuxCon Europe)
+
+## Special Guest - Lei Mao Hui, Fujitsu
+
+  - Lei
+      - Working for Fujitu
+      - Developing on house Distro
+      - Spoke at ALS and Linux Conference about experience with SPDXX
+
+<!-- end list -->
+
+  - Reason Fujitsu needs SPDX
+      - Want an SPDX file for all their packages
+      - Customers ofter require license info
+      - Released under GPL3, but includes software under other license
+        as well. Many\!
+          - MIT, BSD, GPL2, etc.
+      - SPDX is good for this purpose
+      - So they added into production Development
+
+<!-- end list -->
+
+  - Yocto SPDX
+      - Lucky for them that Yocto supports SPDX
+      - But the activity on Yocto SPDX has been slow
+      - Found some issues when using
+          - Only supports SPDX 1.1
+          - Doesn’t do a great job even with that
+          - Is complex to use; takes a long time
+          - May introduce license conflicts
+      - In the end you can download the SPDX
+
+<!-- end list -->
+
+  - Fujitsu’s contributions to Yocto SPDX
+      - So they did some work to improve:
+          - Created a patch to upgrade to SPDX 1.2
+              - Unfortunately was never accepted into Yocto
+      - Would like to upgrade to SPDX 2.0
+      - And to improve performance
+      - Has been working on some of the SPDX open source tools
+          - including DoSocks developed by UNO
+      - Lei has been continuing to submit improvements to Yocto
+          - Improved performance
+      - Currently discussing more improvements with Yocto
+      - Will be continuing to improve and to upgrade to SPDX 2.1
+
+<!-- end list -->
+
+  - Question
+      - Has yocto been receptive?
+          - Yocto has not been active or focused on SPDX.
+          - Some people have been interested
+          - Not sure why they are not interested
+      - Kate will help and follow up
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - SPDX 2.1 is now released and official
+          - Starting to focus on use cases and tooling
+          - last call was a joint call with the Legal Team
+              - Templetazation focus
+              - Agreed on interfaces between teams
+  - Tooling
+      - Incorporated results from the bake off
+          - Overall, everyone at the bake off got good feedback, leading
+            to improvement of all tools
+      - XML Format
+          - Legal Team has been working on new format for license
+            templates
+          - Makes it easier for multiple contributors
+          - Working now on making it consumable for external tools
+          - Really good progress
+              - Should have draft standards in the next month or two.
+
+## Legal Team Report - Jilayne/Paul
+
+  - Joint Call with Tech Team
+      - Worked on syncing tag names to be consistent with spec
+      - Went really well
+  - License List
+      - Business as usual with new licenses
+      - More license requests for licenses in other languages
+      - Probably need to have a discussion about how to handle
+        consistently
+
+## Outreach Team Report - Jack
+
+  - Website
+      - New site is up
+      - Jack’s in process of posting new stuff
+  - Next agenda
+      - Working on new docs, templates, etc
+          - Mostly to help explain aspects of how to use
+          - Trying to assemble list of topics and then prioritize
+          - Very open to ideas
+
+## Cross Functional Topics - Phil
+
+  - Future topic - Will be a discussion of license in different
+    languages
+      - Legal Team will come forward with a strawman. A few months out.
+  - Guest stars
+      - Always looking for more
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Lei Mao Hui, Fujitsu
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Yev Bronshteyn, Black Duck
+  - Scott Sterling, Palamida
+  - Paul Madick, Dimension Data
+  - Gary O’Neill, SourceAuditor
+  - Tarek Jomaa, ARM
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Alexios Zavras, Intel
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2016/2016-12-01.md
+++ b/general/2016/2016-12-01.md
@@ -1,0 +1,82 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+  - Minutes of Nov meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - Has been focusing on coding up best practices for creating a
+        Notices file
+          - Will need some input from the Legal Team, probably a joint
+            meeting
+          - Output will be pseudo-code which could be the basis for a
+            tools (basis is sparkle queries)
+      - 2.1 is out there; no current bugs reported
+          - Kate gave a presentation on 2.1 in Yokahama; will get to
+            Jack for posting on website
+  - Tooling
+      - All upgraded to 2.1
+      - No bugs reported
+      - Python library being upgraded
+          - Useful for implementing SPDX in a Python-based sw tool
+  - 2017 Goals Brainstorm
+      - Tooling to make quality of licensing more visible
+          - Mark G started this work
+          - The idea is to grade a project, based on SPDX file, for how
+            complete the licensing is
+  - Looking to get plug-ins adopted into communities
+      - Apache and Eclipse
+  - Web based tools
+      - Current java tools involve installing java environment
+      - e.g. Past a license into a webpage and have it matched to an
+        SPDX template
+  - Discuss pros/cons of moving to single format
+      - JSON- Happy medium between tag value and RDF
+  - Write a git plug-in for generating SPDX docs
+      - Could then grade
+  - Another Google Summer of Code Project
+
+## Legal Team Report - Jilayne/Paul
+
+  - How to leverage git hub for document maintenance
+  - xml work
+      - Still plugging away
+      - Need to assess where we are in Thursday’s call
+  - License list
+      - No Sept release
+      - Some requests have trickled in
+  - 2017 Goals Brainstorm
+      - Big thing is getting the XML templates up
+      - Getting up and running on GitHub
+      - Make sure notice files work is accurate
+      - Upgrading the license expressions language
+      - Supportive of license match Web App
+
+## Outreach Team Report - Jack
+
+  - A few meetings have been missed
+  - Website is up
+  - Outlining documentation needs
+  - 2017 Goals Brainstorm
+      - Do a survey of companies using supply chains - understand what
+        they are doing wrt gathering license data
+          - Could use other existing groups such as Open Chain
+
+## Cross Functional Topics - Phil
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Paul Madick, Dimension Data
+  - Gary O’Neill, SourceAuditor
+  - Tarek Jamal, ARM
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Alexios Zavras, Intel
+  - Michael Herzog- nexB
+  - Philippe Ombrédanne- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-01-05.md
+++ b/general/2017/2017-01-05.md
@@ -1,0 +1,99 @@
+  - Attendance: 14
+  - Lead by Phil Odence
+  - Minutes of Dec meeting approved
+
+## Special Presentation- Georgia (Zeta) Kapitsaki
+
+  - Goals of work
+      - Automate license specification and selection
+      - Helping smaller companies and independent developers
+      - Helping with combining licenses
+          - Created a graph of compatibility for this purpose
+          - Based on analysis by computer scientists (not reviewed by
+            lawyers
+  - Selected SPDX because it was the only standard way to represent
+  - Analysis
+      - Use RDF version of SPDX
+      - Parse and find the different licenses
+      - Based on compability graph to determine whether the license
+        combinations are OK
+      - Can analyze multiple docs to determine compatibility as well
+  - Implementation
+      - Based tools on SPDX community tools; implemented Java
+      - Started with v1.1; needs upgrading
+      - Had a problem with finding real files and so used on line
+        FOSSology tools to create
+  - Process
+      - Uses graph, but graph could be used manually independent of SPDX
+      - Find compatible/incompatible licenses
+      - Determines problems and flags compatibility problems
+  - Available on GitHub
+  - Question
+      - Are you looking at type of file when analyzing compatibility?
+        Make files for example
+          - No they analyze all licenses
+          - Would be a direction for the future
+          - Might also us dependency information
+      - How did you determine which files were compatible and
+        incompatible
+          - Did their own analysis
+          - Perhaps allow configuration of compatibility
+
+## Cross Functional Topics - Phil
+
+  - ANNUAL GOALS
+      - Roll out github-maintainable XML license templates
+      - Define an approach to creating notice files from an SPDX doc
+      - Develop a web-based license match tool
+      - Implement tool to score a project’s licensing quality
+      - Gain Apache/Eclipse Foundation adoption
+      - Sponsor a Google Summer of Code Project
+      - Conduct a supply chain management survey
+      - Build “whole product” around the spec—what is required for
+        adoption
+      - Deploy existing SPDX group tools on web
+      - Develop a git plug-in to generate an SPDX doc
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - Focus has been on support for implementations
+          - Best practice
+          - Tools
+              - Pseudo code for notices generation
+  - Moving git repo from LF over to GitHub at end of January
+
+## Legal Team Report - Jilayne/Paul
+
+  - License list release
+      - No Q4 license list release
+      - Next one in next few days
+  - Transition to Github list will be around end of January
+
+## Outreach Team Report - Jack
+
+  - No meeting yet this year
+  - Look at Leadership Conference
+  - Approach to Summer of Code
+  - Create survey
+  - Working on supporting docs
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Paul Madick, Dimension Data
+  - Gary O’Neill, SourceAuditor
+  - Georg Link, UNL
+  - Mark Gisi, Wind River
+  - Jack Manbeck, TI
+  - Alexios Zavras, Intel
+  - Matt Germonprez, UNO
+  - Robin Gandhi, UNO
+  - Dave Marr, Qualcomm
+  - Sayonnha Mandal, UNO
+  - Georgia Kapitsaki, U of Cyprus
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-02-02.md
+++ b/general/2017/2017-02-02.md
@@ -1,0 +1,73 @@
+  - Attendance: 8
+  - Lead by Gary O'Neall
+  - Minutes from January approved
+
+## Legal Team Report - Jilayne/Paul
+
+  - Working on the License/XML on Github
+      - Thanks to Brad - we're making good progress
+  - Working with the tech team on the format and tooling for the
+    License/XML
+  - Meetings scheduled for the Linux Leadership Summit
+      - 9-11 AM on Thursday,we will have an additional session with
+        Legal and Technical to discuss the License XML next steps (Note:
+        This session is not documented in the Linux Leadership Summit
+        schedule since it overlaps with some of the keynotes)
+
+## Outreach Team Report - Jack
+
+  - The Google Summer of Code submission is nearly complete
+  - The agenda for the leadership summit is worked out and posted on the
+    SPDX website and Leadership Summit schedule
+      - There is an additional 9-11 joint legal/tech discussion that is
+        not in the Leadership Summit schedule
+  - We are holding off on survey until after we the presentation of the
+    University of Omaha Nebraska's SPDX survey results
+  - Next month we plan on publishing the attribution generation
+    pseudocode/documentation produced by the tech team
+
+## Tech Team Report - Gary
+
+  - Completed document describing attribution generation including
+    Pseudocode
+      - psuedocode for generating notice files from SPDX documents is
+        at:
+
+<https://docs.google.com/document/d/1wG9ZpoEy9Dy9bBRNncWiK8GTiaPdZyfPgYQwUySjA5Q/edit>
+
+  - best practices document has been started, outline from prior WIKI
+    and google docs draft is:
+
+<https://docs.google.com/document/d/1cZoZEzHiBTIdUjPfSFyTrkor3VCyQQ3bydQrPSQ1wO8/edit>
+
+  - Google Summer of Code applications are coming due
+      - Request for any project ideas to be updated at
+        ttp://wiki.spdx.org/view/Technical\_Team/Ideas\_List
+      - If anyone is interested in being a mentor, please email Gary
+        (gary@sourceauditor.com)
+  - Kate will be presenting with Thomas at FOSDEM this weekend, on the
+    experiment of build SPDX generation (via FOSSology 3.1)
+
+into the ELBE build system - so anyone who's at FOSDEM is encouraged to
+stop by the talk.
+<https://fosdem.org/2017/schedule/event/license_compliance_easy/>
+
+## Cross Functional
+
+  - Jack will send out email reminder the Leadership Summit agenda
+  - The email and the SPDX website will include the 9-11 meeting
+  - We haven't confirmed a conference phone for the leadership summit
+    yet
+      - Discussed possible alternatives of VoIP (e.g. Skype) or using a
+        cell phone with a speaker
+
+## Attendees
+
+  - Michael Herzog
+  - Gary O'Neall
+  - Jilayne Lovejoy
+  - Paul Madick
+  - Thomas Steenbergen
+  - Jack Manbeck
+  - Yev Bronshteyn
+  - Mark Gisi

--- a/general/2017/2017-03-02.md
+++ b/general/2017/2017-03-02.md
@@ -1,0 +1,135 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+  - Minutes of Feb meeting approved
+
+## Special Presentation- Mark Charlebois / Rashmi Chitrakar, Qualcomm
+
+  - Mark from corp R\&D, Rashmi from the open source group
+  - Mark works on Dronecode
+      - Goal is to build with Yocto
+      - Want to provide good license info
+      - At the outset Yocto build only supported SPDX 1.0 and uses
+        FOSSology for scanning
+          - Yocto is a distribution that comes with recipes for custom
+            builds
+      - Motivation
+          - reducing scan times was key
+          - FOSSology was taking as much as 6 days
+          - Introducing LiD to address
+  - (Deck is available)
+  - Yocto
+      - has a number of build stages
+      - current integration was inserted after patch stage to only scan
+        what’s patched
+      - but that doesn’t allow for reusability
+      - So, the approach was to scan upstream sources and focus scan on
+        only patches
+      - Uses Yocto archiver
+  - FOSSology integration
+      - Mark was not able to even get it going
+      - Old, did not seem well maintained
+  - New integration
+      - Implements approach to
+      - Leverage newer SPDX capabilities
+          - Relationships between files
+          - Usage info (e.g. dynamic library)
+      - Allows for parallelizing across machines
+      - Can flag discrepancies (e.g. two different licenses declared)
+      - Goal
+          - create a federated commons of pre-scanned code
+          - so, everyone’s work is cut by, say, 90% (as they only need
+            to scan their customer 10%)
+  - LiD
+      - Main Features of Scanners
+          - They have access to FOSSology tools (Nomos, Monk)
+          - Evaluated using Qualcomm code for testing
+          - Nomos was pretty good at detecting license language (94%)
+          - Monk, only about 25%
+          - Used SPDX license list as source for license matching
+      - Goal
+          - Aiding in license compliance
+          - Hope was to generate SPDX
+  - Main functions
+      - Scans source code to ID license language
+      - Natural Language Process “Bag of words” approach
+      - Jakarta index shows how well it matches
+      - Levenstein measures to determine where to start/end
+      - Output- color coded matches (and deviations)
+      - Matched about as well as Noms
+      - Accuracy
+          - Right license
+          - Right region
+      - Better than Nomos at extracting full text; Monk really fell
+        short
+      - Can be tuned
+          - Based on LiD Scores (1-perfect)
+              - Scores of above .6 were pretty good, but user can adjust
+          - Nomos, being REGEX based is very computationally expensive.
+  - Will be available on GitHub
+      - But available already
+
+<!-- end list -->
+
+  - Q\&A
+      - What’s going on with Debian?
+      - It’s being tested on Debian, not a lot of feedback yet
+
+## Tech Team Report - Kate
+
+  - Spec
+      - Have been working on reference examples
+          - Filling in how to do examples
+      - Spec being converted to docbooks for style
+          - Mobile-friendly
+      - Getting the spec up on GitHub so changes can be tracked, pull
+        requests, etc
+          - Eventually we’ll move there from Bugzilla for issue tracking
+      - FacetoFace in Tahoe
+          - Jilayne did a great presentation that is available as video,
+            Kate’s as well
+          - JSON format discussion
+  - Tools
+      - Talked through plans at Face to Face
+
+## Outreach Team Report - Jack
+
+  - Accepted for Google Summer of Code
+      - Starting to get interest
+  - Short meeting last week
+      - Talked about feedback from Matt’s project surveying companies
+      - Need to decide if we will do a survey
+      - Jack says we really need to look at the Ecosystem
+          - Define user types and what to tell them they should do
+          - Need to paint a picture of what success is with SPDX
+          - Some feedback from site “I’m a developer, what do I do?”
+  - Considering whether we need someone on the outreach team who is more
+    OSS community-focused
+      - Perhaps looking at “SPDX lite” (wrong word) sort of approach,
+        and easy way to get started
+
+## Legal Team Report - Jilayne/Paul
+
+  - Good meetings at Tahoe
+      - 2 hour working session
+          - Action plan for XML conversion
+          - How to completely connect the dots and organize upcoming
+            task
+  - Today’s call will follow up
+  - Brad Edmondson developing deck and presenting to ABA group
+
+## Attendees
+
+  - Mark Charlebois, Qualcomm
+  - Rashmi Chitrakar, Qualcomm
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Philippe Ombrédanne- nexB
+  - Paul Madick, Dimension Data
+  - Jilayne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Michael Herzog- nexB
+  - Mark Gisi, Wind River
+  - Thomas Steenbergen, HERE
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-04-06.md
+++ b/general/2017/2017-04-06.md
@@ -1,0 +1,70 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+  - Minutes of March meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Prepping for Google Summer of Code
+      - 10 proposals
+      - At least 3 or 4 are very promising, only 1 or 2 that aren’t that
+        great
+          - Examples:
+              - On-line validation tool (already engaged with community)
+              - Automating SPDX gen in GitHub (already thought out
+                architecture)
+              - License grade
+      - Mentors lined up for 2-4 slots we’ve requested
+      - Will pick appropriate number based on slots
+
+## Outreach Team Report - Jack
+
+  - Creating a developer-friendly area in Git for SPDX
+      - Versions of the spec
+      - Information exchange
+          - following example of nexB creating an umbrella repo for the
+            nexB family of repos
+  - Talking about what we expect people to do
+      - So we can make more definitive statements
+      - for different market segments sort of
+      - Will guide website
+
+## Legal Team Report - Jilayne
+
+  - XML markup
+      - Made some recent decisions
+      - Down to less that 60 licenses
+      - Still work to do and volunteers needed
+  - Reception
+      - Seeing interest on GitHub
+      - Getting useful feedback on particulars of licenses
+  - Challenge
+      - Juggling two lists until next release
+      - Unclear where to log updates
+      - Enduring until next release
+      - May make sense to post “Bear with us” message
+          - in GitHub
+          - and current repo
+  - Timing
+      - uncertain as it depends on getting the work done
+      - plus a week or two of Gary once XML is done
+  - Brad presented to ABA
+      - Put a lot of time into slides
+      - Should be posted on website
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Paul Madick, Dimension Data
+  - Jilayne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Michael Herzog- nexB
+  - Mark Gisi, Wind River
+  - Alexios Zavras, Intel
+  - Thomas Steenbergen, HERE
+  - Matije Suklje, LF
+  - Gary O’Neill, SourceAuditor
+  - Dave Marr, Qualcomm
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-05-04.md
+++ b/general/2017/2017-05-04.md
@@ -1,0 +1,78 @@
+  - Attendance: 10
+  - Lead by Phil Odence
+  - Minutes of April meeting approved
+
+## Guest Presentation- Philippe
+
+  - ScanCode
+      - Open source project
+      - Tool to enable developers to find the license and origin of
+        components they are using
+  - Features
+      - Accurate
+          - Scanned Linux kernel and results were superior to two other
+            tools that were tested
+      - Handles source and binaries
+      - Well tested and community maintained
+      - Easy to improve license detection
+  - How it works
+      - Input: Simple test files
+      - Performs a diff against a large number of licenses and mentions
+      - Handles packages via package manager.
+      - Uses natural language parser for copyrights
+      - Output in SPDX (or JSON)
+  - Two pieces ScanCode Toolkit and Code Manager
+  - Other projects in code.org
+
+## Tech Team Report - Kate/Gary
+
+  - Restarted discussions about feature needs for next release
+      - Looking at:
+          - Philippe’s results
+          - Debian
+          - Other testing results
+      - Wiki page has ideas for next release or two
+          - Feel free to add there or via email
+  - Also looking at putting together a test suite
+      - Set of packages
+      - Results to be compared
+  - Google SoC
+      - Select three proposals
+      - Students being notified about now
+      - Next steps
+          - Community bonding
+          - Working with Students
+          - Will provide status
+
+## Outreach Team Report - Jack
+
+  - Working on Umbrella project
+      - A wrapper around all the repositories for tools
+  - Discussion of a tool certification project
+      - Aiming to have done in Q1 18 timeframe
+      - Initial testing at LinuxCon Europe. Prague in Oct
+  - Call for Papers this week for NA LinuxCon, LA in August
+
+## Legal Team Report - Jilayne
+
+  - Down to 24 licenses to review
+  - Proposal for how to handle non-English licenses
+      - Have handled some ad hoc
+      - Need a broader policy
+      - Will have implications for license matching guidelines
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neill, SourceAuditor
+  - Philippe Ombrédanne- nexB
+  - Brad Edmondson, Harvard
+  - Jilayne Lovejoy, ARM
+  - Jack Manbeck, TI
+  - Robin Gandhi, UNO
+  - Kevin Nelson, Optum
+  - Dennis Clark, nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-06-01.md
+++ b/general/2017/2017-06-01.md
@@ -1,0 +1,70 @@
+  - Attendance: 9
+  - Lead by Phil Odence
+  - Minutes of May meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Good progress on getting spec to GitHub
+      - Should have a new version within the next month
+      - Will be adapting processes to new source
+  - Substantively working though list of items for next release
+      - Still up in the air whether we will go to a 2.2 or directly to
+        3.0
+          - Need to resolve by Aug
+          - 2.2 candidates- clean up appendices for license list work, a
+            few additional fields
+      - 3.0 will imply compatibility issues
+      - Timeframe depends on above, but likely 2018 in any case
+  - Summer of Code
+      - A number of students have started
+      - Participation in Tech Calls
+      - One just starting to commit to GitHub
+  - Tooling
+      - Moving apace
+  - News- Someone from IBM mentioned they are using SPDX short
+    identifiers internally (at OSCON event).
+
+## Legal Team Report - Jilayne/Paul
+
+  - Lots of activity
+  - XML work still underway; Gary supporting with tooling
+  - Other large threads
+      - Discussion about how to deal with licenses that have been
+        translated
+          - There is a default policy with which we’ve been consistent
+          - Re-looking into this in light of new XML stuff and need for
+            automated matching
+          - JL started a Wiki page to pull together all the proposals
+      - Kate/JL reached out to FSF
+          - For rallying support
+          - Issue: how we represent license and “or later” with the
+            syntax sometimes goes unnoticed
+              - Perhaps recasting as a separate v2 only license is a
+                better way to handle
+              - But there are implications we need to think through
+
+## Outreach Team Report
+
+  - Basically we are still working on a proposal for how to allow tools
+    to get a badge or certification for working with SPDX documents
+  - and an umbrella project  for Github for all of our projects out
+    there.
+  - Kate- also looking to create an archive of past projects which are
+    no longer active
+  - Bakeoff at LinuxCon Europe (October in Prague) is likely.
+      - Working on test suite to be available for this.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Paul Madick, Dimension Data
+  - Michael Herzog- nexB
+  - Jilayne Lovejoy, ARM
+  - Kate Stewart, Linux Foundation
+  - Bradlee Edmondson, Harvard
+  - Gary O’Neall, SourceAuditor
+  - Alexios Zavras, Intel
+  - Mike Dolan, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-07-06.md
+++ b/general/2017/2017-07-06.md
@@ -1,0 +1,94 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+  - Minutes of June meeting approved
+
+## Guest Presentation - Anna Buhman
+
+  - Goals: Integrate GitHub with SPDX
+      - Auto Generation
+      - And kept up to date
+      - Therefore easier to use
+  - Uses
+      - Repo admin sets up
+      - Or non admin or someone outside could generate as well
+      - Perhaps on a portion of the code
+  - How it works
+      - Scans using an open source scanner with every change
+      - Creates doc and a pull request for updated doc which human must
+        approve
+          - anticipates needing some human modifications
+      - Above is working today
+  - Future modifications
+      - Rather than replacing, combing with old version to retain human
+        mods
+      - Email notification of new docs
+      - User-selectable license scanner
+  - Project comments
+      - Learning lots about different kinds of software
+          - Example, learning about controlling GitHub with Python code
+      - SPDX seemed very complicated at first
+      - But understanding licensing she understands the requirements
+      - Work so far is on GitHub in the SPDX area; Wiki too
+  - Questions:
+      - How to keep from overwriting human modifications?
+          - Compare section by section and default to original giving a
+            human the choice
+      - When will a demo be available?
+          - Maybe on a future call
+
+## Tech Team Report - Kate/Gary
+
+  - Spec source is now on GitHub, versioned, etc,
+      - Big thanks to Thomas Steenbergen
+      - Working out permissions/process modifications
+      - Looking at how to link to from spdx.org
+  - Have been working through the topics for the next rev
+  - Tooling
+      - Summer of Code students have been giving updates
+          - Gitter account set up wth lots of good conversations
+          - Great progress overall
+
+## Legal Team Report - Jilayne/Paul
+
+  - Good last few calls
+  - XML Format
+      - Gary set up a we to view previews
+      - Down to last few files
+  - Discussion about Linus’ note about GPL
+      - Linus tried to clarify what it applied to our not
+          - explicit about user space not subject to being a derivative
+            work
+      - Not calling it a license exception, per se, but will likely be
+        treated as we treat exceptions
+      - Not a clear way to represent; working on that now
+      - There had been two versions, but that was cleaned up
+  - Some chatter on mailing list about how we identify “only” as in GPL
+    2.0 Only
+      - Problem: We are explicit about “or later” but not about “only”
+      - Working with FSF who would prefer: GPL-2.0-Only
+      - Considering modifications to the expression language
+
+## Outreach Team Report - Jack
+
+  - Michael working on umbrella project page for Git
+      - Idea is to be an SPDX home for developers
+  - Working on a write up of goals for tools etc.
+      - Kate working on it.
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Jack Manbeck, TI
+  - Gary O’Neall, SourceAuditor
+  - Anna Buhman, UNO
+  - Paul Madick, Dimension Data
+  - Michael Herzog- nexB
+  - Thomas Steenbergen, HERE
+  - Bradlee Edmondson, Harvard
+  - Jilayne Lovejoy, ARM
+  - Robin Gandhi, UNO
+  - Georg Link, UNO
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-08-03.md
+++ b/general/2017/2017-08-03.md
@@ -1,0 +1,114 @@
+  - Attendance: 10
+  - Lead by Phil Odence
+  - Minutes of July meeting approved
+
+## Guest Presentation - Rohit
+
+  - Studying computer science in India
+      - Working with SPDX for a number of months
+      - Great experience in learning about how open source works
+      - And, was surprised to learn about license issues
+  - Project- On line SPDX tools
+      - move existing tools to web interfaces
+      - started with simple UI
+          - and, of course, used open source
+          - java and python
+          - needed a java VM
+          - finally found a project that worked for him
+  - Three tools
+      - Validation tool
+      - Converter tool
+      - Comparison tool
+  - Vailidation Tool
+      - Very simple UI
+      - Basically just upload a file
+      - Returns result of SPDX compatibility errors
+      - Works for both tag value and RDF
+  - Comparison Tool
+      - takes two file inputs (for comparison)
+      - after files uploaded, they go through validation
+      - If so, they are compared
+      - output is Excel sheet, saved on the server, user gets download
+        link
+  - Conversion Tool
+      - conversions between format types
+      - user selects type of conversion
+      - returns required format
+          - similar to spreadsheet, stored on server with download link
+  - Next steps
+      - creating API so other applications can call
+      - benefit is that java tool prereqs don’t need to be called
+  - Rohit went through a very short demo but will set up a more detailed
+    one with the Tech Team
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - Got through all of the topics in the Google Doc
+      - Making good progress
+  - 2.2 v 3.0 discussion
+      - Still open to input on burning use cases that aren’t covered
+      - Please feel free to provide input
+      - SPEC URL- <https://github.com/spdx/spdx-spec>
+  - Tooling
+      - most of the focus has been on GSoC
+          - everyone is making great progress
+          - evaluation last week and everyone passed\!
+      - Progress on Python libraries
+      - Helping legal team with tooling
+
+## Legal Team Report - Jilayne/Paul
+
+  - Uptick in activity on XML review
+      - Brad and Alexios have been great
+      - This has been a longstanding need, so great to see progress
+  - Discussion about Linus’ note on Linux and GPL
+      - Will be added to license list
+  - On the plate now: Lots of chatter on email list about implications
+    of adding “+” operator
+      - background
+          - used to have two different licenses to handle “only” and “or
+            later”
+          - now using an operator
+          - left “GPL only”
+      - It’s created some problems
+          - current meaning of GPL-2
+          - problems with standard header
+      - reached a conclusion about how to handle going forward
+      - Best option
+          - deprecate plus operator
+          - go back to two different licenses
+              - doesn’t really apply to other licenses anyway
+              - we believe, but still open for discussion
+      - big topic on legal call today
+  - License comparison tool, web-based
+      - <https://certification.openchainproject.org/spdxweb/>
+          - URL could change
+  - API thought from Phil
+      - Assuming we publish APIs for hosted tools, we will need to
+        specify terms of use.
+
+## Outreach Team Report - Jack
+
+  - Jack unavailable. His email input:
+      - Update from my side is that we are still working on fleshing out
+        and documenting the program tools that can scan licenses and
+        generate/read spdx documents.
+      - Kate- Also talking about how to come up with a test suite for
+        tools to make sure tools correctly read/generate SPDX
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Rohit Lodha, Google Summer of Code
+  - Gary O’Neall, SourceAuditor
+  - Uday Shankar, Black Duck
+  - Alexios Zavras, Intel
+  - Matija Suklje, FSFE
+  - Kate Stewart, Linux Foundation
+  - Bradlee Edmondson, Harvard
+  - Jilayne Lovejoy, ARM
+  - Michael Herzog- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-09-07.md
+++ b/general/2017/2017-09-07.md
@@ -1,0 +1,96 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+  - Minutes of July meeting approved
+
+## Guest Presentation - Krys Nuvadga
+
+  - Studying sw engineering in Cameroon
+  - GSoC project: License grader tool.
+      - Command line tool that would compare and SPDX doc to Source
+        files
+      - To determine the coverage of the info in the SPDX document
+  - Use cases
+      - Scan and pass SPDX doc to get license information in a format to
+        perform calculations
+      - Get a source file validator to determine if a particular file
+        was covered
+          - Factors considered to determine if something was source file
+              - LoC
+              - Characters
+  - Started with a simple case to get running
+  - Incremental approach
+      - Developed module by module
+          - Used Python
+          - Scanner
+          - Source code analysis passing results as XML
+          - Results comparison
+          - Grading for each package
+  - Features
+      - Scanning
+      - Computation on source package
+  - Status
+      - Working
+      - Still WIP
+      - Refining
+      - Addressing performance issues
+  - Questions
+      - why to use
+          - To determine how complete the file license information is
+      - Will the user get a list of fils without info?
+          - Yes
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - All on GItHub now
+          - migrated Google doc discussions
+      - 2.1.1 version fixing typos
+      - 2.2
+          - slated for late in the year
+          - will include new features
+          - feature set still open, please contribute
+      - Kate speaking next week at the Open Source Summit talking about
+        testing scanning tools
+  - Tooling
+      - Completing GSoC
+          - All students passed
+          - All up on GitHub
+          - Very successful
+
+## Legal Team Report - Jilayne/Paul
+
+  - XML Conversion slightly stalled
+  - “ONLY” issue has required focus
+      - Brought up some inconsistencies
+      - Lots of discussion on tech and legal calls and joint ones
+          - Jilayne summarized in wiki
+      - Proposal
+          - Add ONLY operator
+          - Remove “only” from current names
+              - will necessarily cause some backward compatibility issue
+
+## Outreach Team Report - Jack
+
+  - Working on tool to generate test files for scanners
+      - working fine
+      - cleaning up documentation
+      - will create a test file and will upload it
+          - needs a name
+          - to be resolved in call today
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Krys Nuvadga, University of Buea, Cameroon
+  - Gary O’Neall, SourceAuditor
+  - Paul Madick, Dimension Data
+  - Jack Manbeck, TI
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, ARM
+  - Matija Suklje, FSFE
+  - Rashmi Chitrakar, Qualcomm
+  - Bradlee Edmondson, Harvard
+  - Thomas Steenbergen, HERE
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-10-05.md
+++ b/general/2017/2017-10-05.md
@@ -1,0 +1,112 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+  - Minutes of Sept meeting approved
+
+## Guest Presentation - Alexander Lisianoi
+
+  - Background
+      - Working on masters in Technical University of Vienna
+  - Project
+      - Turning Python Code into Javascript
+          - Pooling PY and License expression
+          - Libraries that are self contained
+          - Initially looked easy
+      - Results
+          - It works\!
+      - How it went
+          - Long list of tools available, so choosing a tool is the
+            first step
+              - Brython, Batavia, Transcript
+              - Brython can read in pure Python
+              - Bytavia uses Python byte code
+              - Transcript actually translates to javacode, so he picked
+                that one
+                  - Downside is that it doesn’t handle every Python
+                    capability
+          - Encountered a lot of bizarre results
+              - And complained a fair amount
+              - Tricky to know what goes wrong; have to debug both in
+                parallel
+              - Errors can be subtle
+              - How things are compared differs between languages
+      - The resulting tool
+          - You can parse, but it can be broken
+      - Value of the work
+          - Javascript is very commonly used for front ends these days
+          - You don’t want to have to support two technologies for front
+            and back end
+          - This allows leveraging the backend scripts for building
+            front end
+          - Valuable to tool developers using JS and to development
+            communities
+          - As a side-effect of the work, we Alexander helped
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - All on GItHub now
+  - Last few meetings have been focused on
+      - FSF proposal
+          - Supporting legal team on expanding license expression
+            language
+      - Testing work from Jack
+          - Tool testing cases
+              - Scanners for locating license language
+              - License language matchers (using matching guidelines)
+          - Also testing license list generator
+              - Which requires test cases as well
+          - Looking at creating a repo for all test cases
+              - Two tool types
+              - License list gen
+          - Will be community based so folks can contribute cases
+  - Preview
+      - Looks like there will be a new tool contribution from an LF
+        member
+      - A tool to create a summary
+          - Input SPDX tag value; output easy to read/intrerpret format
+
+<!-- end list -->
+
+  - LinuxCon Europe
+      - There will be a meeting for those creating tools
+      - New testing work with be on the agenda
+
+## Legal Team Report - Jilayne/Paul
+
+  - FSF Proposal
+      - For how the GPL version is represented
+      - Questions about new operators, default
+      - Generated a large meeting with tech folks
+          - Lively discussion
+          - Did not reach resolution
+      - FSF has come back with another proposal
+          - Technical challenges
+          - Difference of opinion, particularly for case where
+          - Part of the issue is that FSF is focused on just the
+            identifiers vs. how we use with SPDX
+              - License does not specify “or later” or “only”
+              - How do we represent without representing legal judgment
+              - Fundamentally there are different opinions on what it
+                means when there is no specification
+              - Very important to FSF (including Richard Stallman)
+
+## Outreach Team Report - Jack
+
+  - Mostly license test file work as described above
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Alexander Lisianoi, Technical University of Vienna
+  - Matthew Crawford, ARM
+  - Matija Suklje, FSFE
+  - Steve Winslow, Linux Foundation
+  - Mike Dolan, Linux Foundation
+  - Jack Manbeck, TI
+  - Michael Herzog- nexB
+  - Gary O’Neall, SourceAuditor
+  - Paul Madick, Dimension Data
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-11-02.md
+++ b/general/2017/2017-11-02.md
@@ -1,0 +1,52 @@
+  - Attendance: 5
+  - Lead by Phil Odence
+  - Minutes of Oct meeting approved
+
+## Tech Team Report - Kate
+
+  - Focus on new license list
+      - Getting ready
+      - Adding FSF Libre field
+      - Trevor extending to an API, if they want to push changes, or we
+        can pull
+  - Prague
+      - SPDX Open Source Tools Session
+          - MarkG demoed sparts as part of Intel booth, and illustrated
+            how Hyperledger with SPDX can be used in supply chain
+          - Thomas Steenbergen announced open source review toolkit
+            (ORT) and provided overview of ScanCode
+          - Michael Jaeger reviewed how SW360 and new release of
+            FOSSology can be used to work with SPDX
+
+source{d} discussed proposal they're working on to apply machine
+learning to license recognition.
+
+  -   - Kate overviewed the SPDX tools repository and some of the newer
+        additions by GSoC students as well as the test suite.
+
+  -   - Kate did a talk on "automating license compliance - filling in
+        the missing pieces" - more info at <http://sched.co/BxI3>.
+          - Lots of developer interest in this topic now.
+      - FOSSology Hands-on training had section on SPDX documents, that
+        she presented.
+
+## Legal Team Report - Paul
+
+  - XML project continues well
+  - Still discussions on “or later” issue
+      - On hold for the moment as Jilayne is out
+
+## Outreach Team Report
+
+  - Jack still working on testing tools
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Paul Madick, Dimension Data
+  - Mike Dolan, Linux Foundation
+  - Bradlee Edmondson, Harvard
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2017/2017-12-07.md
+++ b/general/2017/2017-12-07.md
@@ -1,0 +1,79 @@
+  - Attendance: 15
+  - Lead by Gary O'Neall
+  - Minutes of Nov meeting approved
+
+## Guest Speaker - Pedro Giffuni - FreeBSD
+
+  - Overview and history of FreeBSD
+  - Licensing - several variations of licenses, difficult to keep track
+      - Mostly free of copyleft (exceptions tools like gcc)
+      - Mix of BSD styles, MIT, ISC
+  - SPDX helps solve some of the issues with non-uniform licenses
+  - SPDX helps describe licenses when sharing code with other projects
+      - Used WindRiver service to do initial identifications
+      - Identified licenses needed manual review - not all of the
+        license matches were precise
+      - Breakdown of the licenses found was provided
+  - Pedro has been adding the SPDX tags
+  - Currently, only tagged C files and headers
+  - Build files and documentation still need to be tagged
+  - Just adding tag, not removing the licenses
+      - Discussion on the advantages / disadvantages of keeping the
+        license
+      - Most important aspect is to add the SPDX ID for easy
+        identification
+  - Question on tagging some of the non-core files
+      - Other projects are outside the tree and not currently tagged -
+        they are maintained by other groups
+
+## Tech Team Report - Kate and Gary
+
+  - SPDX proposals for 2.2 and 3.0 versions of the spec are now in
+    github
+  - Some discussion on extending the license expression to include an
+    ambiguous operator
+  - Some discussion on various tooling effort including the tools
+    presented by Thomas in Prague
+  - Most tooling efforts have been focused on supporting the legal team
+    move to the license XML format
+  - Kate and Philippe provided an update on the use of license ID's in
+    the Linux Kernel
+      - All files now have detectable licenses\!
+      - LWN has an article describing the effort:
+        <https://lwn.net/Articles/739183/>
+  - Philippe presented at the Paris Open Source summit
+
+## Outreach Team Report - Jack
+
+  - Moving to new wordpress website
+  - Encouraged everyone to take a look at the site (note: you will need
+    access to sign in)
+  - Target to move in December, but it may end up being January
+
+## Legal Team Report - Jilayne
+
+  - Closed the GPL identifier issue requested by the FSF
+      - The updated solution was accepted by FSF and Richard Stallman
+  - We are now in "feature freeze" for the next release
+      - We should hold off on opening up or discussing larger issues not
+        related to the next release
+      - Effort should be focused on resolving remaining issues in the
+        github repository
+
+## Attendees
+
+  - Kate Stewart, Linux Foundation
+  - Philippe Ombredanne, NexB
+  - Bradlee Edmondson, Harvard
+  - Pedro Giffuni, FreeBSD
+  - Robert Musial, Progressive
+  - Jeff Luszcz, Flexera
+  - Dennis Clark, NexB
+  - Gary O'Neall, Source Auditor
+  - Alexios Zavras, Intel
+  - Jilayne Lovejoy, ARM
+  - Scott Lammons, FreeBSD
+  - Mathew Crawford, ARM
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-01-04.md
+++ b/general/2018/2018-01-04.md
@@ -1,0 +1,28 @@
+  - Attendance: 5
+  - Lead by Phil Odence
+  - Minutes of Dec meeting approved
+
+## Tech Team Report - Kate
+
+  - Focus on new license list
+
+## Legal Team Report - Paul
+
+  - XML project continues well
+  - Still discussions on “or later” issue
+      - On hold for the moment as Jilayne is out
+
+## Outreach Team Report
+
+  - Jack still working on testing tools
+
+## Attendees
+
+  - Phil Odence, Black Duck
+  - Kate Stewart, Linux Foundation
+  - Paul Madick, Dimension Data
+  - Mike Dolan, Linux Foundation
+  - Bradlee Edmondson, Harvard
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-02-01.md
+++ b/general/2018/2018-02-01.md
@@ -1,0 +1,60 @@
+  - Attendance: 13
+  - Lead by Phil Odence
+  - Minutes of Jan meeting approved
+
+## Tech Team Report - Kate
+
+  - Highlights
+      - Looking at multiple formats supported
+          - Much of January dedicated
+          - JSON and YAML
+          - Some interest in deprecating
+      - Submitted Google SoC project, once again
+          - Have usually been accepted in advance
+          - Should know by next meeting
+          - Can still contribute ideas
+
+## Outreach Team Report - Jack
+
+  - Website migration
+      - Waiting on date from LF
+      - Need a mechanism for pushing some generated pages
+        (licensing/RDF)
+  - Today’s meeting will be to lay out a roadmap
+  - Linux Leadership Summit
+      - Meetings Friday
+      - Jilayne sending out notice to try to hustle up participation
+      - Anyone who needs an invite can contact Kate
+  - FOSSDEM is this weekend
+      - Will be streamed from Brussels
+      - Legal and Policy track
+          - Jilayne speaking
+
+## Legal Team Report - Jilayne
+
+  - Major release of license list recently
+  - 3.1 release
+      - Aiming to align 3.2 version with 2.2 spec
+      - Undergoing technical and legal review
+      - Transitioning to taking advantage of GitHub capabilities
+          - Technical stuff on track
+  - Reviewing some new licenses, need naming conventions
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synpsys
+  - Kate Stewart, Linux Foundation
+  - Mike Dolan, Linux Foundation
+  - Steve Winslow, LF
+  - Jeff Luszcz, Flexera
+  - Jack Manbeck, TI
+  - Denisse Weil,
+  - Robert Musial, Progressive
+  - Gary O’Neall, SourceAuditor
+  - Bradlee Edmondson, Harvard
+  - Matthew Crawford, ARM
+  - Jilayne Lovejoy, ARM
+  - Michael Herzog- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-03-01.md
+++ b/general/2018/2018-03-01.md
@@ -1,0 +1,60 @@
+  - Attendance: 6
+  - Lead by Phil Odence
+  - Minutes of Feb meeting approved
+
+## Tech Team Report - notes sent by Kate
+
+  - Thomas continues to get closer on 2.1.1 release, most changes from
+    Trevor merged now.
+  - Reviewed PURL proposal and concensus was to adopt for 2.2, after we
+    see it finalize and be picked up by other projects.
+      - PURL is a a generalized way to specify a package.
+  - Discussion of multiple formats being supported (JSON, YAML, etc.), 
+    as long as there are translation tools, and we follow the RDF
+    naming, agreement to introduce them in 2.2.
+
+## Outreach Team Report - Jack out
+
+  - Website migration- No update from the LF
+  - British Computer Society
+      - Open Source Group
+      - March 22
+      - Alexios presenting on SPDX
+      - <https://ossg220318.eventbrite.co.uk/>
+
+## Legal Team Report - Bradlee
+
+  - 3.1 LL release, end of March
+      - Then back to 3 month cadence
+  - Jilayne working with FSF on status of their license evaluation
+  - For Summit Topics
+      - Use of GitHub for licenses and Spec
+  - Philipe ID’ed some licenses in the Kernel that are not in the list
+      - He’s putting together pull requests
+      - There are a number of others, the he believes might be
+        candidate.
+          - He’ll prioritize and will “drip” to the Legal Team
+      - Also some discussion about what to do, if anything, about
+        proprietary licenses
+          - Could be make sense to have a common identifier for commonly
+            used ones
+              - Could conceivably use the same architecture for
+                proprietary
+  - Also discussing a “relaxed” format.
+      - Not necessarily including all the checksums
+      - So could might introduce levels of SPDX compliance (A, AA,
+        AAA…or something)
+  - Discussion of how to get more lawyers involved.
+      - Women lawyers would be particularly welcome
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Alexios Zavras, Intel
+  - Dennis Clark, NexB
+  - Steve Winslow, LF
+  - Bradlee Edmondson, Harvard
+  - Matthew Crawford, ARM
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-04-05.md
+++ b/general/2018/2018-04-05.md
@@ -1,0 +1,93 @@
+  - Attendance: 13
+  - Lead by Phil Odence / Jack Manbeck
+  - Minutes of March meeting approved
+
+## Adoption Update- Kate
+
+  - License List Identifiers Update
+      - DEP 5 adopting, LF and others
+  - IDs in Source
+      - U-Boot, selected projects, LF projects including the Kernel
+      - Eclipse, FreeBSD, REUSE.software
+      - Open Gov Partnership
+  - Doc Creation
+      - New formats: YAML, others
+      - Tooling
+          - Open Source
+              - SPDX Tools, FOSSology, ScanCode
+          - Commercial
+      - Wind REiver, Protecode, SourceAuditor, TripleCHeck, WS (license
+        list only), BD
+      - Scan tool accuracy- Different tools get slightly differing
+        results
+      - Formats correctness- worth checking too
+      - Outreach time is working on examples for testing
+      - SPDX tools have compare capabilities
+  - New Tools for Inside Org workflow
+      - SPDX online tools to validate and compare
+      - SW360, ORT, Quartermaster
+  - Between Orgs
+      - Aligning with OpenChain
+      - REUSE by FSFE- Conventions for best practices for how/where to
+        include license info (check out their cute video)
+      - Emerging: Software Parts Ledger
+          - Blockchain Hyperledger (driven by Wind River)
+  - Missing Pieces
+      - Real world reference examples, use studies, build integration
+
+(copy of Kate's slides attached at the bottom)
+
+## Tech Team Report - Kate
+
+  - Looking at google summer of code. That’s apriority right now. We are
+    reviewing proposals from candidates and have eighteen this year\!
+    The quality of the proposals seems to be very good. Not sure how
+    many slots google will give us yet (should know next week) but we
+    are asking for 5-6.
+  - We have just enough mentors for the project’s but would welcome any
+    additional ones. No experience needed and you can be teamed up with
+    an experienced mentor. There is much you can do, even non-technical.
+  - The 2.1.1 specification update is pending. All GIT issues are
+    resolved. This is a minor update for mostly types and clarifications
+    and changes to support the specification being in GitHub. Kate is
+    working with Thomas to be able to generate a review version to send
+    out. Expect the review time frame to be 1-2 weeks long.
+
+## Outreach Team Report - Jack
+
+  - We are revamping the main suite for the Use area. What we had was an
+    initial cut. Pages are being broken out and expanded. First section
+    to change will the license identifiers in source (Steve Winlsow from
+    the LF is doing this) followed by the list and documents sections.
+  - SPDX website move. No movement yet. Still waiting on the LF to come
+    back with a new update. They have to get extra help to figure out
+    how to do the license list and rdf pages that we auto generate.
+  - If anyone is going to LinuxCon in Vancouver (August) the call for
+    papers is open. Please submit any you might o have on SPDX. We are
+    also investigating whether we can do another tool bake off and/or a
+    birds of a feather session.
+
+## Legal Team Report - Jilayne
+
+  - 3.1 license list is still pending. Need to make sure all open issues
+    on it are resolved. Anyone wishing to help (which would be greatly
+    appreciated) should join the Legal Calls.
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Matthew Crawford, ARM
+  - Steve Winslow, LF
+  - Dennis Clark, NexB
+  - Kate Stewart, Linux Foundation
+  - Jack Manbeck, TI
+  - Jilayne Lovejoy, ARM
+  - Michael Herzog- nexB
+  - Matija Šuklje, Liferay
+  - Bradlee Edmondson, Harvard
+  - Gary O’Neall, SourceAuditor
+  - Dave Marr, Qualcomm
+  - Philippe Ombrédanne- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-05-03.md
+++ b/general/2018/2018-05-03.md
@@ -1,0 +1,82 @@
+  - Attendance: 12
+  - Lead by Phil Odence
+  - Minutes of April meeting approved
+
+## Guest Presentation, Automating Governance with SPDX- Yev Bronshteyn
+
+  - Variant on Leadership Summit Presentation
+      - Don’t need to define SPDX
+      - Will show product for illustrative purposes
+  - Governance Today
+      - Different formats for BoMs
+      - Challenges
+          - Manually updating
+          - Compliance Management
+          - Requires consistent tooling
+  - Goals using SPDX
+      - Automate BoM
+      - Automate Reporting
+      - Single format
+  - Illustration
+      - Replace disparate BoMs with SPDX versions
+      - Load into a single data store (example Apache Jena Fuseki
+      - Query with Sparql
+      - Demo
+          - Aggregating multiple BoMs
+          - Committing change to GItLab
+          - CI/CD- Build and Scan
+          - Generate new SPDX doc for changed project
+          - Sparql queries
+              - Policy checks
+          - Voila
+
+## Tech Team Report - Kate/Gary
+
+  - Working on outstanding requests for 2.2
+      - License expression features
+      - Handling cases of annotations and extensions to address
+  - 2.1.1 pdf
+      - Wrestling with tools a bit
+  - GoSoC
+      - Students and mentors in place
+      - Should be hearing from students during community bonding period
+      - Projects lined up
+      - Will present during General Meetings
+
+## Outreach Team Report - Jack
+
+  - LinuxCon Vancouver
+      - Trying to organize “back off” day before event starts
+  - Website:
+      - Still waiting on LF for moving Website to Wordpress
+      - Content
+          - Looking at a variety of ways
+          - Looking at audio/video recordings
+              - Could include monthly talks
+              - Yev volunteered to do his
+      - Looking for more people involvement in OTeam
+
+## Legal Team Report - Paul
+
+  - Released latest rev of license list
+      - Kudos Jilayne and others
+  - Working out how to manage license submissions in new world
+      - GoSoC student working out automation
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Matthew Crawford, ARM
+  - Yev Bronshteyn, Black Duck/Synopsys
+  - Steve Billings, Black Duck/Synopsys
+  - Gary O’Neall, SourceAuditor
+  - Dave Marr, Qualcomm
+  - Jack Manbeck, TI
+  - Kate Stewart, Linux Foundation
+  - Steve Winslow, LF
+  - Paul Madick, Dimension Data
+  - Matije Suklje, Liferay
+  - John Scott, Ion Channel
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-06-07.md
+++ b/general/2018/2018-06-07.md
@@ -1,0 +1,46 @@
+  - Attendance:
+  - Lead by Gary O'Neall
+  - Minutes of May meeting approved
+
+## Outreach Team Report - Jack
+
+  - Mail list migration on June 13th. Changing from spdx-biz to
+    spdx-outreach for mail list name. spdx-general will become parent,
+    all of others will be child. If signed up for any child,
+    automatically parent. This will give us a master mail list.
+  - Jack will be sending an email out on June 11th, apprising all of the
+    mail list change.
+  - Room reserved for SPDX plugfest at OSS for Aug 27th.
+  - No update on the web site change. Agreement not to wake them up, and
+    leave alone for now.
+
+## Legal Team Report - Paul
+
+  - Regular meetings in progress, knocking down issues happening in
+    github
+  - Meetings with GSoC students to cover requirements
+
+## Tech Team Report - Gary
+
+  - GSoC students all started, 2 working with legal team.
+  - still waiting on spdx 2.1.1 to have proper generated .pdf, no
+    comments back yet on updated version published on web.
+  - spdx-spec issues are all tagged in github
+  - most of focus is 2.2 at this point.
+
+## Cross team - Gary
+
+  - looking at getting GSoC student - probably Yash to present at next
+    general call.
+
+## Attendees
+
+  - Gary O’Neall, SourceAuditor
+  - Jack Manbeck, TI
+  - Kate Stewart, Linux Foundation
+  - Steve Winslow, LF
+  - Paul Madick, Dimension Data
+  - Jilayne Lovejoy, ARM
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-07-11.md
+++ b/general/2018/2018-07-11.md
@@ -1,0 +1,65 @@
+  - Attendance: 10
+  - Lead by Phil Odence
+  - Minutes of June meeting approved
+
+## Guest Presentation, Online XML Editor- Tushar Mittal
+
+  - XML Editor for Editing Licenses
+      - For contributors to License List
+  - Demo
+      - User can
+          - upload flies, or
+          - Specify one of the current licenses
+      - Options
+          - Text, Tree, Split View Editor
+          - Text
+              - Editor guides to sticking with SPDX license schema
+              - Beautify cleans up XML nicely
+          - Tree Editor
+              - Operates on the same file
+              - Easy way to modify attributes
+      - Legal team is very enthusiastic about the tool
+          - It will make their lives much easier.
+
+## Tech Team Report - Gary
+
+  - GSoC
+      - Good progress across the board
+      - Tushar obviously has done some great work
+      - Additionally upgrading Python libraries and work on build tools
+  - Most calls focused on 2.2 list of potential enhancements and issues
+      - Progress a little slow due to vacations
+  - LinuxCon NA, Vancouver
+      - There will be some tools work going on
+      - Anyone interested should contact Gary or email the list
+
+## Outreach Team Report - SteveW
+
+  - SPDX short form IDs has gone live
+      - Includes guidelines for developers who want to add IDs to their
+        files
+      - <https://spdx.org/ids>
+
+## Legal Team Report - Jilayne
+
+  - V3.2 of License List just released
+      - Will be updating General Mailing list including stats on new
+        licenses
+  - Continuing to monitor pull requests
+  - Today’s meeting will recap old/stale
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Tushar Mittal, GSoC Student
+  - Gary O’Neall, SourceAuditor
+  - Yash Nisar, GSoC Student
+  - Dave Marr, Qualcomm
+  - Steve Winslow, LF
+  - Matthew Crawford, ARM
+  - Mark Atwood, Amazon
+  - Jilayne Lovejoy, ARM
+  - Bradlee Edmondson, Harvard
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-08-02.md
+++ b/general/2018/2018-08-02.md
@@ -1,0 +1,101 @@
+  - Attendance: 13
+  - Lead by Phil Odence
+  - Minutes of July meeting approved
+
+## Guest Presentation, - Supporting Continuous Integration, Ndip Tanyi
+
+  - Idea- Automatically generating SPDX docs as part of CI process
+  - Scope
+      - Focused on Travis CI, NPM and Python
+  - Demo
+      - Add an install and SPDX build script to build script
+      - And some statements to push the SPDX docs to the repo
+  - Future extensions
+      - Pushing to GItHub as a commit
+      - Other CI systems
+  - Has been designed generically enough to be extensible to other
+    languages and environments
+
+## Tech Team Report - Kate/Gary
+
+  - Tools: GSoC is wrapping up in the next couple of weeks. Thank you to
+    the students for their hard work and improvements to the project
+    tools\!
+
+<!-- end list -->
+
+  - Specification:
+      - Working through resolution of the external identifiers of the
+        PURL specfication and our External Identifiers. We’re trying to
+        get key discussion participants (Yev, Philippe, Treveor, Gary,
+        Kate) all on the same call.
+      - on that note, we’re seeing a lot of interest in Security and
+        ties into External Identifiers
+
+<!-- end list -->
+
+  - Security:
+      - NTIA held a software transparency workshop 2 weeks ago, and are
+        moving forward with a workgroup to reconcile the formats that
+        are out there. When there are more details on the workgroup,
+        Kate will send out the invitation to participate to the SPDX
+        general and technical lists.
+      - SPDX team will also be spinning up a security working group to
+        focus on improving SPDX to support the SBOM for security issues,
+        so watch out for more information, and if you have security
+        contacts who are interested in participating, please subscribe
+        to <https://lists.spdx.org/g/spdx-security> We'll be starting
+        discussions there in the next month.
+
+## Legal Team Report - Jilayne/Paul
+
+  - 3.2 is out
+  - Some clean up of old issues in process
+  - Request to that legal folks try out Tushar’s tool
+  - Exceptions
+      - The term is imperfect as it handles some items that are not
+        “exceptions” per se
+          - Patent grants, for example
+          - Considering changing the term to be more neutral and
+            inclusive
+              - “Modifiers” maybe?
+              - Will send an email to a wide audience get people
+                thinking about it and set up a special meeting
+
+## Outreach Team Report - Jack
+
+  - Website
+      - Making more sense of the License List and Documents section
+
+<!-- end list -->
+
+  - New time for Outreach calls is 7pm EDT
+      - \* Shane Coughlin, from Open Chain, is getting involved to lead
+        the Outreach to Companies (Japan based)
+
+<!-- end list -->
+
+  - OSS Summit
+      - Bake-off is on the Tuesday
+      - Morning will be on producing SPDX documents, and checking valid
+      - Afternoon session will be on consuming them.
+      - 6 tools (3 open source, 3 commercial) will be participating.
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Kate Stewart, Linux Foundation
+  - Ndip Tanyi, Alberta University
+  - Tushar Mittal, GSoC Student
+  - Gary O’Neall, SourceAuditor
+  - Yash Nisar, GSoC Student
+  - Jack Manbeck, TI
+  - Steve Winslow, LF
+  - Jilayne Lovejoy, ARM
+  - Paul Madick, Dimension Data
+  - Mike Dolan, Linux Foundation
+  - Matije Suklje, Liferay
+  - Mark Atwood, Amazon
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-09-06.md
+++ b/general/2018/2018-09-06.md
@@ -1,0 +1,54 @@
+  - Attendance: 12
+  - Lead by Jilayne Lovejoy
+  - Minutes of August meeting approved
+
+## Guest Presentation, Using the Hyperledger Platform to track open source, Mark Gisi, Wind River
+
+  - 3 concepts: softer parts (tracked in ledger), software artifacts
+    (tracked in ledger) and chain of custody - concept of using ledger
+    to track through the supply chain
+  - allows to know what data was delivered and when
+  - SParts Projects - software parts ledger: free digital ledger to
+    track open source artifacts across supply chain; 3 components:
+    ledger (container), CLI, and
+  - example/demo of 96board w/Zephyr OS
+  - can compare compliance artifacts delivered to what is on ledger
+  - can store a variety of different data in separate envelopes
+  - targeting commercial grade MVP in Oct 2018
+  - Mark to send around link to slides
+
+## Tech Team Report - Kate/Gary
+
+  - great set of meetings at Open Source Summit in Vancouver and good
+    progress
+  - focus on 2.2 spec which will hopefully provide multiple formats
+  - new formats will make use of SPDX easier - yeah\!
+
+## Legal Team Report - Jilayne/Paul
+
+  - continue to work on old issues, happy to have GSoC tooling
+  - no meeting today
+
+## Outreach Team Report - Jack
+
+  - making updates to website, working through transition to WordPress
+  - Gary and Steve working on updates to License list part of the
+    website and making sure
+  - Shane from OpenChain has joined outreach to help spread the wordJL
+
+## Attendees
+
+  - Kate Stewart, Linux Foundation
+  - Dennis Clark
+  - Jeremiah Foster
+  - Alexios Zavras
+  - Steve Winslow
+  - Mark Atwood
+  - Paul Madick
+  - Mark Gisi
+  - Kevin Miller
+  - Gary O’Neall
+  - Scott Lamons
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-10-04.md
+++ b/general/2018/2018-10-04.md
@@ -1,0 +1,71 @@
+  - Attendance: 8
+  - Lead by Phil Odence
+  - Minutes of Sept meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - Focus on multiple formats
+          - How do deal with XML, JSON, YAML
+          - Proposal to link to software heritage identifies
+              - SW heritage- presentation came out recently on how code
+                should be ID’ed in repos
+              - Seems to make sense to extend references to point to
+              - General agreement on last tech call
+  - Tooling
+      - Got integrated on line tools up
+          - License submittal
+          - XML editor
+          - Beta quality, ready to go.
+            <http://spdxtools.sourceauditor.com>
+  - GSOC has worked very well
+      - Should thank Google
+          - Post on Website
+          - Could use some social media
+          - Topic for Outreach
+      - May want to point projects to FSFEurope software reuse site
+        which advocates SPDX <https://reuse.software/>
+          - Would be a good credibility builder
+          - The link is on the site, but not easy to find
+  - Other Groups
+      - NTIA- Government group defining a BoM standard
+      - Prototype work in health care
+          - Fingers crossed that they will use SPDX
+      - SWID
+          - Active discussion
+          - Mapping fields between SPDX an SW
+      - Other groups may be able to use our use cases
+          - They are wrestling with what is a components
+          - Also, how a company can keep their own supplementary license
+            list
+              - Can do via a SPDX doc that is just licenses and make
+                external reference to
+          - Steve W will help out
+
+## Legal Team Report - Jilayne
+
+  - New license backlog
+      - Trying to clear out for next release
+      - Looking forward to new tooling
+      - Could use testing help
+      - Need some Python help on the tools
+          - Mostly fixing up formatting stuff
+
+## Outreach Team Report - Jack
+
+  - Little activity
+  - Regrouping
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Matthew Crawford, ARM
+  - Jilayne Lovejoy
+  - Jack Manbeck, TI
+  - Steve Winslow, LF
+  - Mark Atwood, Amazon
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-11-01.md
+++ b/general/2018/2018-11-01.md
@@ -1,0 +1,67 @@
+  - Attendance: 6
+  - Lead by Phil Odence
+  - Minutes of Oct meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - SEVA discussions
+          - Looking at fields that we might incorporate
+              - Security
+              - Evidence
+          - Idea is to bring in as a separate section
+          - Good Progress
+      - Some discussions with NTIA Group as well
+          - SWID
+      - May start using the security mailing list soon
+  - Tooling
+      - Multiple formats
+          - Challenges solves
+          - XML, JSON, YAML, Tag value, RDF
+      - Attention back to updating tooling with spec
+      - Some concern about file sizes with certain packages/formats
+          - May simply be an issue of LOTS of files
+      - Generating License List
+          - Didn’t work perfectly
+          - Giving another run
+      - Updating tooling for license submittal/editing
+          - A few bugs need to be worked around
+
+## Legal Team Report - Jilayne
+
+  - There’s a fair backlog of issues to work through
+      - Ongoing process
+  - 3.3 Is out
+      - Started new practice of release notes
+  - Tooling and new request system has to be nailed down
+      - People are going through multiple paths/processes
+      - Need to standardize
+      - Tooling is close
+          - Need a few more text fields
+          - All submissions seem to come from Gary
+  - License inclusion guidelines
+      - Inbound request regarding open hardware languages
+      - Already included open data license
+      - May need to revisit inclusion guidelines
+  - OSI discussion about naming issues with SPDX
+      - Need to find opportunity for better collaboration
+
+## Outreach Team Report - All
+
+  - Seems to be a lot more use of SPDX in the wild than we are aware of
+      - How do we run down and catalog?
+      - Wonder if it’s time for another poll
+          - Last poll results:
+            <https://spdx.org/sites/cpstandard/files/pages/files/spdx_survey_results_may_2013.zip>
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Andrew Katz, Orcro
+  - Jilayne Lovejoy
+  - Steve Winslow, LF
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2018/2018-12-06.md
+++ b/general/2018/2018-12-06.md
@@ -1,0 +1,40 @@
+  - Attendance: 4
+  - Lead by Gary O'Neall
+  - Minutes of Nov meeting approved
+
+## Legal Team Report - Paul
+
+  - Linux Kernel Enforcement statement was discussed (and continues to
+    be discussed on the legal mailing list)
+      - Discussion on whether to add the statement as an SPDX license
+        "exception"
+      - Discussion was well represented with members of the Software
+        Freedom Conservancy and Red Hat present
+  - Discussing changing language or term for "exception"
+      - Considering "modifier"
+      - Language for the current exception is planned to be updated
+
+## Tech Team Report - Gary
+
+  - Currently focused on adding security vulnerability information
+      - Working with SEVA which has created an XML Schema to represent
+        NIST National Vulnerability Database information
+      - Working with NIST and SWID organization to normalize the package
+        information
+      - Request was made to make sure we also include remediation
+        information
+      - Request was made to include weakness enumeration
+
+## Outreach Team Report - All
+
+  - No updates from the outreach team
+
+## Attendees
+
+  - Gary O’Neall, SourceAuditor
+  - Mark Atwood, Amazon
+  - Paul Maddick, Dimension Data
+  - Mark Baushke, Juniper Networks
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-01-03.md
+++ b/general/2019/2019-01-03.md
@@ -1,0 +1,118 @@
+  - Attendance: 15
+  - Lead by Phil Odence
+  - Minutes of Dec meeting approved
+
+## Guest Presentation, JC Herz
+
+  - Background
+      - Years of working with companies and DOD in open source
+  - The Issues/concerns
+      - License issues- SPDX handles well
+      - Concerns about security close on the heels
+      - Compliance is an additional step- Jumping through the hoops to
+        document
+  - SEVA Software Evidence Archive
+      - Elements
+          - Serves S-BOM function
+          - Augments with content that needs to travel with software
+          - Therefore allowing compliance work to be automated
+          - Freeing up valuable resources to do what they are supposed
+            to do
+          - Can apply to a single component or a full application, so
+            SEVA doesn’t distinguish
+      - Format Issue
+          - Customers required XML, beyond SEVA JSON
+          - To be useable by a highly secure facility, data has to be
+            hardened for which XML is better suited
+          - Can be constrained and format can be verified (and extended)
+  - SPDX and SEVA Overlap
+      - License Info
+          - For the most part SPDX handles beautifully
+              - Government also needs to distinguish government open
+                source
+              - A little more information about state of software (e.g.
+                pre-release)
+      - Security extra needs
+          - Some concern about spurious vulnerabilities
+          - Answer is to extend a BoM to include patch info, etc
+          - End of life indicator
+          - They take SPDX familiar thing and provide some extensibility
+      - How to name “supplier”?
+          - Working with Kate
+          - OSS organization for example
+          - A bank’s black list
+      - Vulnerabilities
+          - Key requirement for vulnerabilities info in SBOM, although
+            just a link might make more sense
+              - Reason is “audit” function. What you knew when. So needs
+                a time stamp.
+              - Bureaucratic are not going to change in favor of
+                something that makes more sense for developers
+              - Concerns that this will get worse over time
+  - Other Side - Logistics
+      - Moving and shipping of SW/chain of custody- Where did it come
+        from exactly
+          - Not something OSS community has had to worry about
+          - Bad mirror issue, for example.
+      - Signed? Timestamp? Delivery date and time for software.
+          - Something like FedEx analogy
+      - Package URL helps identify
+  - Q\&A
+      - What can SPDX group do?
+          - JC thinks that they should open source SEVA
+              - Could contribute to LinuxF perhaps
+          - Understand and need to balance needs of OSS consumers and
+            dev communities
+              - Don’t want to burden them
+              - Automate
+          - Challenge- How to distinguish enterprise quality OSS vs. pet
+            projects
+
+## Tech Team Report - Kate/Gary
+
+  - Tools
+      - Starting to plan for GSoC submissions with Gary/Kate
+      - Steve has been trained on releasing License list, so Gary now
+        has backup
+      - Steve has been working on some new tools for summarizing the
+        SPDX\_license\_ids based on a new SPDX go library - currently
+        its just supporting TV, but he hopes to add in the other formats
+  - Specification
+      - Gary & James have been working through SeVA XML and working
+        through how it can be added.
+
+## Legal Team Report - Jilayne
+
+  - License List
+      - V3.4 out before Christmas
+          - Big success to not have to scramble through holidays
+          - Release notes in the GitHub repo
+      - Instructions for requesting now live in Repo as well
+          - Leverage GSOC work has been automated.
+      - New frontier- Getting open hardware licenses on list
+          - Expanding definition of what goes on the list
+
+## Outreach Team Report
+
+  - None this month
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy
+  - Steve Winslow, LF
+  - Alexios Zavras, Intel
+  - Luis Villa, Tidelift
+  - Jams Neushal, Neushul Solutions
+  - Matthew Crawford, ARM
+  - Kevin Nelson, Optim Tech UHG
+  - Dennis Clark, NexB
+  - Thomas Steenbergen, HERE
+  - Bradlee Edmondson, Harvard
+  - Gary O’Neall, SourceAuditor
+  - Nicholas Toussaint, Orange
+  - JC Herz, Ionchannel
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-02-07.md
+++ b/general/2019/2019-02-07.md
@@ -1,0 +1,106 @@
+  - Attendance: 10
+  - Lead by Phil Odence
+  - Minutes of Jan meeting approved
+
+## Tech Team Report - Kate/Gary
+
+  - Tools
+      - Applying to participate in GSoC for 2019
+          - Variety of proposals on Wiki:
+            <https://wiki.spdx.org/view/GSOC/GSOC_ProjectIdeas>
+          - We’ll hear back end of Feb 26 if we are selected.
+      - tools-golang
+          - Steve Winslow has contributed new Go libraries to SPDX to
+            support generating SPDX documents see:
+            <https://github.com/spdx/tools-golang>
+          - He also created a tool to scan the kernel looking for
+            SPDXIDs that Kate used for her talk at LCA to get latest
+            status of the Kernel.
+          - Go Steve\!
+  - Specification
+      - Discussing Mark Atwood's Idea for alternative name spaces for
+        companies licenses that are not open source.
+          - Spec can handle via "LicenseRef-"
+          - What guidance do we provide?
+      - Unblocking contributions to 2.2
+          - Kate is working with Thomas to unblock contributions to 2.2
+            (switch master over to 2.2 from 2.1.1)
+          - We will be starting to take pull requests into 2.2 spec, for
+            features approved, please assign issue to yourself if you
+            want to write up the feature.
+          - Focus for next few months
+  - Started a tech call in Asia friendly time
+      - Call will be on 2nd Tuesday of each month 10am Japan/12pm
+        Australia (and 5pm PST Monday) on
+        <https://www.uberconference.com/SPDXTeam>
+      - First topic will be SPDX-lite discussion that's started in the
+        OpenChain workgroup.
+
+## Legal Team Report - Jilayne
+
+  - License List
+      - New process and links posted
+          - Published policy says advocates need to stay engaged or
+            requests may drop off the radar
+          - GitHub process seems like a great way to handle requests
+      - Need work outside the call
+
+## Outreach Team Report - Jack
+
+  - LinuxCon Aussie Presentation
+      - Included Stat1/3 of files in Kernel have SPDX in them
+      - Great momentum
+  - Panel at FOSDEM on OSS Compliance tooling
+      - Alexios attended
+          - Lots or proposals on tools, so organizers turned into a
+            panel w/ Bradley K moderating
+          - Theme was need for interoperatblity
+      - Video will be published
+      - Alexios also mentioned that at recent copyleft conference, SPDX
+        came up in every talk
+  - Website
+      - Looking into status of move to Wordpress with LF
+      - Request a new license page has been directed to GitHub repo
+  - Need an Outreach reboot
+
+## Cross Functions
+
+  - Alternate name space
+      - Basics
+          - Many companies have source available non-OSS licenses
+          - Would be good for companies to be able to have standard
+            local names
+      - Proposal is to use DNS
+          - Addresses issues with flat, first come first served
+          - DNS will be around for a long time
+          - Allows companies to self-assign
+          - Internationalized by default
+          - Immediately readable
+          - Leading dot clearly differentiates from SPDX standard names
+          - Challenges
+              - Doesn’t cary text
+              - Companies’ names may change through M\&A and may lose
+                domains in the process
+              - How to ensure that a company doesn’t change license text
+      - Sentiment is in favor of
+          - Retain “License Ref” prefix
+          - Standardize on place to log license data
+          - In a one-license SPDX doc
+          - Mark will mock up with one of the Amazon licenses,
+            collaborating with Kate
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Kate Stewart, Linux Foundation
+  - Mark Atwood, Amazon
+  - Jilayne Lovejoy
+  - Gary O’Neall, SourceAuditor
+  - Dennis Clark, NexB
+  - Alexios Zavras, Intel
+  - Jack Manbeck, TI
+  - Mark Baushke, Juniper
+  - David Ryan
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-03-07.md
+++ b/general/2019/2019-03-07.md
@@ -1,0 +1,41 @@
+  - Attendance: 5
+  - Lead by Phil Odence
+  - Minutes of Feb meeting approved
+
+## Tech Team Report - Gary
+
+  - Tools
+      - Google Summer of Code
+          - Accepted again
+          - Lots of activity from students
+      - \*Plenty of ideas
+  - Spec
+      - Jack jumped in to help with publishing from GitHub
+      - Started up APAC SPDX call
+          - Lots of interest from Automotive
+          - Discussion of “SPDX Lite”
+              - “Files analyzed” field set to zero changes many required
+                fields to option
+      - Will be monthly
+
+## Legal Team Report - Paul
+
+  - License List
+      - Working through new licenses, normal stuff
+
+## Outreach Team Report
+
+  - No update.
+
+## Cross Function
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Steve Winslow, LF
+  - Mark Atwood, Amazon
+  - Paul Madick, Dimension Data
+  - Gary O’Neall, SourceAuditor
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-04-04.md
+++ b/general/2019/2019-04-04.md
@@ -1,0 +1,58 @@
+  - Attendance: 18
+  - Lead by Phil Odence
+  - Minutes of March meeting approved
+
+## Special Presentation - Gary/Steve
+
+  - SPDX: Bridging the Compliance Tool Gap
+  - <https://events.linuxfoundation.org/wp-content/uploads/2018/07/SPDX-Bridging-the-Compliance-Tooling-Gap.pdf>
+
+## Tech Team Report - Gary
+
+  - Spec
+      - Starting to put out 2.1.1 in pdf form
+          - Kudos to Jack
+      - Starting in on 2.2
+  - Tools
+      - GSoc
+          - Very active
+          - Lots of students and mentors
+          - Good project
+
+## Legal Team Report - Jilayne/Paul
+
+  - License List
+      - 3.5 Release out\!
+          - 7 new licenses and exceptions
+          - including 3 open hardware licenses
+              - More open hw planned for 3.6
+
+## Outreach Team Report - Jack Manbeck
+
+  - Rethinking a bit and redefining
+  - Survey is next step
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Steve Winslow, LF
+  - Nisha Kumar, VMWare
+  - Dave Huseby, LF
+  - Alexios Zavras, Intel
+  - Nicolas Toussaint, Orange
+  - Mark Atwood, Amazon
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Jilayne Lovejoy
+  - Philippe Ombrédanne- nexB
+  - JC Herz, Ion Channel
+  - Andrew Sinclair, Canonical
+  - Paul Madick, Dimension Data
+  - Jack Manbeck, TI
+  - Michael Herzog- nexB
+  - Mark Baushke, Juniper
+  - Stephanie, Qualcomm
+  - Uwe, Qualcomm
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-05-02.md
+++ b/general/2019/2019-05-02.md
@@ -1,0 +1,64 @@
+  - Attendance: 15
+  - Lead by Phil Odence
+  - Minutes of April meeting approved
+
+## Special Presentation - Aaron/Jilayne
+
+  - FINOS Presentation on new handbook:
+    <https://github.com/finos-osr/OSLC-handbook>
+      - Discussion on including License Exceptions in the handbook
+          - Gary to contribute to issue on license exceptions, proposal
+            for how to write the exception YAML so it can be included in
+            tooling for license expressions
+  - ( Suggestion to coordinate with reuse.software
+      - Suggestion to reach out to OASDL
+
+## Tech Team Report - Gary
+
+  - GSOC all 8 slots granted, projects will be announced on May 6
+  - Jack got the PDF generation working for the spec, we will be
+    transitioning to the github based spec process (thanks Jack\!)
+  - 2.1.1 based on Thomas' Github work and Jack's PDF work will be out
+    for review soon - 2 week review
+  - Tool bake-off and SPDX generation comparison proposed for October at
+    European OSS Europe France
+      - Anyone interested in participating should contact Gary or Kate
+
+## Legal Team Report - Jilayne/Paul
+
+  - License List
+      - Callout for help, request for more contributors and participants
+        in the calls
+      - Agenda for today
+          - Improving the documentation - make it easier to find key
+            information (like inclusion principles), especially for
+            people contributing first time/requesting a new license
+          - Discussion scheduled for today’s call regarding the
+            inclusion principles, e.g., OSI approved but if OSI rejects,
+            do we reject?
+              - We do reject non-open source licenses today, but do we
+                want to include licenses commonly found in the wild?
+
+## Outreach Team Report
+
+  - None
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Denver Gingerich, SFC
+  - Aaron Williamson, FINOS
+  - Jilayne Lovejoy
+  - Steve Winslow, LF
+  - Gary O’Neall, SourceAuditor
+  - Kate Stewart, Linux Foundation
+  - Alexios Zavras, Intel
+  - John Horan, next
+  - JC Herz, Ion Channel
+  - Dave McLoughlin
+  - Paul Madick, Dimension Data
+  - Philippe Ombrédanne- nexB
+  - Mark Atwood, Amazon
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-06-06.md
+++ b/general/2019/2019-06-06.md
@@ -1,0 +1,57 @@
+  - Attendance: 12 (attendance list at bottom)
+  - Lead by Paul Madick
+  - Minutes of May meeting approved
+
+## Tech Team Report - Gary
+
+  - Spec No issues remaining to latest spec, 8 GOSC students approved
+    and working. Looking forward to new tools this summer. Lots of new
+    projects adopting SPDX and Linux kernel clean up of licensing still
+    working (about 2/3 through). Making great progress.
+  - Tools
+
+## Legal Team Report - Jilayne/Paul
+
+  - License List
+  - GSOC student on last call. Great information. Legal Meeting minutes
+    has the description, take a look if you are interested or would like
+    to provide input.
+  - Reworking the license inclusion guidelines and moving into github
+    repository in the documentation folder. Please weigh in if you are
+    interested in more licenses. Still looking for more volunteers to
+    move license submissions into license approvals.
+  - A big welcome to new co-lead of legal team Steve Winslow and a big
+    thank you to Karen for her years of stewardship as she steps away
+    from the co-lead position.
+
+## Outreach Team Report - Jack Manbeck
+
+  - Not a lot going on now, but working on a survey. Intention is to
+    send the survey to companies to see where they are at in
+    using/implementing SPDX. Maybe include some community in survey, but
+    not sure yet.
+
+## General Items
+
+  - Conversation: are we meeting for summer LF event in SD. Not
+    currently, but Kate will look into getting meeting room for ½ day,
+    etc. Jack, Paul, Kate, Steve and others are potentially available to
+    attend at least one day in SD.
+
+## Attendees
+
+  - Alexios Zavras, Intel
+  - JC Herz, Ion Channel
+  - Dave McLoughlin
+  - Paul Madick, Dimension Data
+  - Jilayne Lovejoy
+  - Steve Winslow, LF
+  - Kate Stewart, Linux Foundation
+  - Alexios Zavras, Intel
+  - Philippe Ombrédanne- nexB
+  - Jack Manbeck
+  - Mike Herzog
+  - Mark Atwood
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-07-11.md
+++ b/general/2019/2019-07-11.md
@@ -1,0 +1,76 @@
+  - Attendance: 14
+  - Lead by Phil Odence
+  - Minutes of June meeting approved
+
+## Special Presentations - Xavier Figouoa/ Philip Ekong Obie, GSoC
+
+  - Python Library- Adding support for more formats
+  - Generating SPDX docs from IDs in code
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - All known issues are addressed in 2.2
+      - Under discussion:
+          - Idea of a short format for copyrights ala license IDs from
+            FSFE
+              - Would be added as an appendix (like license IDs)
+              - Could use a joint tech/legal teams call
+          - Exploring branching strategy
+          - Pared down version, defining minimal subset (from Japan work
+            group)
+              - Still SPDX compliant as it will utilize mandatory fields
+              - Part of the spec
+              - Important to communicate that; it’s not a fork
+  - Tools
+      - GSoC
+          - 8 projects total (a record)
+          - Great progress, all passed first evaluations
+      - Flurry of tooling work with the new license list
+          - Better matching/copyright matching
+          - License format improvements
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+  - License List
+      - 3.6 version went live yesterday
+          - 10 new licenses and exceptions
+          - Other mark up and doc updates
+      - Attention now turning to 3.7
+      - Other topics of discussion already covered.
+  - Namespace Project
+      - Need to make clear the difference between LL and NS registry
+      - NS is an option for rejected licenses
+      - Could be a stop before being accepted
+
+## Outreach Team Report - Kate
+
+  - Shane has readied the survey
+      - Based on input from Phil, Jack, Kate, Gary
+      - Will go do the General Meeting mailing list
+
+## Cross Functional -
+
+  - Will designate one Tech Call per month to include Legal Team
+      - Third one of the month
+      - Starting next week
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Jilayne Lovejoy, Canonical
+  - Steve Winslow, LF
+  - Gary O’Neall, SourceAuditor
+  - Kate Stewart, Linux Foundation
+  - Philippe Ombrédanne- nexB
+  - Alexios Zavras, Intel
+  - Michael Herzog- nexB
+  - David Ryan
+  - Dave McLaughlin, Rogue Wave
+  - Paul Madick, Dimension Data
+  - Mark Atwood, Amazon
+  - Xavier Figouoa
+  - Philip Ekong Obie
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-08-01.md
+++ b/general/2019/2019-08-01.md
@@ -1,0 +1,101 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+  - Minutes of July meeting approved
+
+## Special Presentations - Umang Taneja, Tanjong Smith, GSoC
+
+  - Umang
+      - License submittal workflow automation
+          - Aim is to enhance user experience
+          - Compare submitted text against existing licenses to see if
+            there’s duplication or close match
+          - Problems he’s trying address
+              - What if the license is on the list, proposed,
+                rejected…or a close match to one of those
+              - Current XML formatting- word-wrap doesn’t match license
+          - Also creating/documenting an API
+      - Tasks:
+          - Create API- use without logging in, so can be accessed by
+            other tools
+          - Create License Matcher- looks for exact and close matches
+              - Returns all matches and close matches
+          - Compare with not accepted as well as rejected licenses.
+              - Reports appropriately according to match
+              - Relies on user input regarding whether to go ahead with
+                submittal
+          - Improve formatting of generated license
+      - Screenshots available at:
+        <https://docs.google.com/document/d/1NMcLZVXxBV2PZobPJh1OugbCfC2d8kbAOX4m4TauEYk/edit?usp=sharing>
+      - Some discussion of how the workflow should work with close
+        matches
+      - Aiming for demo in future Legal Team meeting
+
+<!-- end list -->
+
+  - Tanjong
+      - License namespace
+          - A way to name valid licenses outside of the License List
+          - Created namespace and UI
+          - Also a mechanism for turning into a license request
+          - Took feedback from the joint/legal team meeting
+
+## Tech Team Report - Kate/Gary
+
+  - Spec
+      - Progress on Appendix for including other fields in the source
+        like the license ID
+          - Worked with Legal team members and general agreement to keep
+            scope at file level
+          - Recommend using existing Tags with SPDX prefix, and
+            expectation that format follows fields.
+          - Motivation is that this makes it easier for tools to pick up
+            data accurately from source.
+      - SPDX document generation from project sources (demo'd last
+        month)
+          - Philip is looking for projects to try the tool on, if you
+            have some you want to experiment with, please contact him.
+  - Tools
+      - GSoC
+          - Continues to go very well
+          - All students passed second evaluation
+      - Looking for feedback from community:
+          - License matching algorithm approaches
+              - Some encoded rules
+              - Some depended on XML markup
+              - Should we encode in XML or handle programmatically?
+                (Discuss with Gary)
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+  - License List
+      - 3.6 version went out last month
+      - Working issues in 3.7
+          - Good input/support from Tech Team
+      - Recent meetings have been joint with Tech Team
+          - Very helpful at this point
+
+## Outreach Team Report - Kate
+
+  - Shane has readied the survey
+  - Phil to reach out to Shane and Jack and determine deployment plan.
+
+## Cross Functional -
+
+  - None
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Matthew Crawford, ARM
+  - Umang Taneja, GSoC
+  - Tanjong Smith, GSoC
+  - Steve Winslow, LF
+  - Gary O’Neall, SourceAuditor
+  - Kate Stewart, Linux Foundation
+  - Paul Madick, Dimension Data
+  - Mark Atwood, Amazon
+  - Jilayne Lovejoy, Canonical
+  - Jack Manbeck, TI
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-09-05.md
+++ b/general/2019/2019-09-05.md
@@ -1,0 +1,110 @@
+  - Attendance: 17
+  - Lead by Phil Odence
+  - Minutes of Aug meeting approved
+
+## Special Presentations - Hiro Fukuchi, Sony
+
+  - SPDX- Lite
+      - Open Chain Japan Work Group
+          - Member companies- Toyota, Denso, Panasonic, Pioneer, Sony,
+            Fujitsu, Olympus, Renesas
+      - Common Problem- Can’t get OSS information from suppliers (HW
+        vendors, ODMs, SOC, partners…in Asia (China/Taiwan) and Japan
+          - They don’t have complete information
+          - Don’t have the tools to generate and evaluate
+      - SPDX Lite is part of guidelines
+          - Fits in at a fairly high level of maturity
+              - OpenChain - “Making Process”
+              - SPDX (and OSS tooling) - “Improving Process”
+              - Most suppliers are at low levels of maturity
+          - Looking not to fork, but to expand usage of SPDX Lite
+      - Lite Description
+          - Subset of SPDX
+          - Minimum requirement
+          - Can be manually generated
+          - Proved in actual business use
+      - Scenarios
+          - 1 Unskilled suppliers
+              - Useful at a lower level of maturity than SPDX requires
+          - 2 Non-engineering Staff
+              - More understandable by Legal and Procurement staff.
+          - Skilled suppliers would still use full SPDX
+              - OpenChain compliant suppliers would be sophisticated
+                enough
+      - Question: Is SPDX Lite fully SPDX compliant
+          - Yes, all mandatory fields are included in SPDX Lite plus
+            some of the optional fields may be included.
+
+## Tech Team Report - Gary
+
+  - Spec
+      - Being worked in a GitHub repo
+          - Set up for pull requests for 2.2
+          - Anyone who has ideas or proposed changes, please submit as a
+            pull request
+          - One in place is SPDX Lite
+              - Proposal is as an Appendix
+              - Thought is a profile for a specific use case
+              - Could be first of a number of profiles
+  - Tools
+      - Successful conclusion to GSoC
+          - All passed
+          - A number of new libraries including Python, Golang
+          - Mentors and students were great
+          - Record number of projects
+      - Challenge now is integrating and putting into production
+          - All legal team tools have been submitted as pull requests
+              - Should be up and running in a month or so.
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+  - Legal Team License Submittal Demo (GSoC)
+      - Video and minutes available
+      - Need to update contribution instructions
+  - Team call today
+  - License List
+      - 3.7 release at end of month
+          - Fewer licenses in release that some recents
+      - Recent discussions have been more high level on principles than
+        specific licenses
+
+## Outreach Team Report - Jack
+
+  - Survey
+      - Has been out for a few months
+      - 37 responses so far
+      - Will make one more pass
+      - Looking at presenting at Gen Meeting in Nov
+  - Philipe has been talking to the Python community about using SPDX
+    License IDs and expressions in Python package manifest
+      - Could be a model for other communities
+          - …some of which have been using formally or informally
+          - Potentially high leverage
+          - RUST and Go are using sporadically
+
+## Cross Functional -
+
+  - None
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Steve Winslow, LF
+  - Gary O’Neall, SourceAuditor
+  - Jack Manbeck, TI
+  - Nicolas Toussaint, Orange
+  - Mark Atwood, Amazon
+  - Jilayne Lovejoy, Canonical
+  - Hiro Fukuchi, Sony
+  - Shinsuke Kato, Panasonic
+  - Philippe Ombrédanne- nexB
+  - Michael Herzog, NexB
+  - Patrice-Emmanuel Schmitz, Trasys International, European Commission
+  - Richard Fontana, Red Hat
+  - Mark Baushke, Juniper
+  - Paul Madick, Dimension Data
+  - Nisha Kumar, VMWare
+  - David Marr, Qualcomm
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-10-03.md
+++ b/general/2019/2019-10-03.md
@@ -1,0 +1,65 @@
+  - Attendance: 10
+  - Lead by Kate Stewart
+  - Minutes of Sept. meeting approved
+
+## Legal Team – Steve
+
+  - Working on the next release – 3.7
+      - Looking for volunteers to put together the XML and test files
+      - Targeting next week
+      - Small release
+  - Trend – licenses that don’t strictly follow the open source
+    definition (e.g. source available but some proprietary restrictions)
+      - Discussion on whether these should be included and update the
+        license inclusion principles – more information available at
+        <https://github.com/spdx/license-list-XML/issues/925>
+      - Looking to make a decision early in the 3.8 release
+
+## Tech Team Report - Kate
+
+  - SPDX Lite
+      - Changes are added as a pull request and will likely be accepted
+        soon
+  - Security fields to be added in 2.2
+      - Working with Uday on a Google Doc which will be turned into a
+        pull request
+      - Coordinating with Todo group and others
+  - Looking at adjusting the minimum required fields to allow for
+    security use cases without all the licensing
+      - General support for reducing the number of mandatory fields
+      - Steve will bring to the legal team the discussion on removing
+        the of the mandatory legal related fields
+  - GSoC – completed, all students passed
+      - SPDX Tool updates which include the GSoC contributions are all
+        checked in
+      - Plan to update the spdxtools website within the next 2 weeks
+      - Amazon will start using the namespace features soon
+  - Request to add specification for the namespace
+      - Mark agreed and will create a pull request
+      - The license ID web page can also be updated
+
+## Outreach Team Report - Jack
+
+  - Survey
+      - Working on summarizing the survey results
+
+## Cross Functional
+
+  - Several compliance and SPDX related talks planned for the Open
+    Source Summit Europe in Lyon at the end of the month
+
+## Attendees
+
+  - Steve Winslow, LF
+  - Gary O’Neall, SourceAuditor
+  - Jack Manbeck, TI
+  - Mark Atwood, Amazon
+  - Paul Madick, Dimension Data
+  - Nisha Kumar, VMWare
+  - Rose Judge, VMWare
+  - Matija Šuklje
+  - William Bartholomew, Github
+  - Dave McLoghlin, Rogue Wave
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2019/2019-12-05.md
+++ b/general/2019/2019-12-05.md
@@ -1,0 +1,70 @@
+  - Attendance: 10
+  - Lead by Phil Odence
+  - Minutes of Nov meeting- Lightly attended, no minutes kept
+
+## Tech Team Report - Kate/Gary
+
+  - SPDX 2.2
+      - moving on pull requests being merged/included.
+      - Tools for generating Multiple formats being tested (help
+        welcome).
+  - SPDX 3.0
+      - Identifying a common base (based on some of NTIA framing work)
+        with specific profiles (licensing, security, pedigree,
+        provenance, export)
+      - SPDX 2.2 would be a base+licensing profile.
+  - Related Groups
+  - OMG including part of the SPDX models, people regarding as a point
+    to add security information.
+  - NTIA phase 1 documents are published at <https://www.ntia.gov/sbom>
+    (SPDX is a recognized format there).
+  - NTIA phase 2 workgroups are forming, and there will be one on
+    "formats & tooling” (which will feature SPDX tools ;-) ) those
+    interested in participating in discussions on tooling and how to use
+    tools are welcome to subscribe at:
+    <https://lists.linuxfoundation.org/mailman/listinfo/ntia-sbom-formats>
+
+<!-- end list -->
+
+  - Tools
+      - nothing beyond above, mostly testing new formats
+
+## Legal Team Report - Paul/Steve
+
+  - Fairly quiet this Q, lighter participation
+      - 3.8 release will be light on new licenses
+  - Reviewing and updating license inclusion guidelines
+      - Should end up with broader inclusion at some level
+          - particularly for non-OSS licenses that include making source
+            available
+      - Good legal/tech team collaboration on 3.0
+          - One key topic is the license for the docs
+              - Currently CC0
+              - This has raised some concerns
+              - Dredging up historic rationale
+
+## Outreach Team Report
+
+  - Survey reminder went out.
+      - End of year down line.
+  - Pushing Jan meeting to 1/9.
+
+## Cross Functional -
+
+  - None
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Steve Winslow, LF
+  - Gary O’Neall, SourceAuditor
+  - Mark Atwood, Amazon
+  - Paul Madick
+  - Alexios Zavras, Intel
+  - Dave McLoughlin, Flexera
+  - Rose Judge, VMware
+  - Michael Herzog- nexB
+  - Philippe Ombrédanne- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-02-06.md
+++ b/general/2020/2020-02-06.md
@@ -1,0 +1,58 @@
+  - Attendance: 8
+  - Lead by Phil Odence
+  - Minutes of Dec meeting
+
+## Tech Team Report - Kate
+
+  - Spec
+
+<!-- end list -->
+
+  -   - Working on closing open pull requests in 2.2
+          - Should be frozen this month
+          - At which point we will commence a review period
+          - Goal is to get 2.2 out to catch up with the tools
+
+  - Tools
+    
+      - GSOC starting up again
+          - Gary, Kate and Phillippe are driving
+          - Could you some projects; add to wiki page
+      - That will free up for focus on next rev
+          - Main feature is generalized profiles for different SBoM
+            types
+      - Europe meet up
+          - Suggestions came back to legal team
+
+## Legal Team Report - Steve
+
+  - Finalizing additions for 3.8 release
+      - Should be out this weekend
+  - Expanding license inclusion guidelines
+      - In practical directions
+      - Team is aligned conceptually
+      - Need to get words down on paper
+      - Aiming to have in place to use as filter for 3.9 list
+  - Reviewing license expression syntax as well
+
+## Outreach Team Report
+
+  - Closed out the survey
+
+## Cross Functional -
+
+  - None
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Steve Winslow, LF
+  - Kate Stewart, Linux Foundation
+  - Jilayne Lovejoy, Canonical
+  - Jack Manbeck, TI
+  - Jim Hutchison, Qualcomm
+  - Kevin Nelson, UHG
+  - Nisha Kumar, VMware
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-04-02.md
+++ b/general/2020/2020-04-02.md
@@ -1,0 +1,94 @@
+  - Attendance: 19
+  - Lead by Phil Odence
+  - Minutes of April meeting
+
+## Guest Speaker- Allan Friedman, NTIA
+
+  - NTIA’s Multistakeholder SBOM Process
+      - Concerns about software supply chain risks have garnered more
+        attention and energy in the OSS community, industry, and
+        governments around the world. One natural starting point is a
+        greater expectation of transparency of software components and
+        dependencies. Any solution must scale up and down the software
+        supply chain, and across the incredibly diverse software
+        ecosystem, from modern CI/CD application development to critical
+        infrastructure and embedded systems. Over the past two years,
+        NTIA has helped a diverse set of stakeholders find a common
+        vision for a "software bill of materials" (SBOM) that has the
+        potential to scale as needed, and serve as a foundation for even
+        more innovation around software supply chain security and
+        quality. The SPDX community has played a key role in this
+        discussion, and emerged as a key standard. This presentation
+        will give an overview of the policy landscape, the progress
+        made, and the work yet to be done around SBOM. 
+      - Allan’s slides
+         https://drive.google.com/open?id=1KOsm6grnSZ5FsSnzTI9ybYT9m84F8Zfe
+
+## Tech Team Report - Gary & Kate
+
+  - Spec
+      - Wrapping up 2.2 spec
+          - NTIA's request for mechanism to illustrate Known unknowns
+            made it in
+      - 3.0 Visions
+          - William Bartholomew’s talk about profiles was great
+            (recorded)
+          - Santiago talk about linking artifacts and signing helped
+            clarify a lot of misconceptions (recorded)
+  - Tools
+      - Gary’s been working on 2.2 tooling
+          - Working on a complete rewrite to the java tools to support
+            multiple formats
+      - Google SoC
+          - 15 different submissions
+          - Google is looking for additional mentors on each project
+          - So, we need more mentors; contact Gary
+
+## Legal Team Report - Steve
+
+  - Finalized updates to license inclusion principles
+      - Mostly clarifications
+      - But also to broaden a bit for non-OSS source available licenses
+      - <https://github.com/spdx/license-list-XML/blob/master/DOCS/license-inclusion-principles.md>
+  - 3.9 list release has been pushed out a bit
+      - Were waiting for above
+      - <https://github.com/spdx/license-list-XML/issues?q=is%3Aopen+is%3Aissue+milestone%3A%223.9+release%22>
+  - In anticipation of 3.0 working on a licensing profile
+  - With Tech Team, updating back end of SPDX website to manage move
+    from Drupal to Wordpress
+      - Maintaining license URLs
+      - Static pages moving do a different domain.
+
+## Outreach Team Report - Jack
+
+  - Will be looking for help to update content for Website as per above
+  - Documenting comprehensive list of SPDX-related tooling
+
+## Cross Functional -
+
+  - None
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Alan Friedman, NTIA
+  - Rose Judge, VMware
+  - Steve Winslow, LF
+  - Kate Stewart, Linux Foundation
+  - Alexios Zavras, Intel
+  - Jack Manbeck, TI
+  - Jim Hutchison, Qualcomm
+  - William Bartholomew, GitHub
+  - Dave McLoughlin, Flexera
+  - Michael Herzog- nexB
+  - Alex Rybak, Flexera
+  - Gary O’Neall, SourceAuditor
+  - Paul Madick
+  - Brad Goldring, GTC Law
+  - David Wheeler, Linux Foundation
+  - Mike Dolan, Linux Foundation
+  - Bob Campbell, DXC
+  - Mark Atwood, Amazon
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-05-07.md
+++ b/general/2020/2020-05-07.md
@@ -1,0 +1,77 @@
+  - Attendance: 19
+  - Lead by Phil Odence
+  - Minutes of April meeting
+
+## Presentation - SPDX 2.2 Overview, Kate
+
+  - SPDX 2.2 is released\!
+  - Great job team
+  - <https://docs.google.com/presentation/d/1JGVS6vzGwueTDCBHWUNy9ItEFHZ5BwFZoUZsl7Ccxsw/edit#slide=id.p87>
+
+## Tech Team Report - Kate / Gary
+
+  - Spec
+      - See above
+  - Tools
+      - Just released java tools updating to 2.2
+          - Will be separate tool for new formats and will be migrating
+            that way in the next month or two
+          - Leaner, faster, more modern
+          - Python libs support new JSON today
+      - Maintaining full forward/backward compatibility
+  - GSoC
+      - Students will be joining
+      - They are getting oriented now
+      - Will start coding in a month
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+  - License List
+      - Release postponed to Mid-May so as not to clash with 2.2
+      - Another week of work on tagging remaining requests
+
+## Outreach Team Report - Jack
+
+  - Twitter
+      - @SPDXTeam is now a Twitter handle
+
+## Cross Functional - Steve
+
+  - Website
+      - Existing website is on Drupal
+      - All LF stuff moving to Wordpress
+          - Some issues with auto generated pages on Wordpress
+          - Critical to maintain URLs
+          - Solution- License and RDF will stay at their current
+            locations
+          - New site will be spdx.dev
+              - Full redirects will be in place
+              - So no issues for users with migration
+          - Contents has been largely maintained
+              - Some cleanup of formatting and organization
+          - Plan to improve content over time.
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Mark Atwood, Amazon
+  - Steve Winslow, LF
+  - Kate Stewart, Linux Foundation
+  - Alexios Zavras, Intel
+  - David Wheeler, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Matthew Crawford, ARM
+  - Jack Manbeck, TI
+  - Bradlee Edmondson, Harvard
+  - Hal Hearst, Synopsys
+  - Anisha Srivastava, Student
+  - Takashi Ninjouji, Toshiba
+  - Paul Madick
+  - Brad Goldring, GTC Law
+  - William Bartholomew, GitHub
+  - Jilayne Lovejoy, Canonical
+  - Matije Suklje, Liferay
+  - Philippe Ombrédanne- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-06-04.md
+++ b/general/2020/2020-06-04.md
@@ -1,0 +1,84 @@
+  - Attendance: 17
+  - Lead by Phil Odence
+  - Minutes of May meeting
+
+## Presentation - Health Care PoC & NTiA, Ed Heierman, Abbott Labs
+
+  - Discussed medical device manufacturers’ development of
+    proof-of-concept SBOMs using SPDX
+  - Demonstrated tag-value SPDX file, and tooling to generate through
+    Excel spreadsheets as well as an open online tool
+      - the latter is also able to import existing SPDX files
+  - He will make slides available.
+
+## Tech Team Report - Kate / Gary
+
+  - GSoC
+      - Coding period just started
+      - Also doing funding for one student through CommunityBridge
+        Mentorships, will start in July
+  - Tools
+      - Java tooling updated to released 2.2 spec
+      - Python – partial implementation, still in progress
+  - Spec
+      - v2.2 published
+      - now focusing on refactoring into specific profiles for v3.0 –
+        security; revised licensing profile
+      - also transforming v2.2 spec into format for submission to ISO
+      - if looking at repo, will be seeing churn from section
+        renumbering, table formats, etc. to align with ISO guidelines –
+        will be v2.2.1
+      - will use transformed version as basis for v3.0
+      - active areas: security, licensing, base, integrity, usage rules
+        (lifecycle of software, etc.)
+      - Tuesday weekly calls as well as out-of-band calls
+      - SPDX Japan calls – once a month, happening second Monday of each
+        month – 8PM Eastern, for now reach out to Kate for invite (will
+        document on website)
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+  - License List
+      - v3.9 released in May
+      - Announcement: <https://spdx.dev/license-list-v3-9-released/>
+      - Continuing with v3.10 work, good involvement from new
+        participants
+
+## Outreach Team Report – Steve (Jack unable to attend)
+
+  - Website
+      - static website migrated from Drupal to WordPress, now at
+        <https://spdx.dev>
+      - old license list URLs remain the same under
+        <https://spdx.org/licenses>
+      - redirects should be seamless from old to new URLs (and vice
+        versa)
+      - now turning to updating old content on the static pages, etc.
+      - any issues, suggestions, feedback can be emailed to Jack, Kate
+        and Steve, or submitted at
+        <https://github.com/spdx/spdx-website/issues>
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Ed Heieman, Abbott Labs
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Steve Winslow, LF
+  - Alexios Zavras, Intel
+  - Takashi Ninjouji, Toshiba
+  - Peter Shin, Canvass Labs
+  - Jilayne Lovejoy, Canonical
+  - Emmanuel Tournier, Black Duck/Synopsys
+  - David Wheeler, Linux Foundation
+  - Mike Dolan, Linux Foundation
+  - Ed Heierman, Abbott Labs
+  - Mark Atwood, Amazon
+  - Jeremiah Foster, Purism
+  - Mark Baushke, Juniper
+  - McCoy Smith, LexPan
+
+• • •
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-07-02.md
+++ b/general/2020/2020-07-02.md
@@ -1,0 +1,55 @@
+  - Attendance: 11
+  - Lead by Gary O'Neall
+
+## Presentation - Google Summer of Code Project Concurrent RDF Parser - Rishabh Bhatnagar
+
+  - Presentation available at
+    <https://docs.google.com/presentation/d/17LSMZMi6GXwmrCv7qIpQz6pbGdRjjdQQDdOqbVPqpR0/edit#slide=id.g822549bbf3_1_0>
+  - Demo available at <https://gordf.herokuapp.com/>
+  - Rishabh-walked through the architecture of the plan for his GSoC
+    project and how its going to work with golang
+  - Can be used as a general RDF parser as well.
+
+## Tech Team Report - Kate / Gary
+
+  - Spec update - Kate
+      - 2.2.1 —\> ISO see: <https://spdx.github.io/spdx-spec/v2-draft/>
+          - Any remaining issues please submit by 7/7, frozen after
+            that.
+      - 3.0 progress moving forward in joint calls.
+  - Tools - Gary
+      - 1st phase of coding for GSOC
+      - Added community bridge program with 2 additional project
+          - 2 CB projects started - Python libraries and license
+            matching algorithm in Python
+
+## Legal Team Report - Steve/Paul
+
+  - Experimenting to use etherpad —\> github repo. for the meeting
+    minutes
+  - Working towards 3.10 next release of License list
+  - Joint meetings with tech on SPDX 3.0 licensing profile.
+
+## Outreach Team Report – Steve (Jack unable to attend)
+
+  - Some issues for website has been fixed
+  - Please log any issues into
+    <https://github.com/spdx/spdx-website/issues>
+  - Help is requested for review and any suggested fixes
+
+## Attendees
+
+  - Gary O’Neall
+  - Kate Stewart
+  - Alexios Zavras
+  - Steve Winslow
+  - Rishabh Bhatnagar
+  - Brad Goldring
+  - Mark Atwood
+  - Paul Madick
+  - Rohit Lodha
+  - Anisha Srivastava
+  - Mark Baushke
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-08-06.md
+++ b/general/2020/2020-08-06.md
@@ -1,0 +1,64 @@
+  - Attendance: 14
+  - Lead by Phil Odence
+  - Minutes of Aug meeting
+
+## Presentation - GSoC Smith Tanjong Agbor
+
+  - Validating License Cross References
+
+## Tech Team Report - Kate / Gary
+
+  - Spec
+      - 2.1 is in good shape
+          - Ready to submit to ISO
+          - Many big thanks to Steve, Jack, Rex and others for great
+            work
+          - Should be an ISO Spec in 4-5 months
+      - Also looking at 3.0 for ISO
+  - Tools
+      - Community Bridge funding project
+          - We are through phase 1 (funding for this year)
+          - On track for phase 2 next year
+      - Should have new infrastructure up in the next month or two
+          - Including real URL
+          - and SSL for security
+  - GSoC
+      - All projects are progressing quite well
+          - All students have passed 2nd evaluation
+      - Aveek started this for SPDX (in addition to LF) and it’s been
+        great for us
+          - We get more slots as a consequence
+
+## Legal Team Report - Paul/Steve
+
+  - License List
+      - Monday we relapsed 3.10 license list
+          - 20 new ones
+      - Joint meeting upcoming with the tech team to look at 3.0
+
+## Outreach Team Report
+
+  - No Update
+
+## Cross Functional
+
+  - 
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - David Wheeler, Linux Foundation
+  - Mark Baushke, Juniper
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Paul Madick
+  - Michael Herzog- nexB
+  - Steve Winslow, LF
+  - Michael Herzog- nexB
+  - Matije Suklje, Liferay
+  - Aveek, NextMark Printers
+  - Alexios Zavras, Intel
+  - Michael Richardson
+  - Mike Dolan, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-09-03.md
+++ b/general/2020/2020-09-03.md
@@ -1,0 +1,69 @@
+  - Attendance: 11
+  - Lead by Paul Madick
+  - Minutes of Sept. meeting
+
+## Tech Team Report - Kate
+
+  - Spec
+      - 3.0 discussions occurring now including joint discussions with
+        legal team is in good shape
+      - Shout out to Steve Winslow who has been put up examples and
+        others encouraged to participate
+  - ISO
+      - paperwork has been submitted and we are expecting a vote by end
+        of year
+  - Special Use Cases
+      - work continuing on with medical center
+
+<!-- end list -->
+
+  - GSoC
+      - All projects are progressing quite well and wrapping up
+      - Thank you to all participants (Mentors and Mentees)
+
+## Legal Team Report - Steve
+
+  - License List
+      - released 3.10 license list in August
+      - starting on 3.11
+  - lot of everyday work continuing
+  - Spec
+      - working with Tech team on license profile as break out from
+        other profiles like security profile
+
+## Outreach Team Report Jack
+
+  - Going through web site to give it a facelift in three phases
+      - phase one content verification
+      - phase two small improvements to communicate better
+      - phase three Additional content to help folks start up with SPDX
+  - Aveek has gone through website as a new member of SPDX
+      - from printer side (NextMark) and working on GsoC
+      - Aveek speaking with Kate and Jack on some things that might be
+        helpful regarding website
+  - Vicki volunteered to coordinate some help with the website but
+    requested direction on what Jack would be looking for.
+
+## Cross Functional
+
+  - 
+## Attendees
+
+  - Jack Manbeck, TI
+  - Brad Goldring, GTC Law
+  - Nisha Kumar, VMware
+  - David Wheeler, Linux Foundation
+  - Steve Winslow, LF
+  - Jim Hutchison, Qualcomm
+  - Aveek Basu, NextMark Printers
+  - Kate Stewart, Linux Foundation
+  - Vicki B.
+  - Rishabh Bhatnagar, St. Francis Institute of Technology
+  - Paul Madick
+
+`•  `  
+`•  `  
+`•  `
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-10-01.md
+++ b/general/2020/2020-10-01.md
@@ -1,0 +1,72 @@
+  - Attendance: 8
+  - Lead by Phil Odence
+  - Minutes of Sept meeting Approved
+
+## Webpage Update- Phil
+
+  - No objections to new copy for website
+
+## Tech Team Report - Steve standing in
+
+  - Spec
+      - DCO bot has been turned on for the spec
+      - 2.2.1
+          - ISO requested more information
+          - Developed and submitted
+      - 3.0
+          - WilliamB has set up new branch
+          - Still working on main profile
+          - Minor mods for OMG/NTIA
+          - Japan user group has provided inputs
+          - Vulnerabilities Profile
+              - Working with 3TS group
+          - Linkage Profile
+              - Name still up in the air
+              - Something about of linking docs and vetting provenance
+          - Build Profile
+              - Kate working on looking at different built systems
+  - Tools
+      - Google SoC
+          - All students passed. Congrats\!
+              - Rishabh has stayed involved and done some great work
+          - Community Bridge
+              - 2 projects going
+          - Tools.spdx.org
+              - Funding is $2100 / $2400
+              - All tools being transitioned
+              - Test instance in place <http://52.32.53.255/>
+                  - Please Poke\!
+
+## Legal Team Report - Paul/Jilayne/Steve
+
+  - Licensing Profie
+      - This has been the recent focus of the team
+      - Simplify/Clarify what’s been in place
+      - Working doc for initial draft:
+        <https://docs.google.com/document/d/1k_2tSlFXvW_SbW-I1DcSEoCNBMQJd4FEFIQr6KCJuyU/edit#>
+      - Base + Licensing is targeted at the historical use case for SPDX
+      - Next step will be to clean up the initial draft for further
+        discussion
+  - License List
+      - Little change due to focus on Licensing Profile
+      - Building up a little backlog
+  - Minutes for Legal Team going forward keeps minutes here:
+      - <https://github.com/spdx/meetings>
+
+## Outreach Team Report
+
+  - No Update
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Paul Madick
+  - Rishabh Bhatnagar, St Francis Inst Tech
+  - Aveek, NextMark Printers
+  - Steve Winslow, LF
+  - Jilayne Lovejoy, Canonical
+  - Michael Herzog- nexB
+  - Mike Dolan, Linux Foundation
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2020/2020-11-05.md
+++ b/general/2020/2020-11-05.md
@@ -1,0 +1,92 @@
+  - Attendance: 16
+  - Lead by Steve Winslow
+
+## Presentation: William Bartholomew
+
+  - Discussed efforts working with 3T-SBOM group to align approaches and
+    modeling
+  - Walked through key points of changes to base profile
+      - Relationships being promoted to “object” level
+      - Artifact; external references
+      - Extensibility, potential for other authenticity measures than
+        just hashes (e.g. public keys)
+  - Briefly discussed other profiles
+
+## Legal Team Report – Steve / Jilayne
+
+  - 3.11 release update
+      - originally scheduled for Oct. 31
+      - most of 3.11 cycle was focused on SPDX 3.0 licensing profile
+        discussions
+      - shifted release to approx. Nov. 25
+  - call for participants to review license submissions / provide
+    comments on “yes/no, should this be added” out-of-band from biweekly
+    calls
+
+## Tech Team Report – Kate
+
+  - Work proceeding on SPDX 3.0
+  - Linking profile: focus on aligning with container-based ecosystems,
+    work by Nisha and Santiago
+  - Other profiles proceeding as well
+  - Tooling: Online Tools recently updated
+
+## Other matters
+
+  - Comments from Aveek re: ways to provide better on-ramps into the
+    SPDX community for newcomers
+      - Availability of Gitter as a real-time chat option; possibly
+        explore other options
+      - May discuss on next month’s General meeting
+
+## Additional Notes from KATE
+
+Here are the notes I took, since Steve was kind enough to host.
+
+Attendees: Steve Winslow, Kate Stewart, Mark baushke, Rishabh Bhatnagar,
+Aveek, Jilayne Lovejoy, Emmanuel Tournier, William Bartholomew, Alexios
+Zavras, Mike Dolan, Paul Madick, Mark Atwood, Michael Herzog, David
+Wheeler
+
+William went through and did a review of SPDX 3.0 Base Profile
+highlighting the differences.
+
+Artifacts - are promoting a specific External Reference (likely PURL) to
+be used Document - Now has a set of profiles that
+
+Complies with a profile - expect that mandatory are supported. If not
+have profile - can use the field, but not expected to meet the full
+requirements.
+
+Next step is converting this into the written text. Move into the other
+areas as well.
+
+Now’s the time to chime in in SPDX 3.0 specification if you have
+
+Mark Baushke - problem on how to express the overall license. Userland
+and Kernel based licensing in one package. Use Case interested in - Fast
+packet forwarding - kernel module with GPL2, and userland. …. show how
+to represent.
+
+Legal Team - 3.11 release - pushing it out until Nov 25th, today one
+more meeting. 11 new license requests have been submitted in September.
+Help requested. : Commenting on licenses in github comments. XML files.
+
+Web site
+
+`           Refresh is ongoing.   Feedback and suggestions are welcome.   `  
+`           Mission discussed last month has now been incorporated`
+
+Technical Team - SPDX 3.0 in progress Online tools - yaml conversions
+coming.
+
+Aveek - Observing SPDX - Community building and bringing new people into
+group. Group chat/slack? — use gitter, start discussing there as well.
+Need to improve our launching platform. Slack group? - with mentoring
+and advocates how to start off.
+
+Aveek has volunteered to provide his findings to help us grow the
+community next month as a guest speaker.
+
+Possibly Steve, Jilayne & Paul can provide overview of SPDX 3.0 License
+Profile in January?

--- a/general/2020/2020-12-03.md
+++ b/general/2020/2020-12-03.md
@@ -1,0 +1,79 @@
+  - Attendance: 11
+  - Lead by Phil Odence
+  - Minutes of Nov meeting Approved
+
+## Tech Team Report - Gary
+
+  - Spec
+      - Nov, busy month
+      - Mostly working on Base Model
+          - Working on Relationships
+              - Between, for example, files, packages, etc
+              - Exploring verification methods, digital signatures, etc
+              - Supporting Contains
+          - This should clear the way to get more work done on the other
+            profiles
+              - Process work too
+              - Hoping enough is in place after next meeting to remove
+                blockers
+  - Tools
+      - New release of online tools is up
+          - Quite significant
+          - Much new functionality
+          - As such, there will likely be issues
+              - Report in GitHub or emailing Gary
+              - There was a character encoding issues that was quickly
+                resolved
+      - New license list generator has improved the LL
+      - Good work/improvements on Go libraries
+          - THANKS, Rishabh
+
+## Legal Team Report - Paul/Jilayne/Steve
+
+  - Main Nov work 3.11 License release
+      - A little smaller than previous was
+  - 3.12 discussions starting today
+      - Aiming for end of Jan
+      - Dealing with a little backlog of new requests
+      - Could use help, as usual
+  - Documentation/Website
+      - Core team has been overhauling
+      - Updating License List page
+          - Including moving to GitHub
+
+## Outreach Team Report
+
+  - Aveek’s ideas for increasing SPDX Participation
+      - Started discussing last meeting
+  - Rough plan
+      - Approach student communities at different schools
+      - Give assignments to students or onboarding
+          - e.g. Open Printing has a generic, easy, but comprehensive
+            assignment defined
+          - May need different ones for different technologies
+      - Single point of contact to guide students
+          - Perhaps students from previous years
+      - Identify basic issues to assign
+      - Encourage participation in GSOC and LFMP
+      - Encourage previous students to mentor
+      - Organize Virtual Meetups
+      - From student groups in schools
+  - Also has the idea of talking to other projects about benefits
+      - Will start with Open Printing
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - David Wheeler, Linux Foundation
+  - Rishabh Bhatnagar, St Francis Inst Tech
+  - Aveek Basu, NextMark Printers
+  - Steve Winslow, LF
+  - Jilayne Lovejoy, Canonical
+  - Mark Atwood, Amazon
+  - Paul Madick
+  - Mike Dolan, Linux Foundation
+  - Jim Hutchison, Qualcomm
+  - Rose Judge, VMware
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-02-04.md
+++ b/general/2021/2021-02-04.md
@@ -1,0 +1,165 @@
+  - Attendance: 26
+  - Lead by Phil Odence
+  - Minutes of Dec meeting Approved
+
+## 3T-SBOM - Kay/Bob
+
+  - Basis
+      - To standardize, tools need to talk to each other
+      - Developed 9 use cases
+      - Started up in 2019; several groups involved
+      - Provenance/Pedigree distinction
+      - Started w/NTIA fields as basis
+      - Developed model very similar to SPDX
+      - Started w/ software but can be broader
+  - Merging Efforts
+      - Common goals/members; working for some time
+      - So, made sense to merge
+      - Harmonized meetings
+          - Profile groups meeting separately from Tech meeting
+          - All a little fluid
+      - Longer Term thoughts
+          - Licensing and contribution agreements for spec
+          - User scenarios, broader scope
+              - May need to update naming scheme
+              - Broader scope may require expanded governance and
+                funding
+  - Questions
+      - Funding discs
+
+## Tech Team Report - Kate/Gary/Others
+
+  - Spec - Kate
+      - Overview
+          - SPDX 2.2 being refactored into upcoming 3.0 effort, with
+            Core and separate topical Profiles
+          - Has been happening in parallel with 3T SBOM efforts
+      - Core - William
+          - Area with most overlap with 3T efforts
+          - Have been working on identifying areas of differences
+            between the two, gradually converging
+          - Last month was focused on identifying remaining differences
+            and working through them, determining how critical they are
+          - Remaining differences are centered on (1) naming things and
+            (2) external references
+          - Also working through tooling and how to document the core
+            standard
+          - Close to done on what the model will look like, want to turn
+            next to actually writing it up in a format that is suitable
+            for use cases – transition from modeling to authoring of
+            spec text
+      - Licensing - Steve
+          - Described background of licensing fields combined with
+            “core” in 2.2 and prior spec versions
+          - Splitting out licensing-related fields into a separate
+            optional profile
+          - Previously discussed and brainstorming in a shared Google
+            Doc
+          - Was previously planning to wait on migrating into GitHub
+            until spec format was finalized; sounds like that will still
+            be some time until finalized
+          - Will work on migrating Google Doc brainstorming outcomes
+            into GitHub in MarkDown or plain text
+      - Defects – Thomas
+          - Includes “vulnerabilities”
+          - Worked with William on documenting an example
+          - Still working on remediation-related fields
+          - Hoping to have more concrete examples, and to restart the
+            security discussions before the end of this month
+      - Linking – Nisha
+          - Mockups:
+            <https://github.com/SantiagoTorres/spdx-linking-mockups>
+          - “Linking” – how different software components are related to
+            each other, and to separate components in the broader
+            ecosystem
+          - Profile aims to capture, if using e.g. a container or a CNAB
+            (Cloud Native Application Bundle), meant to surface those
+            connections
+          - Focused on cloud native use case, but could also be used in
+            e.g. the embedded world, for something like an embedded OS
+            utilizing multiple components
+              - Kay – other scenarios thinking about: e.g. IoT devices,
+                wanting to list out both software and hardware
+                components
+              - Santiago – working on similar for in-toto, to
+                authenticate components
+          - Currently stuck on sorting out the overlap between the
+            Linking profile and the Integrity profile. Current thinking,
+            integrity signatures should be handled via “relationships”
+            between elements
+      - Integrity – Santiago
+          - Slides: \[TO BE FILLED IN\]
+          - There are a lot of outstanding questions, still being sorted
+            through
+          - Milestone structure: Document integrity \>\> Document
+            Authentication \>\> Document & supply chain policy \>\>
+            Linkage & supply chain integrity
+          - Discussed roles of each stage and current status of
+            milestones
+      - Usage and Other Emerging – Kate
+          - Spearheaded by team in Japan
+          - Looking at carrying e.g. contract info along in SPDX
+            documents
+          - Also looking at Pedigree / Provenance profiles, for fields
+            to carry build information
+  - Tools and Google Summer of Code (GSoC) - Gary
+      -  GSoC: Applications open for projects, Gary is applying now,
+        will update next month
+      - Will post link to project page
+      - Looking at different tooling for supporting spec process
+
+ 
+
+## Legal Team Report - Paul/Jilayne/Steve
+
+ 
+
+  - 3.12 release, pushed back to Feb. 19/20, may push further back
+    depending on issue status
+  - Ran into some issues with CI/build system, thank you to Gary and
+    William for helping to resolve
+  - Jilayne – description of what the legal team works on
+      - License list for those not familiar with it:
+        <https://spdx.org/licenses>
+
+ 
+
+## Outreach Team Report - Aveek
+
+ 
+
+  - Recurring meeting with several community members about how to
+    welcome new folks to the community
+  - Discussing initial tools, assigning initial issues to newcomers
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - David Martin, Mitre
+  - Kay Williams, Microsoft
+  - Steve Winslow, LF
+  - Jilayne Lovejoy
+  - Paul Madick, Jenzabar
+  - Kate Stewart, Linux Foundation
+  - Gary O’Neall, SourceAuditor
+  - Aveek Basu, NextMark Printers
+  - Sean Geary, Revenera
+  - William Cox, Synopsys
+  - Maximilian Huber, TNG
+  - Emmanuel Tournier, Black Duck/Synopsys
+  - Thomas Steenbergen, HERE
+  - Alfredo Espinosa
+  - Nishad Thalhath
+  - David Edelsohn
+  - Philippe Emmanuel Douziech
+  - William Bartholomew, GitHub
+  - Alexios Zavras, Intel
+  - Santiago
+  - Henk Birkholz
+  - Ariel Patano
+  - Jorge Rodriguez-Moreno
+  - Nisha Kumar, VMware
+  - Michael Herzog- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-03-04.md
+++ b/general/2021/2021-03-04.md
@@ -1,0 +1,174 @@
+  - Attendance: 18
+  - Lead by Phil Odence
+  - Minutes of Feb meeting Approved
+
+<!-- end list -->
+
+  - Housekeeping
+      - Zoom - Will be migrating to Zoom for these meetings; working
+        with LF
+      - Phil will need to cut out early; Steve will take over notes
+
+## SPDX BOM for CMake Project
+
+  - Materials:
+      - Slides:
+        <https://github.com/swinslow/slides/blob/main/2021-02-fosdem/2021-02-07-FOSDEM-2021-SPDX-CMake.pdf>
+      - POC repo: <https://github.com/swinslow/cmake-spdx>
+
+<!-- end list -->
+
+  - Background
+      - Presented previously at FOSDEM
+      - Used Zephyr, lightweight RTOS
+      - Goal in parallel with CMake build generate an SPDX file
+          - including relationships
+          - fully automated
+          - not pull from external sources (license data for example)
+          - make is Zephyr-agnostic, so could be reusable
+  - POC
+      - On GHub
+      - Used File-based API on CMake
+          - to tell CMake to dump JSON meta-data files for each artifact
+          - and then build
+      - Created SPDX
+          - Pull from
+              - Sources directory
+              - Artifacts directory
+              - Pull SPDX short form license names from files
+              - Create relationships
+          - Output is two files
+              - Sources
+              - Build artifacts
+              - w links between
+  - Findings
+      - Some limitations to the CMake API data, missing some info that
+        CMake seems to “know”
+      - Some invalid IDs
+      - Graphiz was helpful in visualize the relationships represented
+        in JSON files
+  - Next Steps
+      - Takeaways: the concept basically works; start small and can be
+        improved
+      - Working w Zephyr community
+          - may have made it overly agnostic
+          - could tailor to Z build system
+          - but generalized version is a great starting point
+      - Michael Herzog: developed TraceCode as a tool to similarly look
+        at details during the build process; more generalized, but
+        extremely hard to use for anything sizeable b/c creates so much
+        data
+      - Also looked at Yocto as a way to gather this information
+      - Kate: Richard Purdie interested in this also from the Yocto side
+        – perhaps get together a working group focused on this. Yocto
+        also doing work around reproducible builds, and has been
+        adopting SPDX identifiers.
+
+ 
+
+  -   - Kay: thoughts on a “Build” profile for SPDX 3.0 to incorporate
+        build-time data about e.g. the call used to start the
+        compilation, the environment / compilation settings, etc. We
+        should get various compiler people talking about how to align
+        practices for this
+      - Kate: agreed, let’s get a working group together on this
+
+ 
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+ 
+
+  - Gary and William got the license list CI system moved from Travis to
+    GitHub Actions – thank you\!
+  - 3.12 – aiming to release this weekend; will tie up remaining issues
+    in call after this meeting
+  - Jilayne and Steve looking at getting some bigger projects going
+  - Invite to all to jump into the conversations in issue threads -
+    <https://github.com/spdx/license-list-XML/issues>
+
+ 
+
+## Tech Team Report - Kate/Gary/Others
+
+ 
+
+  - Model and Process update – Gary
+      - William leading discussions on Base profile model – reconciling
+        feedback
+      - Template for how to draft and write the profile specifications
+  - Google Summer of Code – Gary
+      - Should be hearing back shortly whether SPDX was accepted for
+        2021
+
+ 
+
+  - Spec – Kate
+      - Defects / Security – Thomas
+          - currently revising what was discussed on prior meetings
+          - worked with William on expressing vulnerabilities
+          - also looking at: whether / how to express mitigation
+            measures
+      - Linking – Nisha
+          - Sounds like people do want a Linking / Linkage profile
+          - Currently described in the spec as an “External Map” from 3T
+            discussions, but not sure what this means – looking for more
+            details
+      - Integrity – Kay
+          - Working on creating POC for taking an SBOM, serializing it
+            to binary, signing it using the COSI (?) standard
+          - could be signed in other ways, but using this for POC b/c
+            small format and usable for small devices
+          - expect to have this the week after next
+          - spec for document integrity – “here’s how you sign SBOMs” –
+            after having that as an example, plan to start reviewing
+            with broader group
+          - may be a month before ready to discuss on a tech team call
+      - Usage – Yoshiyuki Ito
+          - discussing what info to include in usage profile
+          - looking at using external map to refer to external
+            information sources
+      - Pedigree / Build / Creation – Kate
+          - can start those meetings happening, flesh out ideas
+          - reach out to in-toto folks to align with them
+
+ 
+
+  - SPDX 2.2.1 – Kate:
+      - ISO balloting has finished on the specification, via JDF
+      - Approved from balloting, so should be getting an ISO number in
+        the next few months
+      - May have some tweaks to the 2.2.1 repo coming in, based on
+        comments from ISO reviewers
+
+ 
+
+## Outreach Team Report
+
+ 
+
+  - No Report
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Steve Winslow, LF
+  - Michael Herzog- nexB
+  - Gary O’Neall, SourceAuditor
+  - David Edelsohn
+  - Jeff Schutt
+  - Rose Judge, VMware
+  - Nisha Kumar, VMware
+  - Jilayne Lovejoy, Red Hat
+  - Kate Stewart, Linux Foundation
+  - Emmanuel Tournier, Black Duck/Synopsys
+  - Jorge Rodriguez-Moreno
+  - Alfredo Espinosa
+  - Kay Williams, Microsoft
+  - Paul Madick, Jenzabar
+  - William Cox, Synopsys
+  - Bob Martin, Mitre
+  - Thomas Steenbergen, HERE
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-04-01.md
+++ b/general/2021/2021-04-01.md
@@ -1,0 +1,103 @@
+  - Attendance: 22
+  - Lead by Phil Odence
+  - Minutes of Feb meeting Approved
+
+<!-- end list -->
+
+  - Plan was to switch to Zoom
+  - Considering using Jitsi
+
+ 
+
+## Tech Team Report - Kate/Gary/Others
+
+ 
+
+  - Spec – Kate
+      - Core Model - Gary
+          - Lots of time on how to manage multiple profiles
+          - How to make it easier for tools
+          - Priority is on consumer/producers of docs
+              - Specifically, how to handle multiple profiles
+      - Licensing
+          - Pull request for early first cut
+          - Incomplete (intentionally) for feedback
+          - Take a look: <https://github.com/spdx/spdx-spec/pull/503>
+          - Comments welcome
+      - Integrity – Kay
+          - Doing Protyping
+          - Binary signing
+          - PGP and X509 and small IOT devices targeted
+          - Demoed two weeks ago
+      - Defects / Security – Thomas not here today
+          - no update
+      - Linking – Nisha not here today
+          - no update
+      - Usage – Yoshiyuki Ito
+          - There was a meeting
+          - Working on ideas
+      - Pedigree / Build / Creation – Kate
+          - Looking for participants
+
+<!-- end list -->
+
+  - Namespace
+      - Kate raised question of anyone using namespace registration
+      - Two organizations are employing
+          - <https://tools.spdx.org/app/license_namespace_requests/>
+          - Example: LicenseRef-.com.amazon.-AmznSL-1.0
+      - Mark will present next month
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+ 
+
+  - 3.12 License List now live
+  - Adding some informal roles on the team, e.g. New License Steward
+  - Discussions of automation opportunities
+  - Kicking off 3.13 release, likely small end of April
+  - <https://spdx.dev/faq/#licenses>
+
+## Outreach Team Report
+
+  - No Report
+
+## A Few More Items
+
+  - Sebastian volunteered to review the FAQ
+  - Google Summer of Code GSC
+      - Kate mentioned that SPDX has been accepted to the Google Summer
+        of Code program and to please let any students know who might be
+        interested.
+      - Aveek mentioned that student submissions end on 4/15 and that
+        some students need some help with the submission
+      - Gary indicated that the preferred method for communication
+        concerning GSC is on gitter.
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Philippe Emmanuel Douziech, CAST
+  - William Cox, Synopsys
+  - Kate Stewart, Linux Foundation
+  - Steve Winslow, LF
+  - Sebastian Crane
+  - Gary O’Neall, SourceAuditor
+  - David Edelsohn, IBM
+  - Kay Williams, Microsoft
+  - Aveek Basu, NextMark Printers
+  - Paul Madick, Jenzabar
+  - Rose Judge, VMware
+  - Bob Martin, Mitre
+  - Michael Herzog- nexB
+  - Karsten Klein
+  - Wayne Beaton, Eclipse
+  - Emmanuel Tournier, Black Duck/Synopsys
+  - Jeff Schutt
+  - Marc Etienne Vargenau, Nokia
+  - Jilayne Lovejoy, Red Hat
+  - Mark Atwood, Amazon
+  - Jim Hutchison, Qualcomm
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-05-06.md
+++ b/general/2021/2021-05-06.md
@@ -1,0 +1,131 @@
+  - Attendance: 18
+  - Lead by Phil Odence
+  - Minutes of Apri meeting Approved
+
+<!-- end list -->
+
+  - Plan was to switch to Zoom
+  - Considering using Jitsu
+
+## SPDX License Name Space at Amazon - Mark
+
+  - <https://docs.google.com/presentation/d/1uCAJW79hzqLAPhXfAn4maCRk9TZUhLJDAPEOBlgUFTw/edit?usp=sharing>
+
+## Tech Team Report - Kate/Gary/Others
+
+ 
+
+  - Spec – Kate
+      - Specification conversations continuing to move forward
+      - Rough template for categories of topics (what were previously
+        being called “profiles”)
+      - Core Model - William
+          - No Update
+      - Licensing - Steve
+          - filed PR with initial draft for discussion of template
+            format, etc.; will update to newer template; previously
+            discussed much of its substance last year
+      - Integrity – Kay
+          - working with in-toto community, framework for end-to-end
+            supply chain security; collaborating with them to see if the
+            specs can be aligned
+      - Defects / Security – Thomas not here today
+          - pushed first draft of fields for (1) vulnerabilities, and
+            (2) defects =\> impact on packages, false positives, etc.
+              - <https://github.com/spdx/spdx-spec/pull/510>
+          - Meetings next week to look at other security specs, their
+            use cases, whether they can / how they should be
+            incorporated
+      - Linking – Nisha not here today
+          - Kate discussing with Nisha / Rose
+      - Usage – Yoshiyuki Ito
+          - No update
+      - Pedigree / Build / Creation – Kate
+          - No Update
+  - GSoC- Alexios
+      - Got 5 slots; can run up to 5 projects
+      - Likely to accept 5 proposals:
+          - 2 for improving Golang tooling libraries (one RDF writing,
+            one JSON reading/writing)
+          - 1 for transitioning / updating online SPDX tools
+          - 1 for spec processing tools
+          - 1 for improved license matcher, taking matching guidelines
+            into account (unplanned submission)
+
+ 
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+ 
+
+  - Working for 3.13, planning to push out over the weekend
+  - Have been trying to clean up old issues
+  - Some updates on documentation in the repo
+  - New participants recently – some discussions on recent calls have
+    included reviewing past history; may want to put together more
+    historical documentation of past context, etc.
+  - Some interest from Debian – interest in getting a Debian-free
+    tickbox into the license list
+  - License submissions – starting to take a harder line on
+    participation from people submitting license requests without
+    sticking with them. For this release, started asking people to
+    create the PR’s themselves – a few of the submitters at least
+    responded and indicated they would do so
+  - Still relying on the calls too much; having people commenting in
+    issues out-of-band would be very helpful
+
+ 
+
+## Outreach Team Report - Kate
+
+ 
+
+  - Continuing to see interest in SPDX across different communities
+  - Zephyr – auto-generation
+  - Possible interest in re-starting Outreach team meetings – Sebastian
+    interest, Aveek also
+  - Kate will reach out to Jack and either ask him to restart or else
+    Kate will restart
+
+## Other Topics
+
+ 
+
+  - Sebastian – interest in Arch Linux in using SPDX
+      - Some work being done on the Arch packaging system, interest in
+        using SPDX licenses
+  - Jitsi
+      - Jilayne - Jitsi – this has gone well, plan to update to this for
+        future General calls
+      - Legal and Tech teams can update if/when they choose
+      - Europe, UK, etc. seems to be working
+      - Bob – recommend putting passwords on it
+      - Steve – discuss whether to put one on. Possible but appears to
+        prevent dial-ins afterwards.
+          - Steve will look into options
+
+ 
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Mark Atwood, Amazon
+  - Matthew Crawford, ARM
+  - Bob Martin, Mitre
+  - Philippe Emmanuel Douziech, CAST
+  - Jilayne Lovejoy, Red Hat
+  - Maximilian Huber, TNG
+  - Alexios Zavras, Intel
+  - Kay Williams, Microsoft
+  - David Edelsohn, IBM
+  - Thomas Steenbergen, HERE
+  - Jeff Schutt, Cisco
+  - Kate Stewart, Linux Foundation
+  - Michael Herzog- nexB
+  - Sebastian Crane
+  - Steve Winslow, LF
+  - Marc Etienne Vargenau, Nokia
+  - Jonas Smedegaard, self
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-06-03.md
+++ b/general/2021/2021-06-03.md
@@ -1,0 +1,138 @@
+  - Attendance: 17
+  - Lead by Phil Odence
+  - Minutes of May meeting Approved
+
+## SPDX Governance Review - Phil
+
+  - Background: About 8 years ago, we put in place a governance
+    structure for SPDX. It was a good effort at the time and has served
+    us, but it’s never really been stressed. Factors are in play today
+    that suggest the need for a legally tighter structure:
+      - OMG CISQ 3T joining SPDX
+      - ISO direction
+      - Executive Order
+      - Working with other standards, i.e. SWID and CycloneDX
+  - The Linux Foundation has a pre-packaged governance solution for
+    standards bodies, call the Joint Development Foundation, a
+    “consortium in a box,” as they refer to it. It’s a free, fast way
+    to set up a highly configurable legal entity and structure designed
+    for specification development. With support LF attorneys who have
+    been involved in a number of such projects for the LF, the Core Team
+    is exploring this option and it looks like it will suit our needs.
+  - There are many ways to configure, and we are going down the path of
+    the simplest possible configuration. Essentially, we can tailor the
+    documents so as to continue to operate as we have. The most
+    significant change would be to change the license for the spec to
+    the Community Specification License. This is a license purpose built
+    for specifications. Like the existing CC license, it grants a broad
+    copyright license to the spec itself. Additionally, requires
+    contributors to grant licenses to any patents that might cover
+    implementations of the spec. This would address user concerns about
+    the possibility that an SPDX contributor seeking to enforce patents
+    that they might hold that cover the spec.
+  - This is really to give you a heads up of something coming in the
+    future. The current governance mechanism defines a mechanism and
+    timetable for such a change that involves a formal announcement and
+    a general meeting to try to reach consensus. That clock is not
+    starting now; just want you to be aware that it’s coming.
+
+## Tech Team Report - Kate/Gary/Others
+
+ 
+
+  - Tools - Gary
+      - Python project is progressing
+      - Exec Order will bring with is some funding for cleaning up
+        tooling gaps
+      - New project
+          - Generating SBOM to work with CI/CD pipelines
+          - Written in Go
+          - Yocto keen to use
+      - NTIA slugfest is upcoming
+  - Spec – Kate
+      - Work
+      - Core:
+          - William Bartholomew and others working to show initial
+            serializations, migration issues
+          - rough format using Markdown as source of truth
+          - GSoC project to translate into schemas
+      - Vulnerabilities:
+          - Thomas has given initial presentation, gathering feedback,
+            meetings to be called to discuss
+      - Usage - Moving forward
+      - Licensing – Steve:
+          - in process, expect to have updated draft by end of July
+          - major open piece is documenting / specifying the license
+            expression model classes
+      - Linkage – Nisha experimenting, looking at re: e.g. containers
+      - Build – Bob, David Edelsohn
+
+ 
+
+  - Sebastian: Meeting times – out of date, time incorrect for General
+    Meeting
+      - Sync to a particular time – Eastern US or UTC?
+      - and just list that time on the wiki, with link to a time/date
+        converter
+      - Steve to sync with Phil to confirm on regular invite time
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+ 
+
+  - 3.13 released in May
+      - issue with version numbers for tagged releases
+      - thank you to Gary for helping address this while on vacation
+  - 3.14 in process now, to be released end of July
+
+ 
+
+## Outreach Team Report - Jack
+
+ 
+
+  - Next meeting June 7
+  - Calendar invite at <https://lists.spdx.org/g/Spdx-tech/message/4059>
+      - use this and not old info on the wiki
+
+## Other Topics
+
+ 
+
+  - IRC channel for SPDX – Sebastian / Philippe
+      - One channel on Freenode, another on OFTC; libera.chat also
+        existing
+      - Switching to libera.chat
+      - Sebastian to register and share with general list
+  - GSoC students also tend to use gitter.im (also accessible via IRC /
+    Matrix)
+  - channel name to be \#spdx
+  - After registered and shared with general list, will also add to
+    website
+
+ 
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Sebastian Crane
+  - Steve Winslow, LF
+  - Kate Stewart, Linux Foundation
+  - William Cox, Synopsys
+  - Marc Etienne Vargenau, Nokia
+  - Mikihito Matsuura, Tokyo University
+  - Bob Martin, Mitre
+  - Philippe Emmanuel Douziech, CAST
+  - Joshua Marpet, MGM Growth
+  - Tiberius Hefflin, Intel
+  - Jilayne Lovejoy, Red Hat
+  - Warner Lost,
+  - Aveek Basu, NextMark Printers
+  - Sharon Burke,
+  - Gary O’Neall, SourceAuditor
+
+<!-- end list -->
+
+  -   - 
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-07-01.md
+++ b/general/2021/2021-07-01.md
@@ -1,0 +1,149 @@
+  - Attendance: 22
+  - Lead by Phil Odence
+  - Minutes of June meeting Approved
+
+## SPDX Governance - Phil
+
+Status of governance changes
+
+  - Still working through a using the prepackaged JDF docs with LF
+    lawyers
+      - Lots there due to general nature
+      - It will have to go through the specified process for discussion
+        and voting
+  - Why?
+      - More scrutiny
+      - Standards requirement- Companies supporting, logos
+          - OMG CISQ 3T joining SPDX
+          - ISO direction – Need more
+          - Executive Order
+          - Working with other standards, i.e. SWID and CycloneDX
+
+ \* Specific concerns that came up
+
+  -   - Community Spec License vs. CCBY
+          - Patent license to address concerns that have arisen from
+            companies we want to support
+      - Also, tangentially related SBOM gen tool showed up in repo
+          - Need criteria for including
+
+  - A question came up about discussion of governance on the Gen Mailing
+    list
+    
+      - We try to limit traffic on the list so one can use to monitor
+        activity without being overwhelmed
+      - There will be a chance for discussion of a governance proposal
+        once process goes in motion
+      - Contact Phil with inputs
+      - We’ll look into a separate list
+
+## Outreach Team Report - Sebastian/Jack
+
+ 
+
+  - Rebooted
+  - SPDX website rework - license for content CC-BY-4.0
+      - Looking to rebuild website as static site.
+      - Code and license - more flex over precise styling and
+        functionality.
+      - Prototype of site in next few weeks.
+  - Technical slides - present about SPDX in own organizations.
+      - Reviewed collateral,  audience focus for collateral that will
+        meet audience needs.
+      - More explanation of “why”.   Point to specification when get to
+        details. 
+  - IRC channel 
+      - Sebastian set up \#spdx on libera.chat
+      - previous channels on OFTC, Freenode; hadn’t taken off
+      - libera.chat has 11 people in it currently
+      - “cloaking” - hides IP address in some cases, replaces with badge
+        for organization you’re associated with; Sebastian can provide
+        “SPDX cloak”
+  - Matrix bridge - feature of libera.chat, enables joining via Matrix
+  - Meeting date and time: 1500 UTC on Wednesdays will be new meeting
+    time, on 14th of July
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+ 
+
+  - Several new folks participating
+  - Ariel and Candice from ClearlyDefined have been digging into the
+    Python stack of licenses
+  - License List 3.14 release - targeting end of July
+
+ 
+
+## Tech Team Report - Kate/Gary/Others
+
+ 
+
+  - Tools 
+      - GSoC - JSON support in Golang; will seek to get GSoC student to
+        present at a future General Meeting
+      - New participants interacting with tools, and seeing pull
+        requests.
+      - NTIA Plugfest 
+          - new tools emerging from communities 
+          - SPDX was most common format in use
+          - Can’t get down to SPDX field to field 
+      - SPDX Plugfest?
+          - Desire to have Japan SPDX Plugfest
+          - One for north america   
+      - Anchore has a tool supporting SPDX output if you need more 3.0
+        examples we can on it. (github.com/anchore/syft). We have 2.2
+        now but can fairly quickly iterate for some 3.0 support.
+  - Specification
+      - ISO/IEC PRF 5962 - Information Technology — SPDX® Specification
+        V2.2.1- moved to PRF status Publication date : 2021-08
+      - OCI registry overview and how SPDX could interact with
+        containers. 
+      - Specification 3.0 Work 
+          - Looking for more 3.0 examples in serialization
+          - Lacking critical mass for some decisions - vacations
+              - Moving through punch list on core model.
+          - Vulnerability - waiting for core.   Snyk put up a nice
+            post.   
+              - Feedback in progress.   
+              - Serialization needs to become clearer.
+              - More examples are needed. 
+              - Follow up VEX and CSAF
+          - Licensing profile - pretty similar to 2.2 already.
+              - Once formatting for how template can be expressed.
+
+## Other Topics
+
+  - Open Question - why spdx.dev vs. spdx.org;   license list
+    dynamically generated spdx.org - Drupal → Wordpress.   How to keep
+    License list still populate to website.
+  - Keep license list URL stable. 
+  - Wikipedia page on SPDX is pretty stale.    
+      - Needs to be updated.    Outreach will take it. 
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Philippe Emmanuel Douziech, CAST
+  - Bob Martin, Mitre
+  - Joshua Marpet, RM-ISAO
+  - David Edelsohn, IBM
+  - Sebastian Crane
+  - Marc Etienne Vargenau, Nokia
+  - Zach Hill, Anchore
+  - Steve Winslow, LF
+  - Kate Stewart, Linux Foundation
+  - William Cox, Synopsys
+  - Jack Manbeck, TI
+  - Alexios Zavras, Intel
+  - Warner Losh, FreeBSD
+  - Alfredo Espinosa
+  - Jilayne Lovejoy, Red Hat
+  - Chris Lusk
+  - Andrew Jorganson, AWS
+  - Thomas Steenbergen, HERE
+  - Ronda,
+  - Brian Fox, Sonotype
+  - Michael Herzog- nexB
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-08-05.md
+++ b/general/2021/2021-08-05.md
@@ -1,0 +1,116 @@
+  - Attendance: 29
+  - Lead by Gary O’Neall
+  - Minutes of July meeting Approved
+
+## New License Matching Library
+
+  - Presented by Mikihito Matsuura
+  - Slides:
+    <https://docs.google.com/presentation/d/10n5CSE_LP0HDznhb6_P6zmyA4QpKJX3b_VhOvnF3nuk/edit?usp=sharing>
+  - PyPI: <https://pypi.org/project/yalm/>
+  - GitHub repo: <https://github.com/m1kit/yalm-python/>
+  - GitHub resources repo:
+    <https://github.com/m1kit/yalm-resources/tree/dist>
+  - Uses 2 step process, word matching, then regex
+  - Looking to extend beyond python, to ruby, etc.
+  - Proposal JSON format for template – Should we standardize JSON?
+  - Vulnerable regexes in templates – regex matches may match unintended
+    text
+  - What about a ML engine? Its focus is actual match rather than
+    detection.
+      - Goal is license matching, not license detection
+  - Which matching guidelines are covered and which still needs to be
+    implemented
+      - Some are not covered
+      - Suggest documenting which matching guidelines are not
+        implemented
+      - Perhaps tune the matching guidelines and license templates
+  - Use of the XML format
+      - XML is used as input
+  - Additional questions and follow-up on a joint technical-legal team
+  - Suggestion PyPI should have spdx- in the name -
+
+## Validate and Generate multiple representations of specifications
+
+  - Presented by Nirmal Praveen Suthar
+  - Slides:
+    <https://docs.google.com/presentation/d/17xrxcJ-74DfFmdZl99ogZTWa-MOgKuKW1PH6Qq5C4sg/edit?usp=sharing>
+  - Relevant links:
+      - Parser: <https://github.com/spdx/spec-parser>
+      - spec-v3-template example:
+        <https://github.com/spdx/spec-v3-template>\* Populates internal
+        graph structure, namespace model. LALR is sufficient, but
+        opportunity for improvement.
+  - Generate a JSON Representation of the Specification from Structured
+    Markdown
+  - Transforms spec into “pretty markdown” and RDF OWL – the latter can
+    be used to generate other schemas used by tools
+  - Validation and report of errors
+  - Reduce redundancy (e.g. handling defaults)
+  - Adds reference sections
+
+## Outreach Team Report - Sebastian/Jack
+
+  - Weekly meetings – Moved to Wednesday
+  - Update WikiPedia entry – currently terribly out of day
+  - Will start with Podcasts
+  - Follow-up with RSS feeds
+  - Updates for the Wordpress website – will be a topic for the next
+    meeting
+  - IRC is up and running and doing well
+  - Please take the SBOM readiness survey:
+    <https://www.linuxfoundation.org/press-release/linux-foundation-research-announces-software-bill-of-materials-sbom-readiness-survey/>
+  - Upcoming “town hall” will discuss tooling – see
+    <https://events.linuxfoundation.org/supply-chain-town-hall/program/schedule/>
+  - DOCFest September 16 – see
+    <https://lists.spdx.org/g/Spdx-tech/message/4142>
+
+## Legal Team Report - Jilayne/Paul/Steve
+
+  - Next team call today – issues pending for release
+  - Next release is expected Saturday or Sunday
+  - Nothing technical expected in this release
+
+## Tech Team Report - Kate/Gary/Others
+
+  - Specification – continuing to work through element and document
+    interaction and modeling as well as identifier naming
+      - Making progress on 3.0
+
+## Other Topics
+
+None
+
+## Attendees
+
+  - Kate Stewart
+  - Maximilian Huber -
+  - Sebastian Crane
+  - Tony Aiuto
+  - David Edelsohn
+  - Gary O'Neall
+  - Christopher Lusk -
+  - Philippe-Emmanuel Douziech
+  - Mikihito Matsuura (GSoC student)
+  - Marc-Etienne Vargenal
+  - Brad Goldring
+  - Alexios Zavras
+  - Rich Steenwyk
+  - Nirmal Suthar (GSoC student)
+  - Joshua Marpet
+  - Andrew Jorgensen (AWS)
+  - Christian Long
+  - Tiberius Hefflin
+  - Paul Madick
+  - Anshul
+  - Jack Manbeck
+  - Christina
+  - Jeff Schutt (Cisco)
+  - Jilayne Lovejoy
+  - Steve Winslow
+  - Christian Long
+  - Emmerich
+  - 2 people on phone where we did not catch the names
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-09-02.md
+++ b/general/2021/2021-09-02.md
@@ -1,0 +1,102 @@
+  - Attendance: 26
+  - Lead by Phil Odence
+
+<!-- end list -->
+
+  - GSoC Presentation was postponed
+
+## SPDX Governance - Phil
+
+  - Intro -Phil
+
+<!-- end list -->
+
+  -   - GOAL of today: Consensus  
+
+<!-- end list -->
+
+  -   - Background
+          - About 8 years ago, we put in place a governance structure
+            for SPDX.
+          - Factors
+              - ISO standardization- near to announcing
+              - Executive Order
+              - More participation from comm members with standards body
+                experience
+              - Working with other standards, i.e. SWID and CycloneDX
+
+<!-- end list -->
+
+  -   - Goal of Change - retain spirit and ways of working
+          - more accurately reflect the current reality and future
+            direction of the project
+          - establishing a mechanism for official company membership in
+            the project
+          - using contribution processes and a license for the spec that
+            ensure explicit patent license  commitments from
+            contributors
+          - improving clarity around decision-making processes and
+            establishing an appeals process
+          - adopting a code of conduct
+
+<!-- end list -->
+
+  -   - Solution - Steve to explain further
+          - Legal Entity creation- switched from JDF to a much simpler
+          - Retained Community Specification model
+
+<!-- end list -->
+
+  - Review of pdf Summary - Steave
+      - Legal Entity
+      - Membership Agreement
+      - Community Specs process and license
+
+<!-- end list -->
+
+  - Q\&A/Discussion
+      - Various clarifications
+      - Code of Conduct
+          - Agreed that under new structure it could, if need be, be
+            modified in the future
+      - Possibility of Dual-licensing Spec
+          - Agreed to not address at this time
+
+<!-- end list -->
+
+  - Resolution
+      - Consensus reached
+      - ...unless significant concerns were raised on the General
+        Mailing List within a day of so of the meeting's close
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Sebastian Crane
+  - Joshua Marpet, RM-ISAO
+  - Mike Nemmers
+  - William Cox, Synopsys
+  - Andrew Jorgenson, AWS
+  - Bob Martin, Mitre
+  - Philippe Emmanuel Douziech, CAST
+  - Alexios Zavras, Intel
+  - Marc Etienne Vargenau, Nokia
+  - Jilayne Lovejoy, Red Hat
+  - Steve Winslow, LF
+  - Mike Dolan, LF
+  - Mark Atwood, Amazon
+  - Gary O’Neall, SourceAuditor
+  - Paul Madick, Jenzabar
+  - Jeff Schutt, Cisco
+  - Vicky Brasseur, Wipro
+  - Warner Losh, FreeBSD
+  - Zach Hill, Anchore
+  - Pierre Tardy
+  - David Edelsohn, IBM
+  - Maximilian Huber, TNG
+  - Bill Jaeger
+  - Michael Mehlberg, Dark Sky Technology
+  - Henk Birkholz, Fraunhofe
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-10-07.md
+++ b/general/2021/2021-10-07.md
@@ -1,0 +1,105 @@
+  - Attendance: 27
+  - Lead by Phil Odence
+
+## Special Topics- Phil / Vicky
+
+  - Governance Update
+      - New governance is in place
+      - Will be announcing mechanism for signing up Member Companies
+      - With that will announce the mechanism for nominating Steering
+        Committee members
+
+<!-- end list -->
+
+  - Wipro
+      - Vicky discussed Wipro’s view of benefits and reasons for joining
+
+## Tech Team Report - Kate/Gary/Others
+
+  - Tools 
+      - no update
+  - Specification
+      - Spec version compatible with ISO, now available
+  - Version 3
+      - Working on how to establish the repos
+  - Question about SPDX Lite
+      - That would be the minimum mandatory fields
+
+## Legal team update - Jilayne
+
+  - New license request volume slowed down this month
+  - Doing some general catchup with members of the legal team
+  - Due for a new release at the end of the month
+  - Update on collaboration with OSI and FSF
+
+  \* Gary is working on 3 year old issues with the LicenseListPublisher
+to automate the inclusion of data from FSF and OSI   \* Data is in the
+isFsfFree column and the OSI approved columns for the SPDX listed
+licenses   \* Recently, getting good response from FSF and OSI -
+especially from OSI   \* OSI has a machine readable format that is being
+actively worked on   \* In addition to tool automation, there may be an
+opportunity for the legal team to have a communication process on
+license updates   \* Jilayne provided history on previous attempts to
+work with FSF on integrating their data which at times has been less
+responsive  
+
+## Outreach team - Sebastian
+
+  - Recent Docfest was a success, brought in several tool vendors to
+    compare results
+  - Updated Wikipedia page progressing slowing
+      - Lead section updated - this is what you seen when you do a
+        Google search
+  - Sebastian resolved an accessibility issue with the SPDX spec web
+    pages - increasing the contrast making it much more readable
+  - Website is being updated
+      - A section will be added to showcase company usage of SPDX
+  - Updating meeting time to be more time available
+      - Times are shown as UTC Note: will change next month
+      - new time will be the off weeks at the same time as legal
+  - going to meetings every other week from once a week.  Vicki pointed
+    out that there will be more work being done on the mailing list, so
+    feel free to volunteer for outreach activities even if you can't
+    make the meetings.
+  - Joshua reported the SPDX official podcasts started
+      - Once a month
+      - Outreach team will meeting every other month
+      - Will interview many community members
+      - Will follow-up with Vicki and others in the general meeting
+  - Kate - presented keynote at open source summit
+      - well received, good interested
+  - Sebastian and Gary reporting increasing interest in SBOM tooling -
+    we're seeing some good momentum
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Alexios Zavras, Intel
+  - Andrew Jorgenson, AWS
+  - Kate Stewart, LF
+  - Gary O’Neall, SourceAuditor
+  - Bill Jaeger
+  - Bob Martin, Mitre
+  - Eric Billingsley, Calculi
+  - Chrissini de Castro
+  - Michael Mehlberg, Dark Sky Technology
+  - Maximilian Huber, TNG
+  - Sebastian Crane
+  - William Cox, Synopsys
+  - Vicky Brasseur, Wipro
+  - Matthew Crawford, ARM
+  - Marc Gisi, Windriver
+  - Pierre Tardy,
+  - Joshua Marpet, RM-ISAO
+  - Brad Goldring, GTC Law Group
+  - Paul Madick, Jenzabar
+  - Jilayne Lovejoy, Red Hat
+  - Christopher Lusk
+  - Clement Poulain
+  - Joshua Dubin, Verizon
+  - Takashi Ninjouji
+  - Jeff Schutt, Cisco
+  - Robert Boyd, Calculi
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-11-04.md
+++ b/general/2021/2021-11-04.md
@@ -1,0 +1,86 @@
+  - Attendance: 25
+  - Lead by Phil Odence
+  - Minutes from last approved
+
+<!-- end list -->
+
+  - Company membership mechanics will be rolled out within a couple
+    weeks.
+
+## GSOC - Ujjwal
+
+  - JSON Support for Golang libraries
+
+## Tech Team Report - Kate/Gary/Others
+
+ 
+
+  - Tools 
+      - no update
+  - Specification
+      - Spec version compatible with ISO, now available
+  - Version 3
+
+<!-- end list -->
+
+  - Most of the work is focused on the core model.  We’re making
+    progress but still have a ways to go to settle on a good code the
+    other profiles will be built on.
+  - A new repo has been setup for the SPDX 3.0 spec since it will have a
+    different way of generating the examples and spec and will also be
+    under the new license as part of the new governance we put in place
+  - We expect more activities on the profiles next month, especially
+    security
+  - Interest in the spec and tools continues to increase – we’re seeing
+    some good signs of adoption from companies, other open source
+    projects, and individuals (if you need more detail – SW360 is
+    engaged in some issues conversations on the tools, the SPDX 2.1 spec
+    issues has some new contributor)
+
+## Legal team update - Jilayne/Pau/Steve
+
+  - FreeBSD will be adopting SPDX tags
+  - Fedora is exploring as well
+  - Conversations about adding better instructions on using Git to
+    contribute to license repo
+
+ 
+
+## Outreach team - Sebastian
+
+  - Processes
+      - Transitioned to monthly meeting
+      - Different ways of working in between under discussion
+  - Wikipedia page updates
+      - Adding history
+  - Adding logos of companies and projects that are using
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Ujjwall Agarwal
+  - Alexios Zavras, Intel
+  - Eric Billingsley, Calculi
+  - Jeff Schutt, Cisco
+  - Sebastian Crane
+  - Bob Martin, Mitre
+  - Steve Winslow, Boston Technology Law
+  - Christopher Lusk, Lenovo
+  - David Edelsohn, IBM
+  - Jilayne Lovejoy, Red Hat
+  - Tony Aiuto
+  - Karan Marjara, AWS
+  - Joshua Marpet, RM-ISAO
+  - Paul Madick, Jenzabar
+  - Adrian Diglio, Microsoft
+  - Alfredo Espinosa
+  - Brad Goldring
+  - Edgar
+  - Joe
+  - Vicky Brasseur, Wipro
+  - Warner Losh, FreeBSD
+  - Fellow Jitser
+  - Aasim, Microsoft
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2021/2021-12-02.md
+++ b/general/2021/2021-12-02.md
@@ -1,0 +1,181 @@
+  - Attendance: 33
+  - Lead by Phil Odence
+  - Minutes from last approved
+
+<!-- end list -->
+
+  - Phil will company membership announcement before end of week
+  - We will be move General Meeting minutes to GitHub and crowdsource
+    during meetings.
+
+## Microsoft and SPDX - Adrian/Steve
+
+  - Microsoft standardizing on SPDX \[Adrian Giglio\]
+      - Why SPDX?
+          - On ISO standard path
+          - Already participating
+          - Great group
+      - Why build their own tool?
+          - Already had tooling
+          - Easy to move to SPDX
+          - Needed certainty to meet NTiA standards
+          - Utilize MS Detection
+          - Needed a great range of environments
+          - Support for very large, complex build systems; layered
+            builds
+      - The Tool
+          - Built on .Net and available for Windows/Linux/Mac
+          - Available as build step in Azure
+          - Plan is to open source
+          - Pulls OSS data from a variety of build system formats
+      - Future
+          - Proving by early March, then rolling out across Microsoft
+          - Exploring different methods of SBOM distribution including
+            web portal
+          - Exploring signing with others in the industry
+
+<!-- end list -->
+
+  - MCR Distributing SPDX SBoMs for Microsoft content \[Steve Lasker\]
+      - How to distribute secured supply chain components? Specifically
+        SBOMs
+      - Supply chain artifact challenges:
+          - artifacts get promoted across environments, including
+            production assets getting pulled from the Internet into
+            restricted networks
+          - private virtual networks within cloud infrastructure
+      - Solution: Validation artifacts need to travel together with the
+        supply chain objects
+          - by default, SBOM might get blocked from being accessed due
+            to "airgapped" / VNet setup
+          - instead, create a private registry within each vnet; with
+            shared internal registry hosting all artifacts + SBOMs, then
+            promoted into each vnet
+      - ORAS: need signatures to be separable, verifiable, able to be
+        validated, prior to bringing artifact / binary into the
+        environment
+          - Microsoft built this for Azure Container Registry, but
+            customers share with other registries and other
+            infrastructure; registries should be a broader standard =\>
+            OCI Artifacts, ORAS Artifacts
+          - Signatures and SPDX SBOMs get attached to the graph
+          - ACR support for ORAS Artifacts today =\> customers can store
+            SPDX SBOMs today:
+            <https://aka.ms/acr/supply-chain-artifacts>
+      - Opportunity: having SPDX document travel alongside the target
+        artifact; CLI that can natively push / pull / validate SPDX
+        SBOMs to Registries
+      - What does the SPDX community want to see in an SBOM?
+          - recording EULA text?
+          - something validated at the time the content is used? =\>
+            needs to be accessible along with the artifact itself
+
+<!-- end list -->
+
+  - Questions/Comments
+      - Dick: what about having vulnerability disclosures together as a
+        part of the distributed info?
+          - Appreciate that the SPDX structure enables describing all
+            the pieces of what went into a software build in the first
+            place =\> static information at a point in time
+          - Scan results are things that you learn about over time =\>
+            e.g. might learn later about a problem that was discovered
+            after it was shipped
+          - Scan results will continue to be additive, whereas the SBOM
+            itself doesn't change
+          - Dick: some vendors are running scans and producing NVD
+            reports together with vendor's findings; making that info
+            available together with the SBOM. During customer risk
+            assessments, they can see beforehand if a CVE is reported
+            =\> if shows up in the disclosure, that helps address the
+            risk.
+          - Scan results, etc., could be attached to the other documents
+            that are included in the registry
+          - Eventually, looking to have a web-browsable portal to easily
+            access these documents. But, the automation is the
+            interesting part.
+      - Just this morning, this was announced to be becoming part of an
+        OCI working group; previously getting proven within the ORAS
+        project
+      - Sebastian: Ostree (Fedora):
+        <https://fedoraproject.org/wiki/Changes/OstreeNativeContainer>
+      - Signature format: shipped in Notary v2, but working on expanding
+        via conversations with the broader community. Needs to be able
+        to be validated broadly.
+      - Dick: NIST workshop that took place this week: ability to
+        distribute SDLC evidence and policy data. Will that be part of
+        this?
+          - Viewing this as plumbing / core infrastructure, in a generic
+            way; new types will emerge for what types of artifacts are
+            used to be deployed / promoted on this infrastructure
+          - Because it's generic / abstracted, any new type can be
+            hosted on this infrastructure
+
+ 
+
+## Tech Team Report – Kate/Gary/Others
+
+  - Tools
+      - New release of SPDX Java Tools available at
+        <https://github.com/spdx/tools-java/releases/tag/v1.0.3>
+  - Specification
+      - Focused on the Core modeling
+      - Made progress on collections, packages, and document definitions
+        and relationships
+      - Significant testing of the model with different use cases and
+        serialization considerations
+
+## Legal Team Report - Jilayne/Pau/Steve
+
+  - License List version 3.15 was released and published to
+    <https://spdx.org/licenses> on Nov. 14
+  - Shortened month for meetings due to Thanksgiving holiday in US
+  - Warner Losh presented to the team about FreeBSD's use of SPDX
+    short-form license identifiers:
+    <https://docs.google.com/presentation/d/1mRWj7DCiicK57BqD4XzUMSZs51TpUUIYIgI-UcB8XDw/edit#slide=id.p>
+
+ 
+
+## Outreach Team Report -
+
+  - No update, but Sebastian sent an email to the General Meeting list
+    with notes on behalf of the team.
+
+## Attendees
+
+  - Phil Odence, Black Duck/Synopsys
+  - Adrian Digli, Microsoft
+  - Steve Lasker, Microsoft
+  - Sebastian Crane
+  - Steve Winslow, Boston Technology Law
+  - Dick Brooks, REA
+  - Rich Steenwyk, GE Healthcare
+  - Annie
+  - Brad Goldring, GTC
+  - Jeff Schutt, Cisco
+  - David Edelsohn, IBM
+  - Jilayne Lovejoy, Red Hat
+  - Aveek Basu, NextMark Printers
+  - Marc Gisi, Windriver
+  - Gary O’Neall, SourceAuditor
+  - Philippe Ombrédanne- nexB
+  - Dick Brooks
+  - Alex Rybek
+  - Brend Smits, Philips
+  - Christopher Lusk, Lenovo
+  - Christopher Phillips
+  - Fellow Jitser
+  - Jilayne Lovejoy, Red Hat
+  - Mashid
+  - Kendra Morton
+  - Marco
+  - Majira
+  - Michael Herzog- nexB
+  - Mike Nemmers
+  - Molly Menoni
+  - Paul Madick, Jenzabar
+  - Rose Judge, VMWare
+  - Vicky Brasseur, Wipro
+
+[Minutes](Category:General "wikilink")
+[Category:Minutes](Category:Minutes "wikilink")

--- a/general/2022/2022-01-06.md
+++ b/general/2022/2022-01-06.md
@@ -1,0 +1,82 @@
+# SPDX General Meeting Minutes - Jan 6, 2022
+
+## Administrative
+- Attendance: 23
+
+- Lead by Phil Odence
+- Minutes from last meeting approved
+
+## SPDX Membership
+- open to companies and organizations
+- earlier mailing list post at https://lists.spdx.org/g/spdx/message/1484
+- signup link at https://enrollment.lfx.linuxfoundation.org/?project=spdx (for companies, which need to be LF members)
+
+## Tech Team Report - Gary/Kate
+### Spec
+- Progress on Core Profile issue
+- working through a punchlist where we need consensus
+* https://github.com/spdx/spdx-3-model/issues
+- continuing for next month or so
+- Docfest - Rose
+- Jan 27 planning second docfest
+- Signup sheet available, see Rose's forthcoming email to General Meeting list
+- Details available to those who sign up
+- To indicate interest to participate, please fill in the following form:
+https://forms.gle/Mq7ReinTY6gDL4cs9
+### Tools
+- Gary sent out email re Proof of Concept tools of how SPDX docs can but used to correlate package level information with vulnerability lookup services
+- Not ready for primetime but a good example
+- To be demonstrated in FOSDEM
+- All log4j issues in SPDX tools were patched (quickly)
+
+## Legal Team Report - Jilayne/Paul/Steve
+### License List
+- 3.15 went out mid Dec
+- 3.16 end of this month
+- Cleaned up/cleared out some very old issues in recent months
+### Other
+- Starting to revive some backburnered projects for 2022
+
+## Outreach Team Report -  Sebastian
+- A quiet month
+- Continuing topics
+- Adding FOSSLight
+- Open to new projects for Outreach Team
+- One thought: When folks want to add a license, it wouldbe interesting to discuss how to better communicate inclusion criteria, process, etc.
+- Review of team's focus
+- Rebooted last year
+- Focus on press releases regarding accomplishments to raise awareness
+- Create a more inviting atmosphere for people to join
+- Idea of ambassadors who can help usher newbees in
+- A Landscape app- graphical interface for tools that support, etc
+- Concept of neighborhoods to represent use cases
+- Updating SPDX page
+- could use some more help
+- Starting a podcast, interviewing users, led by Joshua
+
+
+## Attendees
+
+* Ria Schalnat
+* VM Brasseur
+* Brad Goldring
+* Christopher Lusk
+* David Edelsohn
+* Dick Brooks
+* Jeff Schutt
+* Marc-Etienne Vargenau
+* Rick Steenwyk
+* Robert Boyd
+* Steve Winslow
+* Minatee Mishra
+* Phil Odence
+* Jilayne Lovejoy
+* Paul Madick
+* Gary O'Neall
+* Tony Aiuto
+* Sebastian Crane
+* Kate Stewart
+* Rose Judge
+* Zach Hill
+* Philippe Ombredanne
+* Andrew Jorgensen

--- a/general/2022/2022-02-03.md
+++ b/general/2022/2022-02-03.md
@@ -1,0 +1,90 @@
+# SPDX General Meeting Minutes - Feb 3, 2022
+
+## Administrative
+- Attendance: 33
+- Lead by Phil Odence
+- Minutes from last meeting approved
+
+## Steve Hendrick w/report on SBOM readiness
+
+- [Press release about the report](https://www.linuxfoundation.org/tools/the-state-of-software-bill-of-materials-sbom-and-cybersecurity-readiness/)
+- [Report itself](https://linuxfoundation.org/wp-content/uploads/LFResearch_SBOM_Report_final.pdf)
+- Showing a selected set of slides from the report
+- In all his years as an industry analyst, he never heard of SBOMs. Now though, it's about to become a massive market.
+- Was careful to not be too LF biased by surveying a broad end user community.
+- Anticipate a 60+ percent growth of orgs using SBOMs…if the tooling exists to support that growth. He hasn't yet looked at the tools that are out there.
+- Not a lot of visibility for this from the vendors & tooling providers. Analysts also haven't yet done a market forecast for this, either.
+- Discussion on formats that wasn't included in the report. Won't summarise here as it's not really public.
+
+## Tech Team Report - Gary/Kate/Thomas
+### Spec
+#### Defects
+- Thomas sent out Doodle poll to figure out date for next team call
+- Multiple options on how to include vulnerabilities:  include, separate, and link
+- Working on one document
+#### Core 3.0
+- Good progress on building concensus on when to use properties or relationships (packages containing files for example).   Follow along in spdx-3.0-model repo.
+#### 2.3 Release
+- Follow up from Docfest on some clarifications that emerged from comparisons.
+- Anything that we need to help people adopt SPDX for presidential order.   Dick points out CMS issued an RFI that incorporates SBOM: https://sam.gov/opp/fe53a2be20094034b178e260f29cd0ad/view
+- For licensing-related fields that are currently mandatory but can have noassertion, looking at permitting them to be made as optional for 2.3, presuming NOASSERTION if field is omitted.
+### Tools
+#### DocFest (Rose)
+- Held on 1/27,  24 attendee,  identified - 6 topics - made it through all 6
+- Thanks to analysis team for helping to understand the differences!
+#### GSOC
+- GSOC Summer of Code - Alexios will be lead.
+- Please feel free to contribute
+#### Tooling Release
+- Rohit working on merge for Online tools.
+- Working with CycloneDX team to have tools that interoperate.
+- FOSDEM coming up this weekend - Software Composition and Dependency devroom, https://fosdem.org/2022/schedule/track/software_composition_and_dependency_management/
+
+## Legal Team Report - Jilayne/Paul/Steve
+### License List
+- Will release 3.16 this weekend.
+- Good discussion on Fedora use of identifiers, and use between communities.
+  - Historically added about 80 licenses to license list in 2014, based on Fedora's own list of licenses
+  - Similar to discussion previously with Warner about use in FreeBSD
+  - Will provide updates to General team on Fedora and FreeBSD as it proceeds
+
+## Outreach Team Report -  Sebastian
+- (getting update from email)
+
+---------------------
+
+## Attendees
+
+* VM Brasseur
+* Brad Goldring, GTC Law Group
+* Christina Chen
+* Thomas Steenbergen
+* Steve Hendrick
+* Jilayne Lovejoy
+* Dick Brooks
+* Kate Stewart
+* Alex Rybak
+* Alexios Zavras
+* Gary O'Neall
+* Christine Chen
+* David Edelsohn
+* Edgar
+* Jacob Wilson
+* Jesse Porter, Qualcomm
+* Karan Marjara
+* Lena Smart
+* Marc Etienne Vargenau
+* Matthew Neal Miller, Red Hat Product Security
+* Michael Herzog
+* Paul Madick
+* Pete Allor, Red Hat Product Security
+* Phil Odence
+* Steve Winslow
+* William Cox
+* Andrew Jorgensen
+* Alfredo Espinosa
+* Rose Judge
+* Ria Schalnat
+* Joe Bussell
+* Joshua Dubin
+* Michael Herzog

--- a/general/2022/2022-03-03.md
+++ b/general/2022/2022-03-03.md
@@ -1,0 +1,87 @@
+# SPDX General Meeting Minutes - March 3, 2022
+
+
+## Administrative
+- Lead by Phil Odence
+- Attendance: 22
+- Minutes from last meeting approved.
+
+## How RKVST Uses SPDX for Software Transparency by Jon Geater, CTO Jitsuin
+### Jitsuin, RVST, Digital Twin Consortium
+### The Problem
+* Cyber physical systems- Data is the new oil. Big Opportunity...but requires trusting data
+* Trust can be difficult because everyone is in a supply chain, crossing org boundaries
+* Solution approach: Shared asset history w/evidence
+* Including BOM
+  * Software and hardware combination (depending on industy)
+  * SBOM- super crutial first step
+*Common understanding takes out human time-consuming steps
+* Anyone in the chain should be able to make their own risk assessment
+  * Trust is not the same as security
+  *Things change/are dynamic...and with software that's frequent
+  * So systems need to be able to handle quickly, in real time
+### Conclusions
+* What's needed is resilient operation of dynamic systems
+* Important first step is what's in the box
+* ...then vulernablities and what do to about them
+* interoperatiblity of standard formats
+### Q&A
+
+
+
+## Tech Team Report - Gary/Kate/Thomas
+### Spec
+#### Defects
+* Meetings have started up,  join the mailing list for details.
+#### Core 3.0
+* Kate / William - have been making good progress on punch list
+#### 2.3 Release
+* will be adding in some fields that people have been asking for interoperability with CycloneDX community
+* license namespaces - Mark Atwood and Steve Winslow to sync
+* SPDX Lite - add Package Supplier to match NTIA minimum definition for SPDX Lite profile
+
+
+### Tools
+#### GSOC
+* Submission in,  project ideas still welcome.
+
+
+## Legal Team Report - Jilayne/Paul/Steve
+* 3.16 released at beginning of February; continuing with issues / PRs for 3.17
+* change in meeting cadence - moved to 2nd / 4th Thursday of every month, Steve to update downloadable invites on website
+## Outreach Team Report -  Sebastian
+* Updates to landscape in process
+* FOSDEM talk from Sebastian - recording not yet on FOSDEM website
+  * highlighting key aspects of effective, high-quality SBOMs
+  * will be available at https://fosdem.org/2022/schedule/event/security_sbom/ once it's posted
+* March 20 - LibrePlanet talk - package management
+  * https://libreplanet.org/2022/speakers/#5830
+* OpenSSF interest in vulnerabilities website
+* Kate and Jack - updates to website
+
+---------------------
+
+## Attendees
+
+* Phil Odence, Black Duck Audits/Synopsys
+* Patrick Reilly
+* Sebastian Crane
+* Bob Martin
+* Joshua Dubin, Verizon
+* Steve Winslow
+* Brad Goldring, GTC Law Group
+* Joshua Marpet
+* Joshua Watt
+* Jon Geater, Jitsuin (presenter)
+* Alex Rybak
+* Jeff Schutt
+* Kate Stewart, Linux Foundation
+* Maximillian Huber
+* Mark Atwood, Amazon.com
+* Philippe-Emmanuel Douziech, CAST GmbH / CISQ
+* David Edelsohn
+* Paul Madick
+* Jilayne Lovejoy, Red Hat
+* Ria Schalnat
+* Molly Menomi
+* Robert Boyd

--- a/general/2022/2022-04-07.md
+++ b/general/2022/2022-04-07.md
@@ -1,0 +1,82 @@
+# SPDX General Meeting Minutes - April 7, 2022
+
+
+## Administrative
+- Attendance: 27
+- Lead by Phil Odence
+- Minutes from last meeting approved.
+
+## SPDX in the Yocto Project – Joshua Watt
+* Link ot recording will be provides / Link to slides?
+* Source, policy, code go intro Bitbake and produce and image for embedded systems
+* Recipies contain important SBOM data
+* When recipes are process, SPDX docs are produced
+* Full support for anything that Yocto can build.   Rust & Go are still WIP.
+* Note: need to have external references being on LHS of expression - validation tooling issue, as well as implications for runtime SPDX docs.    Need to be on LHS & RHS.
+* One line in configuation file, to trigger generation.  Some knobs to adjust how much is there.
+
+
+## Tech Team Report - Gary/Kate/Thomas
+### Spec
+#### Defects
+* Meetings have started up,  join the mailing list for details.
+#### Core 3.0 Model
+* xxx
+#### 2.3 Release
+* 2.2.2 released in next day, then start pulling in the PRs to 2.3
+* Focus of changes will be to fill in gaps that DocFest has identified.
+* Planned:  Link to Vulnerability Report,  relax mandatory inclusion of NOASSERTION licensing, more hash algorithms, ... (must align with 3.0 directions)
+#### New working groups
+* Build Profile working group spinning up, starting next week.
+* AI Profile working group has started meeting this week,  currently going through GAP analysis between desired elements for AI BOM & what's in SPDX today based on work from IBM & IEEE.
+* First Canonicalization meeting on 4/15.
+
+### Tools
+#### GSOC
+* Submission in,  project ideas still welcome.
+* Students working on proposals.
+
+## Legal Team Report - Jilayne/Paul/Steve
+* Working on bits of spec for 2.2 & 2.3
+* Working on 3.17 of the license list.
+
+## Outreach Team Report -  Sebastian
+* Podcast update - LF is looking to starting podcasting division, to release what's been recorded over last few months.
+* GSOC candiates is high, and proposals are starting to come in.
+* Microsoft working on a software composition analysis tool - github,  component dection.
+* Membership -
+* SPDX website rebuild to be more under community control.
+* Libreplanet talk - recording at <insert link from Sebastian>
+
+
+---------------------
+
+
+## Attendees
+* Phil Odence, Black Duck Audits/Synopsys
+* Adrian Diglio
+* Alexios Zavras
+* Alberto Pianon
+* Anthony Harrison
+* Bob Martin
+* Christopher Lusk
+* David Edelsohn
+* Dennis Clark
+* Gary O'Neall
+* Jeff Schutt
+* Joshua Watt
+* Joshua Marpet - MJM Growth, et al.
+* Karan Marjara
+* Kate Stewart
+* Marc-Ettinne Vargenau
+* Mark Atwood
+* Matthew Crawford
+* Matt Weber (Collins Aerospace)
+* Luca Miotto
+* Paul Madick
+* Sam Ellis
+* Sebastian Crane
+* Shawn Kilpatrick
+* Steven Kilbane
+* VM Brasseur (Wipro)
+* Brian Fox (Sonatype)

--- a/general/2022/2022-05-05.md
+++ b/general/2022/2022-05-05.md
@@ -1,0 +1,89 @@
+# SPDX General Meeting Minutes - May 5, 2022
+
+
+## Administrative
+### Attendance: 24
+
+* Lead by Phil Odence
+* Minutes from last meeting approved.
+
+## Steering Committee Update - Phil
+* Overview of Steering Committe makeup (Chair, Team Leads - which have largely been the same for many years), plus the addition of one to two Member Representatives as per new governance and membership structure chosen by the SC from the 18 new member entities.
+** See https://github.com/spdx/governance/blob/main/5._Governance.md for details on how it works
+** Bob Martin (MITRE), May Wang (Palo Alto Networks)
+* Question about package identifiers
+** Gary: SPDX has thought about this a lot over the years
+** Main role so far has continued to be enabling support for interfacing with a variety of different package ID methods (PURL, SWID, etc.)
+** Expect to continue this and enable interchange rather than spinning up a brand new package ID method
+
+## Tech Team Report - Gary/Kate/Thomas
+
+### Spec
+*SPDX 2.2.2 has been released
+
+#### Defects
+
+#### Core 3.0 Model
+* Made good progress over last month to solidify core profile model
+* Canonicalization team started up to work on serializations
+* AI team has started up to work on optional profile
+* Build team has started up to work on optional profile.
+#### 2.3 Release
+* Team is starting into pulling in the SPDX 2.3 PRs.
+** focus on incorporating feedback from plugfests, when aligns with 3.0 direction.
+** adding in some fields to improve exchange with CycloneDX of NTIA minimum
+** adding in initial recommendations from Defects & Usage teams
+#### New working groups
+*
+
+### Tools
+* new utility moved to SPDX repo: takes SPDX docs looks at identification info and look up vulnerability data in open source vulnerability database; tool in prototype stage, Branden collaborating on this; more info to come
+* https://github.com/spdx/spdx-to-osv
+#### GSOC
+* Coming up on deadline for selecting slots - Alexios coordinating
+* If any interest in being a mentor or otherwise participating, contact Alexios
+
+## Legal Team Report - Jilayne/Paul/Steve
+* Time for pull requests for next release
+* Matching guidelines need to be dusted off
+* FSFEurope conference for lawyers
+** Jilayne and Richard Fontana presented on upsteam licenses
+** Importance of machine readable communication
+** Participation from upstream projects
+
+## Outreach Team Report -  Sebastian
+* Announced Sebastian as (formally) taking on role as Team Lead of Outreach Team and joining
+
+##Steering Committee
+* SPDX website update
+** Auto generated parts being updated into a single site with cohesive appearance
+* Starting up podcasts
+
+## Attendees
+* Adrian Diglio
+* Andrew jogensen
+* Alex Rybak
+* Bob Martin
+* Brad Goldring
+* Christopher Lusk
+* David Edelsohn
+* Dick Brooks
+* Gary O'Neall
+* Jilayne Lovejoy
+* Johsua Watt
+* Mark Atwood
+* May Wang
+* Phil Odence, Black Duck Audits/Synopsys
+* Ria Schalnat
+* Saul Wold
+* Sebastian Crane
+* Steve Winslow
+* Steven C
+* VM Brasseur (Wipro)
+* Matthew Crawford  (Arm)
+* Michael Herzog (NexB)
+* Warner Losh
+* Karsten Klein
+
+
+        ---------------------

--- a/general/2022/2022-06-02.md
+++ b/general/2022/2022-06-02.md
@@ -1,0 +1,109 @@
+# SPDX General Meeting Minutes - June 2, 2022
+
+
+## Administrative
+* Attendance: 28
+* Lead by Phil Odence
+* Minutes from last meeting approved.
+
+## Steering Committee Update - Phil
+* Governance updates - minor clarifications
+* Starting work on a project management framework
+  * Team Leads trying out a kickoff form before formalizing anything
+* Alexios selected as new co-lead for Outreach Team, joining Steering Committee in that capacity
+
+## OpenSSF and White House Meeting - Kate
+* Focus on SBOMs - looking to engage with SPDX community, particularly on Defects side + laser focus on security
+* Early January 2022 - discussing security and SBOMs; many companies putting resources towards solving problems are OpenSSF members; discussion was under Chatham House Rule, info present but not disclosing speaker / organization
+* New meeting - included representatives from many organizations, including outside OpenSSF / LF
+* Kate and William Bartholomew present and active in SBOM workstream
+  * Mobilization plan: https://openssf.org/oss-security-mobilization-plan/ - Stream 9, "SBOMs Everywhere"
+  * Stream 10 also relevant to SPDX
+  * Additionally a working group for package managers, with recurring meetings
+* June 20 or later - will be meeting in Austin among SPDX, CycloneDX and others re: identifying key use cases; reach out to Kate if wanting to participate in discussion
+* Looking to find companies willing to invest in improving tooling, especially with going to 2.3 and 3.0; tools requested by community; improving documentation; doing outreach
+* CISA Federal Register notice: https://www.federalregister.gov/documents/2022/06/01/2022-11733/public-listening-sessions-on-advancing-sbom-technology-processes-and-practices
+* RedHat readout from meeting: https://www.linkedin.com/posts/mark-bohannon-54b66a_red-hats-open-approach-to-vulnerability-activity-6931970156457840640-BrD8/?utm_source=linkedin_share&utm_medium=member_desktop_web
+
+
+## Tech Team Report - Gary/Kate/Thomas
+
+### Spec
+* SPDX 2.2.2 has been released
+  * docs bugs have been resolved, and can be accessed at: https://spdx.github.io/spdx-spec/
+* SPDX 2.3 is close to feature complete,  we'll be declaring a release candidate in the next week, and generating ontologies for the tools to start trying it out.
+  * Likely aiming to release in next couple of weeks
+  * Documented in spdx-spec GitHub repo re: remaining tasks and activities
+  * Only a couple items left impacting syntax of documents; hoping they'll be resolved this week, though can't commit b/c seeking consensus across multiple teams and time zones
+  * Aiming to have a draft schema out w/in a week after consensus, to be available for review
+  * Tooling folks then to update tools in parallel
+  * A couple of big issues _separate from_ those impacting the syntax: e.g. license namespaces, licenses and snippets; intending to be compatible with existing syntax, but want to document in spec if adopting
+* SPDX 3.0 moving in parallel,  revised model posted.
+  * William leading up core profile team effort
+  * Small list of outstanding items, will soon transition to documentation phase, moving from visual to written model
+  * Defects profile, canonicalisation, usage profile
+  * WG:  AI BOM team meeting regularly, looking at defining how to define training data, data sets, etc., starting to work up minimal set of fields
+    * focused on how to represent models and training data for models
+*  WG: SPDX Implementers Group - meeting to discuss best practices around generating SPDX documents, meeting every other Wednesday
+* WG: Build data - Brandon Lum heading up recurring meeting, Monday nights European time
+* WG: Canonicalization - Meets on Friday,  discussing the serializations for the 3.0 model.
+* Namespace discussions,  additional meeting with Friday.
+* Desire to have working group meetings listed and calendar invites visible
+  * Sebastian - looking to update wiki in short term, https://wiki.spdx.org/
+  * Gary - currently discussed primarily on tech team list
+  * Jilayne - would it make sense to add meeting times to https://github.com/spdx/meetings -- main README
+
+## Legal Team Report - Jilayne/Paul/Steve
+* License List 3.17 released in May
+* Focus currently on discussion of cross-team topics for spec - license namespaces, etc.
+* Looking to get a bit more formalization on cross-team topics:
+  * avoid multiple conversations on separate calls, look to have joint calls where appropriate
+  * proposals for something significant and new: aim to be more disciplined in articulating what's being solved for, e.g. "problem statement" / "what is this trying to achieve"; articulate how this fits into the mission of the project
+  * try to define the goals / problem statement before jumping to implementation
+* Namespace discussion tomorrow - https://lists.spdx.org/g/Spdx-tech/message/4539; please read first before coming to meeting
+
+## Outreach Team Report -  Sebastian / Jack / Alexios
+* GSOC
+  * 2 projects for this summer, now in the community bonding period
+  * communicate with participants
+  * Coding period starts next week
+* Material progress on SPDX website rebuild, sneak peek on upcoming outreach team call
+* Joshua Marpet working on additional outreach things
+* Upcoming talks:
+  * Kate - upcoming RSA talk with Allen Friedman re: SBOMs and tooling, come by and say hi in person if you'll be there!
+  * Steve - Zephyr Developer Summit next week, SBOMs at build time
+  * Steve - OSPOCon / OSS NA later in June, SPDX License List
+
+
+## Attendees
+* David Edelsohn, IBM
+* Kate Stewart, LF
+* Jeff Buddington
+* Gary O'Neall
+* Alex Rybak, Revenera
+* Dick Brooks, REA
+* Alexios Zavras
+* Rich Steenwyk, GE Healthcare
+* Jeff Schutt
+* Sebastian Crane
+* Molly Menoni
+* Phil Odence, Synopsys
+* Steve Winslow, Boston Tech Law
+* Jack Manbeck
+* Yoshiyuki Ito
+* Brad Goldring, GTC Law Group
+* Andrew Jorgensen
+* Michael Herzog
+* Joshua Watt
+* Rose Judge
+* Sunil Jain
+* Karsten Klein
+* Mark Atwood, Amazon.com
+* Tony Aiuto, Google
+* Marc-Etienne Vargenau, Nokia
+* VM Brasseur, Wipro
+* Adrian Diglio, Microsoft
+* Hector Fernandez, VMware
+
+
+        ---------------------

--- a/general/2022/2022-07-07.md
+++ b/general/2022/2022-07-07.md
@@ -1,0 +1,98 @@
+# SPDX General Meeting Minutes - July 7, 2022
+
+
+## Administrative
+### Attendance: 23
+- Lead by Phil Odence
+- Minutes from last meeting approved
+
+## Steering Committee Update - Phil
+* Postive sessions on interop with OWASP/CycloneDX and Allan Friedman at LF Conference
+* ARM is now an SPDX member with some other big companies to come
+* A series of extra meetings to discuss getting license "namespace" proposal resolved
+* Please check what mailing lists you are on, sign up for anything you aren't on but should be, and be mindful of mailing list membership and keeping discussions ot appropriate mailing list.- https://lists.spdx.org/g/spdx
+* Jilayne leading word to define framework for proposing changes and  reaching quicker resolution on new proposals. Looking for project management experience to help inform.
+
+## Brief Documentation Repository Discussion
+* Thread: https://lists.spdx.org/g/spdx/topic/91905419#1537
+* Vicky sent email to list regarding issues for "getting started w/SPDX" documentation
+* Suggestion: a docs repo
+* Getting started is hard, so logging obsticles will enable better doc
+* Legal Team License LIst team has a doc repo for that particular purpose, so need to define what goes in the new repo
+* outreach team has outreach repo for marketing type materials
+* Name? "Docs" seems appropriate., can alway reconfigure or rename later as we build up resources
+* now created at https://github.com/spdx/DOCS
+
+
+## Tech Team Report - Gary/WilliamB
+
+### Spec
+* SPDX 2.3
+* RDF OWL ontology available for review –  https://github.com/spdx/spdx-spec/blob/development/v2.3/ontology/spdx-ontology.owl.ttl
+* JSON Schema available for review - https://github.com/spdx/spdx-spec/blob/development/v2.3/schemas/spdx-schema.json
+draft is ready for review in Github - https://github.com/spdx/spdx-spec/
+* An HTML version will be available once we resolve a script issue.  We will send out an email to the general dist. list once the HTML is available for review.
+* The SPDX Java tools are being updated – code is complete, waiting for the spec to be approved before release.
+*SPDX 2.3 includes the following changes:
+Add external references for security scenarios.
+Added a “primary package purpose” to describe how a software package is intended to be used (e.g. installation file, container) – important for some security scenarios
+Added several additional hash algorithms
+Made several of the licensing properties optional rather than requiring a “NOASSERTION” value
+Added several fields to support lifecycles for the package (valid until date, release date, built date)
+Documented the snippet information in files – consistent with REUSE recommendations
+* SPDX 3.0 modeling work underway
+Closed on a few issues related to identity
+Canonicalization sub-team making progress [could use update from Sebastion]
+working to standardize serializations so they will be interoperable
+Build profile sub-team making progress [could use an update from Brandon]
+Defects sub- team making progress [could use an update from Thomas]
+Aim to get updates from sub-teams next month
+* Had a successful meeting with CycloneDX in Austin and launched technical collaboration to make it easier to translate between SPDX and CycloneDX formats
+* Started 2 Google Summer of Code Projects – both underway
+* Some progress on the license namespace proposal – agreed on the problem statement, agreed on how the current spec supports some of the use cases, agreed on the policies we would use for registration.  Have not yet come to closure on the syntax.
+* Announced William as additional team lead for Tech Team + Steering Committee member 👏
+
+## Legal Team Report - Jilayne/Paul/Steve
+* focus this release cycle has been on the license namespace proposals
+* policies for license namespaces have now been finalized; some of the procedures still to be finalized
+* Jilayne: matching guidelines never updated to reflect the XML structure for the current license-list-XML repo; working on updates
+  * also to resolve where these will live -- just the webpage, just the spec, both?
+* 3.18 release coming up end of July -- need to buckle down on getting new additions in
+
+## Outreach Team Report -  Sebastian / Jack / Alexios
+* Lots of talks!
+  - Kate - OSSNA, also online yesterday for OpenUK
+  - Steve - OSSNA talk re: SPDX License List; Zephyr Dev Summit re: generating at build time
+  - Joshua Watt - OSSNA talk re: SPDX generation in Yocto at build time
+  - Sebastian - have been participating in Reproducible Builds community, section in their monthly report - more collaboration coming
+  - Bob - RSA conference talk, included slides on SBOMs with focus on SPDX
+  - Would be great to have a list of bullet points to talks and links to videos - probably in Outreach repo? Folks can submit issues to Outreach repo with links to talks
+* Kate and Bob involved in IETF working group on SBOMs - effort focused on supply chain integrity, transparency and trust; confidential distributed ledger to gather info, countersign, make available for validation
+* Getting Started material in process
+* Announced Alexios as additional team lead for Outreach Team + Steering Committee member 👏
+* Will be rescheduling meetings for shorter, more actionable + quicker movement
+
+## Attendees
+* Phil Odence, Synopsys/Black Duck Audits
+* David Edelsohn, IBM
+* VM (Vicky) Brasseur, Wipro
+* Gary O'Neall
+* Paul Madick
+* May Wang (Palo Alto Networks)
+* Steve Winslow
+* Bob Martin
+* Christopher Lusk
+* Jeff Schutt
+* William Cox (Synopsys)
+* Bryan Cowan (Fortress)
+* Molly Menoni
+* Ria Schalnat
+* William Bartholomew
+* Jilayne Lovejoy
+* Joshua Watt
+* Marc-Etienne Vargenau
+* Alfredo Espinosa
+* Sebastian Crane
+* Adrian Diglio (Microsoft)
+* Rich Steenwyk (GE Healthcare)
+* Michael Herzog

--- a/general/2022/2022-08-04.md
+++ b/general/2022/2022-08-04.md
@@ -1,0 +1,79 @@
+# SPDX General Meeting Minutes - Aug 4, 2022
+
+
+## Administrative
+### Attendance: 29
+* Lead by Phil Odence, Steve Winslow
+* Minutes from last meeting approved
+
+## Special Presentation, Matthew Crawford
+* A new era for SPDX at Arm, are we ready for change? - A New Era for SPDX at Arm: Are we ready for change? (recording available, insert link later)
+* Thanks to Jilayne, Sami Atabani and SPDX team
+* Old system (ulimately non-std BoM format)
+* Towards generating SPDX
+* New tooling "hot off the press"
+
+## Tech Team Report - Gary/Kate/WilliamB
+
+### Spec
+* SPDX 2.3 release window - 6 days left. If see any issues, raise in Github, or on tech team email list
+   * RC1 window - no roadblocks raised yet.
+   * Schema available and tool creators requested to experiment and raise issues.
+   * Joshua - CVE reporting added, not clear how to use it.   Gary:  using external references to refer to CVEs, as well as other security types.   Any way to indicate a specific CVE has been fixed?   VEX document may be an option.  Recommed going to defects working group.
+   * Java tools have been implemented, will be publised after 2.3 release is out.
+* GSoC checkpoint - Alexios
+  * just passed half-time mark, steady progress on both projects.
+* SPDX 3.0 Model
+   * Good progress on identities,  updated in repo. seee: SPDX v3 model diagram https://github.com/spdx/spdx-3-model/blob/main/model.png
+   * AI BOM profile - discussed into 2 parts - AI App/Model & Data sets
+   * Build Profile - making steady process
+   * Defects - looking at what should be in 3.0 now,  use-cases welcome
+   * Usage -
+
+## Legal Team Report - Jilayne/Paul/Steve
+* 3.18 release pushed by one week - expect to release likely this coming weekend
+* 3.19 - looking to focus on documentation
+* Fedora has now adopted SPDX license identifiers - https://communityblog.fedoraproject.org/important-changes-to-software-license-information-in-fedora-packages-spdx-and-more/
+
+## Outreach Team Report -  Sebastian / Jack / Alexios
+* GSoC - mentioned above
+* general activity, making improvements to outreach team Landscape with Wipro volunteer assistance (thanks Vicky and others!)
+* logos for SPDX's own tools - seeking folks with graphic design talents
+  * can explore with LF marketing (Steve will help with LF interaction)
+  * noted at OpenSSF - using AI image generators
+  * Meeting time is changing to shorter weekly 30 minute meetings.
+
+
+## Attendees
+* Phil Odence, Synopsys/Black Duck Audits
+* Matthew Crawford (Arm)
+* Kate Stewart
+* Gary O'Neall
+* Jilayne Lovejoy (Red Hat)
+* Jari Koivisto
+* Sebastian Crane
+* Alexios Zavras
+* Steve Winslow
+* Ray Lutz (Citizensoversight.org)
+* Akbar (Arm)
+* Alex Rybak (Revenera)
+* Alfredo Espinosa
+* Andrew Jorgenson
+* Brad Goldring (GTC Law Group)
+* Bryan Cowan
+* Christopher Lusk
+* David Edelsohn
+* Jeff H.
+* Karsten Klein
+* Molly Menoni
+* Rich Steenwyk
+* Shailja Kumari
+* Joshua Watt
+* Ria Schalnat
+* Stephen Reeves
+* Janet
+* VM Brasseur
+* Jeff Schutt
+
+
+        ---------------------

--- a/general/2022/2022-09-01.md
+++ b/general/2022/2022-09-01.md
@@ -1,0 +1,88 @@
+# SPDX General Meeting Minutes - Sept 1, 2022
+
+## Administrative
+* Lead by Phil Odence
+* Minutes from last meeting approved (pending recording resolution)
+
+### Attendance: 19
+
+
+## Steering Committee Update - Phil
+
+* LinuxCon Europe, Dublin Sept 13-16, Kate is organizing an SPDX meet up
+     * Let Kate know if you are going to be there!
+     * Nisha is hosting an SBOM tooling BOF as well
+* Other events, still open for papers:
+* Member summit, Tahoe Nov 8-10
+* Open Compliance summit, Japan Nov 7
+* Website / Wiki
+    * SPDX Wiki was place we did work in the past, but been slow migration away from that to Github. E.g., meeting minutes were stored there until recently moved to Github.
+    * Alexios has moved those to Github and Team Leads to look at any other wiki material to move into an appropriate place in Github repos. TBD on whether Wiki eventually gets taken down or just noted as archive
+    * website - Sebastian working on update, more on that in a month or so!
+* New change process - Jilayne - see https://github.com/spdx/change-proposal and email sent to main mailing lists
+
+## Tech Team Report - Gary/Kate
+
+### Spec
+* 2.3
+    * essentially done
+    * has been tagged as current in GitHub
+    * still wrestling a a little with pdf generation
+    * https://spdx.github.io/spdx-spec/v2.3/
+* 3.0 Core
+    * Remaining Model punch list has been articulated,  getting close.
+    * After core model tagged,  serialization will be next focus of the tech team.
+    * Some serialization work happening in parallel in canonicalization meeting.
+* Profile active progress towards 3.0
+    * Defects - meeting again, after summer break
+    * Usage - picking up again in Japan OpenChain group
+    * AI profile - has split into AI application & Dataset profile.    AI BOM presentation scheduled in Dublin.
+    * Build profile - actively working on draft.
+    * New FuSa profile group starting to meet and articulate evidence necessary for Functional Safety Case
+* Tooling
+    * GSoC
+        * Presenations in next month's General Meeting
+        * Open SSF has approved funding Python library clean up, TNG Technology will have 2 contractors helping us with the cleanup between this year
+        * 2.3 updates
+            * Java tools - version 1.1.0 release including support for SPDX 2.3
+            * Maven plug in - version 0.6.0 released with support for SPDX 2.3 and JSON format
+            * On line tools - updated to support SPDX 2.3
+           * Gary working on Cyclone DX converter- new version supports SPDX 2.3, will be moved to SPDX repo this month
+         * Nisha hosting SBOM Tooling BOF in Dublin next month,  all tool creators welcome.
+         * Nisha has taken over as maintainer of spdx-sbom-generator - could use help, see her posts on email list, or show up at meetings she's hosting.
+
+## Legal Team Report - Jilayne
+* Documentation release for end of Oct release cycle
+* lots to do in that timeframe
+* Implementing some improvments and ease of use in license submission tool
+* Richard Fontana has submitted approx 13 new licenses, to align with Fedora! Good for SPDX License List to have better representation for overall linux distro
+
+## Outreach Team Report -  Sebastian
+* Moved to weekly meeting on Mondays, was too hard to squeeze everything in to previous meeting cycle
+     * this is especially helpful for new website work
+     * next week's meeting probably cancelled due to US holiday
+
+
+## Attendees
+* Phil Odence, Synopsys/Black Duck Audits
+* Alex Rybak
+* Bob Martin
+* Brad Goldring, GTC Law Group
+* Bryan Cowan
+* David Edelsohn
+* Deanna Medina
+* Gary O'Neall
+* Jari Koivisto
+* Jeff Schutt
+* Jilayne Lovejoy
+* Joshua Watt
+* Karsten Klein
+* Kate Stewart
+* Matthew Crawford
+* Michael Herzog
+* Ria Schalnat
+* Sebastian Crane
+* Steven C
+
+
+        ---------------------

--- a/general/2022/2022-10-06.md
+++ b/general/2022/2022-10-06.md
@@ -1,0 +1,117 @@
+# SPDX General Meeting Minutes - Oct 6, 2022
+
+## Administrative
+* Lead by Phil Odence
+* Minutes from last meeting approved
+
+### Attendance: 23
+
+
+## Special Presentation - NTIA Conformance Checker – Josh Lin
+* Introducing Josh and GSoC
+* NTIA Minimum Elements
+* Checker "checks" whether SBOM meets minimum requirements
+* plus one other field, doc version
+* Demo
+* Web app
+* Command line available too
+* Q&A
+
+## Steering Committee Update
+* Wiki freeze
+* 2.3 pdf
+* Legal Team License List cadence
+
+## Tech Team Report - Gary
+
+### Spec
+* 2.3
+    * Essentially released
+    * Still some remaining "cleanup" items
+    * But good to go; ready for use
+* 3.0 Core
+    * Continuing to work through core model with punchlist
+    * Schedule
+    * Have been targeting end of 2022
+* looking unlikely,
+* Core work is an important dependency
+* Working with Cyclone DX on interop including tooling
+* good working relationship
+* aiming for lossless translation between the two
+* trying to include as much joint functionality as possiblity
+* Profile active progress towards 3.0
+    * Defects -
+    * Usage -
+    * AI profile -
+    * Build profile -
+    * New FuSa profile
+* Tooling
+    * Lots of activity
+    * Significant interest in the Maven plugin
+    * Fairly significant release of the tools in the next week or so (including Josh's utility)
+    * Lots of progress on Go tools
+
+## Legal Team Report - Jilayne, Steve
+* Current focus is on processes and documentation
+  * ergo less on processing submissions
+* However, submissions have ramped up
+  * Fedora/Richard Fontana in particular has proposed many new licenses
+  * So 32 pending, much higher than normal
+  * https://github.com/spdx/license-list-XML/issues - please come and weigh in on submitted issues, re: whether requests fit with the license inclusion principles at https://github.com/spdx/license-list-XML/blob/main/DOCS/license-inclusion-principles.md
+* Cadence discussion
+  * Has been calendar quarter + 1
+  * Looking at major/minor version numbers
+  * Open to input from tool vendors on Legal Team mailing list - https://lists.spdx.org/g/Spdx-legal
+* Help needed
+  * People to do the work
+  * Automation of license mark up
+* Old license
+  * Fedora, Debian, FreeBSD collaboration on license archaeology
+
+## Outreach Team Report -  Sebastian
+* Website
+  * Rebuild entering next stage
+  * Must meet LF standards
+  * Collecting member logs in vector formats (to scale up and down from phone to mega monitor)
+* 2.3 pdf
+  * SPDX has grown and so has the task
+  * Jack has done previous and conversion for the ISO spec
+  * Stepping back and building markdown to LaTeX pdf convertor
+    * Pandoc has not been effective
+    * Tables are a particular problem
+    * Perhaps there's an existing, non-Pandoc, tool that would serve
+  * Should be addressed in 3.0, built in by design
+    * spec generator that Alexios is driving
+* Help needed
+  * website in particular
+  * bringing content over
+  * so need
+    * writing
+    * graphic design
+    * web development
+
+
+## Attendees
+* Phil Odence, Synopsys/Black Duck Audits
+* Jari Koivisto
+* David Edelsohn
+* VM Brasseur
+* Armin Tanzer
+* Gary O'Neall
+* William Cox (Synopsys)
+* Josh Lin
+* Steve Winslow
+* Karsten Klein (metaeffekt)
+* Alex Rybak (Revenera)
+* Bruce
+* Brad Goldring (GTC Law Group)
+* Jack Manbeck
+* Rich Steenwyk (GE Healthcare)
+* Bryan Cowan (Fortress)
+* Nicolaus Weidner
+* Jilayne Lovejoy
+* Michael Herzog
+* Sebastian Crane
+* Molly Menoni
+* Marc-Etienne Vargenau
+* Ria Schalnat

--- a/general/2022/2022-11-03.md
+++ b/general/2022/2022-11-03.md
@@ -1,0 +1,85 @@
+# SPDX General Meeting Minutes - Nov 3, 2022
+
+## Administrative
+* Lead by Phil Odence
+* Minutes from last meeting approved
+
+### Attendance: 27
+
+
+## Steering Committee Update - Phil
+* Still struggling with V2.3 pdf
+* Discussions with NexB about pulling in some licenses from their database
+* 3.0 - readiing for actual spec writing
+* Finalzing structure
+* Could use some hands on writing help from those already involved
+* SPDX for SBOM/Security Positioning
+
+## Special Presentation - Security info in SBOMs - an update from the Defects WG - Thomas
+* Slides: https://docs.google.com/presentation/d/1sKRHQV--tOo2mjBqHNdXy9YnSDlLOsaFgThtd5RjcIw/edit?usp=sharing
+
+
+## Tech Team Report - Gary, Kate
+* DocFest coming up Nov. 30 based on 2.3 spec, optionally 2.2
+* Working to unblock any issues with sub-teams
+
+### Spec
+* 3.0 Core - Gary
+
+    * Punch list of open items, working through
+    * Started up extra 2 hour meeting every Friday
+    * Should be transitioning to spec writeup soon
+* Profile active progress towards 3.0
+    * Build - Brandon
+      * Making good headway, new GitHub repo with use cases, model
+      * Focusing on a couple of build systems and mapping them
+    * Licensing - Steve
+      * Discussed substance in 2020 drafts, had submitted PR in old spec MarkDown format in spring 2021
+      * Steve and Alexios aligned on formatting, will be submitting new PR to spdx-3-model repo
+    * Defects - Thomas
+    * Usage - most participants in Japan, not on General call
+    * Linkage - no one on call
+      * Gary: understand there's been a lot of discussion on structure, etc.
+    * AI / data - Kate not on call
+      * Sebastian - not on team but provided details: team has focused on details around training AI models on data sets, which can have different properties from the model itself and the software used to create the model
+      * Focused on enabling producers / consumers of SPDX data to be able to better describe properties of AI systems
+* Canoncalization - Sebastian: no updates for this meeting, more next time
+
+## Legal Team Report - Steve
+* 3.19 coming out shortly, focused on docs update so will be smaller set of new licenses
+* 3.20 will be larger
+
+## Outreach Team Report -  Sebastian
+* Website and PDF updates taking longer than planned but moving along
+* Special thanks to Thomas -- fully agree re: call to action, outreach help needed especially re: security
+* Overall need to improve automated tooling for generating spec -- past processes of hand-created spec docs and artifacts haven't been sustainable for new 3.0 work
+
+
+## Attendees
+* Phil Odence, Synopsys/Black Duck Audits
+* William Cox, Synopsys
+* Jari Koivisto
+* Bob Martin, Mitre
+* Steven Carbno / Smart Talk Beacon
+* Gary O'Neall, Source Auditor Inc.
+* Thomas Steenbergen, EPAM Systems Inc,
+* Maximilian Huber, TNG
+* Alexios Zavras, Intel
+* Brad Goldring, GTC Law Group
+* Brandon Lum, Google
+* David Edelsohn, IBM
+* Marc Frankel, Manifest
+* Ramesh
+* Ria Schalnat, HPE
+* Jeff Schutt, Cisco
+* Steve Winslow
+* Alex Rybak, Revenera
+* Daniel
+* Sebastian Crane
+* Michael Herzog, NexB
+* Jilayne Lovejoy, Red Hat
+* Mark Gisi
+* May Wang
+* Gale McCommons, Comcast
+* Tony Aiuto, Google
+* Paul Madick

--- a/general/2022/2022-12-01.md
+++ b/general/2022/2022-12-01.md
@@ -1,0 +1,89 @@
+# SPDX General Meeting Minutes - Dec 1, 2022
+
+## Administrative
+* Lead by Phil Odence
+* Minutes from last meeting approved
+
+### Attendance: 16
+
+## Steering Committee Update - Phil
+* Lots of discussion of participation
+* Certainly could use help on
+* Tech- drafting 3.0
+* Legal- license review
+* Outreach- website
+* Stay tuned for SPDX for Security article
+
+## Special Presentations
+* Contribution to SPDX 3.0 Specification - Alexios
+* Preliminary feedback from DocFest - Gary
+
+## Tech Team Report - Gary, William, Kate
+
+* SPDX 2.3
+  * Updated .pdf from Jack;  review and logging needed
+  * Python tools updated to reflect 2.3 - looking for testers at https://github.com/spdx/tools-python
+
+* SPDX 3.0
+  * Core Profile - William/Gary/Kate
+    * Worked through bulk of outstanding punchlist, now just focusing on identity/agent clarifications.
+    * Established workflow to collect profile contributions (see talk from Alexios above)
+  * Licensing Profile - Steve/Alexios
+    * Profile contributions to SPDX 3.0 unblocked.
+  * Security Profile - Thomas/Jeff
+    *  In addition to linking to VEX documents, team is evaluating minimal VEX elements to embed in SPDX to convey security info in a simplified manner
+    * Documenting Security Use Cases in 3.0
+    * Planning 3 hour workshops on 12/15 & 12/21 to move preliminary security profile information into the model.
+  * Build Profile - Brandon/Nisha
+    * Draft relationship and build element completed (https://github.com/spdx/spdx-3-build-profile)
+    * Created examples to validate two use cases, one github actions and YOCTO (including nested build)
+    * Dependency on identity/agent 3.0 model discussion.
+    * Working on presentation about Build and Safety for OCS Japan event.
+  * Usage Profile - Ito/Ninjouji/Asaba/Kobota
+     * Basic set of fields established but some possible overlap with Build Profile, to be discussed next week.
+     * Planning for presentation at SPDX Minifest at OCS Japan
+  * AI & Dataset Profile - Gopi/Karen/Kate
+* Working on examples using Dataset profile, to look for coverage.
+* Have worked though 3 Datasets, so far no adjustments needed, looking to get more examples from OpenDataology group.
+* Will start to work through AI application examples in December, and upstream dataset profile
+* Standford Cybersecurity talk mention of our work at:  https://youtu.be/ZGnQGfzhwjI
+* Prep for SPDX Minifest at OCS Japan
+  * Functional Safety - Nicole/Kate
+     * Diagraming of all safety artifacts in progress
+     * Some possible new relationships under consideration to be added.
+
+## Legal Team Update - Jilayne/Steve/Paul
+* 3.19 released yesterday
+  * focused on documentation, made good improvements (more to do)
+  * some process discussions still in the works
+  * reworked FAQs, now in the repo so easier to update, welcome suggestions / additions via PRs
+* 3.20 - lots of submissions ready for review
+  * most coming from Fedora adopting SPDX IDs
+  * previously, SPDX had based several additions off of Fedora's "good" licenses
+  * many are things that aren't just in Fedora -- e.g. Warner from FreeBSD has been weighing in; many are old licenses
+* Process of how to review licenses -- aiming to make more accessible to people
+  * may have a training session for the community
+  * watch the spdx-legal mailing list for updates
+
+## Outreach Team Update - Sebastian/Alexios/Jack
+* Working on messaging around SPDX and security -- making clearer and simpler for others to reuse as well
+* Started to collect presentations about SPDX, or about SBOMs generally that mention SPDX -- will look to publish somewhere collectively - https://github.com/spdx/outreach
+
+
+## Attendees
+* Alex Rybak (Revenera)
+* Alexios Zavras
+* Bob Martin
+* Bryan Cowan (Fortress)
+* Gale McCommons (Comcast)
+* Gary O'Neall
+* Jilayne Lovejoy
+* Karen Bennet
+* Marc-Etienne Vargenau
+* Mary Hardy (Microsoft)
+* Maximilian Huber
+* Michael Herzog
+* Paul Madick
+* Phil Odence (Black Duck Audits, Synopsys)
+* Ritesh Sonawane
+* Steve Winslow


### PR DESCRIPTION
There are general meeting notes dating back more than a decade. Instead of putting them all in the same directory and creating clutter, organize them by year.