### PR TITLE
Add missing security minutes

### DIFF
--- a/security/2023-02-22.md
+++ b/security/2023-02-22.md
@@ -1,0 +1,11 @@
+## SPDX Defects Team Workshop February 22, 2023 
+
+## Attendees
+* Thomas Steenbergen
+* William Cox
+* Bob Martin
+* Rose Judge
+* Dick Brooks
+
+## Agenda
+* Documenting the defects specification

--- a/security/2023-03-01.md
+++ b/security/2023-03-01.md
@@ -1,0 +1,30 @@
+# SPDX Defects Team Workshop March 3, 2023
+
+## Attendees
+* Rose Judge
+* Thomas Steenbergen
+* Dick Brooks
+* Jeff Schutt
+* William Cox
+* Henk Birkholz
+* Kate Stewart
+
+## Agenda
+* Approve meeting minutes from last week
+* Continue working on defects specification
+
+## Notes
+### Approve Meeting minutes
+* No minutes from last week
+
+### Documenting the defects specification
+* Working here: https://docs.google.com/document/d/1ZT_w3HiW6LJjouRlw3xHXPnmy7ArwOdlw4vpzIjS9_o/edit
+* https://github.com/spdx/spdx-3-model/blob/main/model.png
+* Thomas met with William in Berlin this week. William is working on how to make the spec into a webpage - what format do we need to follow so it's compatible? William says follow the format of the build profile and he will work on a tool to do the actual rendering.
+* Kate asked us to priotize defining the advisory relationship so we can add this to the document summarizing differences between SPDX 2.x and 3.0 (https://docs.google.com/document/d/1-olHRnX1CssUS67Psv_sAq9Vd-pc81HF8MM0hA7M0hg/edit#)
+* Discussion around ADVISORY_FOR and HAS_ADVISORY (consistent with exisiting relationships in 2.x spec) vs just ADVISORY for a more bilateral definition. Decision to use just ADVISORY for a loose coupling to inidicate security-related relationship between an artifact and a vulnerability. Using the FOR and HAS relationships has potential to duplicate the same information (i.e. `vulnerability ADVISORY_FOR package` and `package HAS_ADVISORY vulnerability`)
+* Q: Relationship must go from Element to Element - what elements does ADVISORY connect to? A: Package and Vulnerability 
+* "Created" - creating an element in a document - "Published" is if the vuln has been published outside the document in public. 
+* Kate is thinking published is ambiguous - Should indiciate the pubishing of the vulnerability itself as opposed to the description of the vulnerability in the SPDX document.
+* Pushback that "publish" is a common term in the vulnerability world
+* Kate is fine with the field being "published", wants a more clear definition. Agreement to define it as "Identifies when the vulnerability was published by a vendor or coordinator"

--- a/security/2023-03-29.md
+++ b/security/2023-03-29.md
@@ -1,0 +1,13 @@
+# SPDX Defects Team Workshop - March 29, 2023 
+
+## Attendees
+* Thomas Steenbergen
+* Rose Judge
+
+## Agenda
+* Approve meeting minutes from last week
+* Continue working on defects specification
+
+## Notes
+### Defects specification
+* https://hackmd.io/@tsteenbe/SJegdlGZn/edit

--- a/security/2023-04-11.md
+++ b/security/2023-04-11.md
@@ -1,0 +1,14 @@
+# SPDX Defects Team Workshop April 11, 2023
+
+## Attendees
+* Adolfo Garcia Veytia
+* Henk Bikholz
+* William Cox
+* Rose Judge
+* Jeff Schutt
+
+## Agenda
+### VEX in SPDX 3.0 
+- If something is likely to change, use a relationship -- otherwise use a property
+
+

--- a/security/2023-04-21.md
+++ b/security/2023-04-21.md
@@ -1,0 +1,34 @@
+# SPDX Defects Team Workshop - April 21, 2023
+
+## Attendees
+* Rose Judge
+* Gary O'Neall
+* Thomas Steenbergen
+* Henk Birkholz
+* Jeff Schutt
+* Sean Barnum
+* Maximilian Huber
+* Karsten Klein
+
+## Notes
+* Worked on the JSON example for the security profile and updated the security profile model appropriately
+* Decided to use relationshipTypes for the security profile as relationships require timestamp(s) and Ids, which adds value over having only a property
+
+### TODO
+* Iterate on the JSON example to include examples for:
+     * each relationshipType, including appropriate timestamps
+     * how a VulnCategorization gets replaced
+     * how vex affects multiple products..discussion w/ tech-team on rootElement to represent the product
+* Update product profile & product class in security profile model to use RootElement 
+* Queue up discussion for SPDX Tech Team
+  1. how to update/replace relationships?
+    * supplements: a opqaue statement provides additional information about another referenced opque statement 
+    * replaces: adds an opaque fresh statement and redners a referenced opque statement stale 
+    * refreshes: a non-opque statement that states that a referenced opaque or non-opaue statement is still fresh 
+    * invalidates: a non-opaque statement that declares another opqaue or non-opaquie statement stale and therefore not valid anymore
+  2. Making the suppliedBy relationship more generic because today only applies to artifacts
+  3. ExternalIdentifier - add an identifierLocator and an issuingAuthority
+  4. Add optional timestamps to relationships, e.g. startTime and endTime
+  5. discuss if one can create relationship on Bundles? (model both relationship directions)
+      From: Bundle of security information (vulnerability rootElement) relating TO: a single package or bundle of packages (SBOM)
+      From a single package (rootElement) to a bundle of vulnerability information. 

--- a/security/2023-04-26.md
+++ b/security/2023-04-26.md
@@ -1,0 +1,73 @@
+# SPDX Defects Team Meeting - April 26, 2023
+
+## Attendees
+* Thomas Steenbergen
+* Jeff Schutt
+* Gary O'Neall
+* Rose Judge
+* Adolfo Garcia Veytia
+* Karsten Klein
+* William Cox
+
+## Agenda
+* Help Rose with Security Profile presentation for SPDX 3.0 Tooling Mini Summit
+* Clean up model with the latest changes
+* Should rename categorization to William name?
+* Revisit status in VEX relationship
+* Adding more types to ExternalReference
+
+## Notes
+### Mini summit presentation
+* Make sure to include VDR example 
+
+### Vulnerability Categorizations
+* Karsten: would expect vulnerabilityCateogrization as a propety of vulnerability element since the two are related
+* Jeff: The reason we used that is because the cvss* score is a way to describe the vulnerability, each type with its own set of properties to describe it
+* Should we rename categorization to assessment?
+* Consensus to change from "VulnerabilityCategorization" to "VulnerabilityAssessment"
+* Published/modified/withdrawn timestamps on vulnerability - do assessments need this? 
+  * Assessments don't need it but VEX needs it
+  * May want to state the lifecycle of an assessment
+    * Also if you want to re-categorize it
+  * Element for vulnerability, element for assessment and element for package
+    * Which is the to and from as we relate from vuln and package and vuln and assessment for that package?
+      * FROM package TO vulnerability
+* Assessment is about the vulnerability as it affects a specific product or package
+* Use VEX to model how a vuln affets or doesnt affect a package
+* Should we consider modeling the assessment stuff? right now it's subclasses of relationships
+* Assessment is its own class - should we consider modeling it as a relationship?
+  * Assessment can have external references if its its own class, but not as relationships
+* VexRelationship type is its own element
+* FROM package TO vulnerability makes sense for VEX but FROM vuln TO package makes sense for the assessment
+* We need to finish this model in a week. Working group scheduled for tomorrow @ 11:30 pacific
+
+### Adding more types to ExternalReference
+* ExternalReferenceType in 3.0 model is defined as
+  * altDownloadLocation: A reference to an alternative download location.
+  * altWebPage: A reference to an alternative web page.
+  * other: Used when the type doesn't match any of the other options.
+  * securityAdvisory: A reference to the published security advisory (where advisory as defined per ISO 29147:2018). It may contain an impact statement whether a package (e.g. a product) is or is not affected by vulnerabilities.
+  * securityFix: A reference to the source code with a fix for the vulnerability (e.g., a GitHub commit).
+  * securityOther: Used when the reference is security related but doesn't match any of the other types.
+
+* Could we add the below types?
+  * bom: A reference to the bill of materials information related to an artifact // Use case Eclipse foundation publishing SPDX SBOMs for all their projects on 
+  * bom-advisories: A reference to API service where up-to-date security advisory statements related to artifacts can be retrieved
+  * bom-vex: A reference to API service where up-to-date VEX statements related to artifacts can be retrieved
+  * binary-artifact:  A reference to binary artifacts related to a package
+  * build-meta: A reference build metadata related to a published package
+  * build-system: A reference build system used to create or publish the package
+  *  source-artifact:  A reference to an artifact containing the source for a package
+  * chat: A reference to the instant messaging system used by the maintainer for a package
+  * documentation: A reference to the documentation for a package
+  * funding: A reference to funding informaton related to a package
+  * issue-tracker: A reference to the issue tracker for a package
+  * mailing-list:  A reference to the mailing list used by the maintainer for a package
+  * metrics:  A reference to metrics related to package such as OpenSSF scorecards.
+  * license: A reference to additional license information related to an artifact
+  * release-notes: A reference to the release notes for a package
+  * release-history: A reference to published list of releases for a package
+  * social-media: A reference to social media chanel for a package or vulnerability
+  * source-artifact:  A reference to an artifact containing the source for a package
+  * support:  A reference to social support channel for a package or vulnerability
+  * vcs :  A reference to version control system related to an artifact

--- a/security/2023-04-27.md
+++ b/security/2023-04-27.md
@@ -1,0 +1,39 @@
+# SPDX Defects Team Meeting - April 27, 2023
+
+## Attendees
+* Thomas Steenbergen
+* Rose Judge
+* Jeff Schutt
+* Adolfo Garcia
+* Gary O'Neall
+* Karsten Klein
+
+## Agenda
+* Continue to finish SPDX security model
+
+## Notes
+### Finish SPDX Security model
+* Walk through Karsten's vulnerability assessment details and how to model
+* Vulnerability is purposely very generic (CVE identifier associated with a package at a certain point in time). Relationship = contains (package contains vulnerability; advisory?)
+* VulnerabilityCvssV3Assessment element: I can make one assessment for the product but may have a different assessment for subcomponent.
+  * The vulnerability assessment should always point at the sub-component package, file or snippet that the vulnerability affects because we already have a relationship between subcomponent and product.
+  * VulnerabilityCvssV3Relationship: from single CVE to single subcomponent or multiple subcomponents?
+*  Cannot have an assessment without a relationship to a package/file/snippet element
+* Add subproduct property to relationship? More work because would need to ammend relationship
+* Require relationship between root package (product) and subackages affected by CVE.
+  * A component may be pointed at by more than one product
+  * Do you follow all relationships?
+  * must point CVE at most specific subcomponent in the graph
+* Decision: 
+  * the security elements will be modeled as relationships, including VEX and various categorizations/assessments such as CVSS, EPSS, etc.
+
+* TODO:
+  * update the model diagram 
+  * create the markdown files by adding definitions to the google doc here: https://docs.google.com/document/d/1ZT_w3HiW6LJjouRlw3xHXPnmy7ArwOdlw4vpzIjS9_o/edit?usp=sharing
+  * upload Karsten's assessment diagram and update as needed to show how we landed at the decision made
+  * create contextually relevant examples for various languages and vulnerabilities  
+* Action items: 
+* Rose: Add to Google doc descriptions for relationship types, externalReferenceTypes plus schedule a 2 hour worshop on Wednesday starting 1 hour earlier than normal.
+* Adolfo: Review vex and add to Google doc descriptions for vex and cvss assessment
+* Jeff: Add to Google doc descriptions for epss & ssvc assessment and model diagram
+* Thomas: Update outstanding PR to match 

--- a/security/2023-05-03.md
+++ b/security/2023-05-03.md
@@ -1,0 +1,63 @@
+# SPDX Defects Team Meeting - May 3, 2023
+
+## Attendees
+* Thomas Steenbergen
+* Karsten Klein
+* Rose Judge
+* Sean Barnum
+* Bob Martin
+* Dick Brooks
+* Adolfo Garcia
+* Jeff Schutt
+
+## Agenda
+* Update on action items from last Friday's workshop
+* Continue to finish SPDX security model
+
+## Notes
+### Update on action items from last Friday's workshop
+* Thomas: Rewrote the MarkDown files to use relationships see https://github.com/spdx/spdx-3-model/tree/security-profile-use-relationships and updated draw.io and png https://github.com/spdx/spdx-3-model/tree/security-profile. 
+* Adolfo and Rose have  been making updates to https://docs.google.com/document/d/1ZT_w3HiW6LJjouRlw3xHXPnmy7ArwOdlw4vpzIjS9_o/edit?usp=sharing
+
+### Continue to finish SPDX security model
+* Need to define relationshipType for each of the assessments
+
+```
+        {
+            "@type": "VulnerabilityCvssV3AssessmentRelationship",
+            "@id": "urn:spdx.dev:cvssv3-1",
+            "relationshipType": "VulnAssessment",
+            "severity": "medium",
+            "score": "6.8",
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N",
+            "from": "urn:spdx.dev:cve-1", [1..1] // the Vulnerability
+            "to": "urn:product-acme-application",  [1..1] // must be the productRootElement in this security bundle or in the SBOM document
+            "assessedElement": "urn:bingo-buffer-v2.2", // [0..1]  a package, file, snippet, relationship
+// urn:product-acme-application -> runtimeDependency ->  urn:bingo-buffer-v2.2 / urn:product-acme-application -> devDependency ->  urn:bingo-buffer-v2.2 
+            "externalReferences": [
+                {
+                    "@type": "ExternalReference",
+                    "externalReferenceType": "securityAdvisory",
+                    "locator": "https://nvd.nist.gov/vuln/detail/CVE-2020-28498"
+                }
+            ]
+        },
+```
+        
+### Conclusion:
+* VulnCvssV2AssessmentRelationship => Relationshiptype: hasCvssV2AssessmentFor
+* VulnCvssV3AssessmentRelationship => Relationshiptype: hasCvssV3AssessmentFor
+* VulnEpssAssessmentRelationship => Relationshiptype: hasEpssAssessmentFor
+* VulnSsvcAssessmentRelationship => Relationshiptype: hasSsvcAssessmentFor
+* VulnExploitCatalogAssessmentRelationship => Relationshiptype: hasExploitCatalogAssessmentFor
+* VulnVexAffectedAssessmentRelationship => Relationshiptype: affects
+* VulnVexNotAffectedAssessmentRelationship => Relationshiptype: doesNotAffect
+* VulnVexFixedAssessmentRelationship => Relationshiptype: fixedIn
+- VulnVexUnderInvestigationAssessmentRelationship => Relationshiptype: underInvestigationFor<br>
+~~* VulnOtherAssessmentRelationship => Relationshiptype: hasOtherAssessmentFor~~ <br>
+~~* VulnGenericAssessmentRelationship => Relationshiptype:  hasGenericVulnAssessmentFor~~
+  * Move to be defined in GA, 3.0.1, or later -> ideally we have a dictionary enabling SPDX creators to define multiple key- values pairs; await SPDX 3.0 security profile end user input to learn what's missing
+* VulnExploitCatalogAssessmentRelationship => Relationshiptype: hasExploitCatalogAssessmentFor
+  * isListed: Boolean [1]
+  * catalogType: kev, other [1]
+  * locator: URL [0...*]

--- a/security/2023-05-17.md
+++ b/security/2023-05-17.md
@@ -1,0 +1,50 @@
+# SPDX Defects Team Meeting - May 17, 2023
+
+## Attendees
+* Thomas Steenbergen
+* Rose Judge
+* Adolfo Garcia Veytia
+* Jeff Schutt
+* Kate Stewart
+
+## Agenda
+
+* Merged https://github.com/spdx/spdx-3-model/pull/338
+* Merged https://github.com/spdx/spdx-3-model/pull/322
+* Merged https://github.com/spdx/spdx-3-model/pull/334
+
+## Notes
+* Discussed example:
+
+```
+{
+  "spdxId": "urn:spdx.dev:cvssv2-cve-2020-28498",
+  "relationshipType": "hasAssessmentFor",
+  "assessmentType": CVSSv2,
+  "score": 4.2,
+  "vector": "(AV:N/AC:M/Au:N/C:P/I:N/A:N)",
+  "severity": "low",
+  "from": "urn:spdx.dev:vuln-cve-2020-28498",
+  "to": ["urn:product-acme-application-1.3"],
+  "assessedElement": "urn:npm-elliptic-6.5.2",
+  "externalReferences": [
+    {
+      "@type": "ExternalReference",
+      "externalReferenceType": "securityAdvisory",
+      "locator": "https://nvd.nist.gov/vuln/detail/CVE-2020-28498"
+    },
+    {
+      "@type": "ExternalReference",
+      "externalReferenceType": "securityAdvisory",
+      "locator": "https://snyk.io/vuln/SNYK-JS-ELLIPTIC-1064899"
+    },
+    {
+      "@type": "ExternalReference",
+      "externalReferenceType": "securityFix",
+      "locator": "https://github.com/indutny/elliptic/commit/441b742"
+    }
+  ],
+  "suppliedBy": ["urn:spdx.dev:agent-my-security-vendor"],
+  "publishedTime": "2023-05-06T10:06:13Z"
+},
+```

--- a/security/2023-05-24.md
+++ b/security/2023-05-24.md
@@ -1,0 +1,22 @@
+# SPDX Defects Team Meeting - May 24, 2023
+## Attendees
+* Thomas Steenbergen
+* Rose Judge
+* Jeff Schutt
+* William Cox
+* Kate Stewart
+
+## Agenda
+* Discuss need for: https://github.com/spdx/spdx-3-model/pull/346
+* Review https://docs.google.com/document/d/1usdnSoBX9qrIozeYf9gKeaGytF0W-UjeVvNikvq06Ks/edit
+
+## Notes
+### https://github.com/spdx/spdx-3-model/pull/346
+* Why do we need https://github.com/spdx/spdx-3-model/pull/346
+* json-ld is also json format; matches the syntax of json but it is also an RDF format
+* Armin: no plan to drop the @type of element; there is no way to identify a type based soley on its properites [if we were to drop the @type]
+* Jeff: is there consensus that we won't lose metadata in json-ld translations?
+* Armin: it's a hard requirement that @type cannot be lost for serialization.
+* Jeff: we need to have serialization discussion in tech call not in a one off meeting
+* Kate: The issue is that if you look in relationships and relationship types - all of the types that have been listed are not there.. it has been boiled down to assessment 
+* Rose: still confused why the relationship type name is lost

--- a/security/2023-05-31.md
+++ b/security/2023-05-31.md
@@ -1,0 +1,16 @@
+# SPDX Defects Team Meeting - May 31, 2023
+## Attendees
+* Thomas Steenbergen
+* Rose Judge
+* Kate Stewart
+* Adolfo Garcia
+
+## Agenda
+-  New Security-related ExternalReference types proposed in https://github.com/spdx/spdx-3-model/pull/352
+
+## Notes
+### https://github.com/spdx/spdx-3-model/pull/352
+* Discussed the changes and provided suggestions for changes directly in the PR
+
+### https://github.com/spdx/spdx-3-model/pull/346
+* Agreed to close. Justification in PR.

--- a/security/2023-06-07.md
+++ b/security/2023-06-07.md
@@ -1,0 +1,24 @@
+# SPDX Defects Team Meeting - June 7, 2023
+## Attendees
+* Jeff Schutt
+* Henk Birkholz
+* William Cox
+* Rose Judge
+* Adolfo Veytia
+
+## Agenda
+* update security use cases in serialization README
+* update to the Security Profile landing page https://docs.google.com/document/d/1usdnSoBX9qrIozeYf9gKeaGytF0W-UjeVvNikvq06Ks/edit
+
+
+## Notes:
+### Update security use cases
+* https://github.com/spdx/spdx-3-model/blob/main/serialization/README.md#use-cases
+* enumerated the security use cases for the serialization WG to include:
+  * vulnerability element
+  * vulnerability element with security external reference types 
+  * hasAssociatedVulnerability relationship between a vulnerability element and a software profile element
+  * hasAssessmentFor relationship for vulnerability assessment relationships between vulnerability element and package element for:
+    * VEX, CVSS, etc. (see the serialized examples listed in Syntax under each Class definition)
+ * foundBy, publishedBy, reportedBy relationship between an agent element and a vulnerability element
+* made edits to the security profile landing page 

--- a/security/2023-06-14.md
+++ b/security/2023-06-14.md
@@ -1,0 +1,16 @@
+# SPDX Defects Team Meeting - June 14, 2023
+
+## Attendees
+* Thomas Steenbergen
+* Rose Judge
+* Henk Birkholz
+* Dick Brooks
+* Karsten Klein
+
+## Agenda
+* Continue work on the Security Profile landing page
+
+## Notes:
+### Security Profile Landing Page
+* https://docs.google.com/document/d/1usdnSoBX9qrIozeYf9gKeaGytF0W-UjeVvNikvq06Ks/edit
+* Rewrote use cases section and fix minor spelling/gramar issues

--- a/security/2023-06-28.md
+++ b/security/2023-06-28.md
@@ -1,0 +1,14 @@
+# SPDX Defects Team Meeting - June 28, 2023
+## Attendees
+* Rose Judge
+* Bob Martin
+* Jeff Schutt
+* Karsten Klein
+
+## Notes
+* Improved example diagram documenting properties of an SPDX Document
+* 1st diagram only represented Core and Software Profile
+* 2nd diagram added details about how SPDX Identifiers relate multiple elements
+* 3rd diagram added Security Profile elements
+* 4th diagram added SPDX identifiers to relate between Core, Software, and Security Profile Elements
+* Will add this drawio file to the meeting directory on GitHub

--- a/security/2023-07-05.md
+++ b/security/2023-07-05.md
@@ -1,0 +1,22 @@
+# SPDX Defects Team Meeting - July 5, 2023
+
+## Attendees
+* Dick Brooks
+* Karsten Klein
+* Bob Martin
+* Jeff Schutt
+* William Cox
+* Kate Stewart
+
+## Notes
+* Summary for last month:
+  * We have security profile as part of the model.
+  * Updated and provided the security profile landing page documentation
+  * Working on a set of example diagrams and associated JSON
+    
+* Looking for link to document which was worked on last week. 
+  * Need input from Rose with diagrams.
+    * Rose on PTO - provided halfway through meeting
+  * Owner of the code that had the CVE - Supplier. 
+
+


### PR DESCRIPTION
Thanks @robcraig-LF for bringing attention to the fact that many security meetings from 2023 had failed to be transferred from the Etherpad to GitHub. This PR addresses that and adds the meeting dates currently missing in GitHub.