### PR TITLE
Outreach Team minutes for July

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Meetings schedules for the SPDX Project are listed below. All times are listed f
 * Descriptions: Regular meeting to discuss and propose the SPDX build profile and other adjacent elements.
 
 ### Canonicalisation group meetings
-* Time and cadence: weekly on Fridays at 09:00
-* Where: <https://meet.jit.si/SPDXCanonicalMeeting>
+<!-- * Time and cadence: weekly on Fridays at 09:00 -->
+<!-- * Where: <https://meet.jit.si/SPDXCanonicalMeeting> -->
 * Descriptions: Regular meeting to develop the Canonical Serialisation for SPDX 3.0 and agree on recommendations to make to the Tech Team where appropriate.
+* *Note*: the group has paused their regular meetings, waiting for final serialization(s) outcome.
 
 ### Defects Profile group meetings
 * Time and cadence: weekly on Wednesdays at 14:00

--- a/outreach/2023-06-12.md
+++ b/outreach/2023-06-12.md
@@ -1,0 +1,54 @@
+# SPDX Outreach Team meetings - 12 June 2023
+
+## Agenda
+
+- Review the Outreach Team members are properly updated
+- Open Source Summit Europe 2023: SPDX Mini summit: what should we showcase?
+- Update on content
+- Timing of 3.0 release
+- Update from last meeting - Github repo for outreach team communications
+
+
+## Attendees
+- Alexios Zavras
+- Bob Martin
+- Gary O'Neall
+- Jordi Mon Companys
+- Phil Odence
+
+
+## Notes
+
+### Outreach Team names
+- SPDX Website https://spdx.dev/participate/outreach/
+- Should we add it to the GitHub repo? https://github.com/spdx/meetings
+- AR: leave Alexios and Bob as Team Chairs; no member list
+- No mention of people in the minutes repo
+  
+### Open Source Summit Europe 2023
+- 19-21 September, Bilbao
+- SPDX Mini summit half-day accepted, Mon 18 afternoon 1330-1700
+- presentations per profile / use case  
+- tooling interop bakeoff/docfest in the morning; results in the afternoon
+- AR: jordi to ask for a room, 10-15 people (not part of OSS summit)
+- "SPDX Tooling Interop" 
+
+### Update on content
+- Last OSS (Vancouver) videos uploaded to LF Youtube channel
+- Three blog posts this week:
+  - Opening blog posts of the series based on the talks given in the Vancouver minisummit
+  - First blog posts of that series
+  - Google Summer of Code celebration
+- SPDX ecosystem interviews:
+  - First guest: VMWare https://project.linuxfoundation.org/vmware-loves-spdxsbom-english (do not share this link, it'll be announced later today in socials)
+
+### Timing of 3.0 release
+- deadline for website content end of June
+
+### Other
+- LF website team to come to next(?) Steering Committe call
+
+- Follow-up from last meeting on Github repos:
+  - https://github.com/spdx/internal/blob/main/outreach/presentation-opportunities.md
+  - https://github.com/spdx/outreach/pull/17
+

--- a/outreach/2023-06-19.md
+++ b/outreach/2023-06-19.md
@@ -1,0 +1,47 @@
+# SPDX Outreach Team meetings - 19 June 2023
+
+## Agenda
+
+- SPDX mini summit, September, Bilbao
+- Blog posts published:
+- "SPDX ecosystem" interview
+- press release for the GA announcement
+- website updates
+
+
+## Attendees
+
+- Alexios Zavras
+- Jack Manbeck
+- Jordi Mon Companys
+
+
+## Notes
+
+### SPDX mini summit, September, Bilbao
+- description
+- registration charge $10
+- Tools meetign in the morning?
+  - email to tech and implementers lists to gauge interest
+
+###Blog posts publihsed
+- OSS NA Summit intro post:https://spdx.dev/unpacking-the-spdx-3-0-tooling-mini-summit-a-new-era-of-compliance-and-security/
+- GSoC post: https://spdx.dev/spdx-projects-in-google-summer-of-code-2023/
+- LinkedIn and Twitter to amplify:
+  - https://www.linkedin.com/posts/spdx-sbom_we-are-beyond-happy-to-announce-that-the-activity-7076560458832322560-9l6O
+  - https://twitter.com/SPDX_SBOM/status/1670798551419420673
+  - https://www.linkedin.com/feed/update/urn:li:activity:7075114958379732992
+  - https://twitter.com/SPDX_SBOM/status/1669348795300315142
+
+### "SPDX ecosystem" interview
+- First one on Thursday: https://youtube.com/live/OuKO0T1Ctws?feature=share
+- youtube live
+
+### press release for the GA announcement
+- There are two alternatives and all quotes are listed
+- almost all quotes collected
+
+### website updates
+- Outreach chairs page updated https://spdx.dev/participate/outreach/
+- profile/use cases pages content to be collected till 30 June 
+

--- a/outreach/2023-06-26.md
+++ b/outreach/2023-06-26.md
@@ -1,0 +1,23 @@
+# SPDX Outreach Team meetings - 26 June 2023
+
+## Agenda
+
+
+## Attendees
+- Alexios Zavras
+- Gary O'Neall
+- Phil Odence
+
+
+## Notes
+
+### meeting notes to GitHub
+- existing notes can be merged
+
+### meeting with GitLab
+- waiting for update from Jordi
+  
+### new website
+- there was a meeting about working the sitemap
+- tomorrow call with LF website team
+


### PR DESCRIPTION
- Adds Outreach Team meeting notes for July
- Marks canonicalization meetings as paused.
