### PR TITLE
Add missing security minutes pt 2

### DIFF
--- a/security/2022/2022-04-06.md
+++ b/security/2022/2022-04-06.md
@@ -1,0 +1,43 @@
+# SPDX Defects Team meeting April 6, 2022
+
+## Attendees
+* Thomas Steenbergen
+* VM Brasseur
+* Karsten Klein
+* Jeff Schutt
+* Bob Martin
+* Henk Birkholz
+* Matt Weber (Collins Aerospace)
+
+## Agenda
+* General
+  * Approval of minutes of last week's meeting -> Thomas / Rose to merge in the suggestions from Dick & Jeff and then merge
+* Agenda for tomorrow's security workshop
+
+## Notes
+### Workshop Agenda
+  * Align on the wording for "Recommend use of at least one package identifier (CPE/PURL) using External Reference" to include in the SPDX 2.3 specification
+  * Stretch (if time permits)
+    * Discuss a new Security Type type for GitBOM / SWID - enable more format to be listed
+* Henk: Is adding identifier types helping 
+* Jeff: How do we tie the SBOM to external references
+* Jeff: Seperate location / identifier 
+
+#### Agenda Outline
+* Principles / framing the discussion
+* The below principles guide the decisions our decision making. Note they are not rules, but when they are violated it should be done intentionally.
+  * It's patch/bandaid - will not solve everything
+  * Optimize for adoption
+  * Easy understand for community members how to create a SBOM
+  * Minimize changes to existing software development practices and tools
+  * Leverage existing public specifications that are already adopted in the community
+  * Define how to translate between current SBOM formats
+  * Optimize for automation
+  * Leverage existing public specifications (but not to the detriment of internal consistency)
+  * Platform and format independent
+  * Supports machine translation between formats
+  * Extensible where needed
+* What do we want to include? (e.g. advisory, gitbom-id, (co)swid tag-id) nail down scope: e.g. include fix info?
+* Agree upon definitions, rely on existing definitions in other standards (e.g., advisory)
+* How to include in the spec?- identify the "socket" in the spec:   Category, ReferenceType, Comment
+* Draft into SPDX 2.3 spec - actual text in the specification - Annex F External Reference

--- a/security/2022/2022-04-07.md
+++ b/security/2022/2022-04-07.md
@@ -1,0 +1,48 @@
+# SPDX Defects Team meeting Workshop April 7, 2022
+
+## Workshop Agenda
+* Principles / framing the discussion
+
+The below principles guide the decisions our decision making. Note they are not rules, but when they are violated it should be done intentionally.
+1. It's patch/bandaid - will not solve everything
+2. Optimize for adoption
+  2.1 Easy understand for community members how to create a SBOM
+  2.2 Minimize changes to existing software development practices and tools
+  2.3 Leverage existing public specifications that are already adopted in the community
+  2.4 Define how to translate between current SBOM formats
+3. Optimize for automation
+4. Leverage existing public specifications (but not to the detriment of internal consistency)
+5. Platform and format independent
+  5.1 Supports machine translation between formats
+6. Extensible where needed
+
+
+* What do we want to include? (e.g. advisory, gitbom-id, (co)swid tag-id) nail down scope: e.g. include fix info?
+* **consensus**: type to describe security vulnerability information using a URL
+* **consensus**: to strongly recommend package identifier, e.g. CPE or PURL
+
+* Proposal
+* Update set of identifiers with GitBOM, SWID
+* Vulnerability info:
+  * Advisory: new vulnerability is discovered and it is included in these package [representing product(s), FOSS, etc.]
+  * Disclosure: here is my package [e.g. product] and reported vulnerabilities for include SW and my statement if they are applicable
+  * security_incident_response: to provide a response to a security breach or incident
+  * informational_advisory: to provide information which are not related to a vulnerability but e.g. a misconfiguration
+  * security_advisory: to provide information which is related to vulnerabilities and corresponding remediations
+* agree upon definitions, rely on existing definitions in other standards (e.g., advisory)
+  * https://www.iso.org/obp/ui/#iso:std:iso-iec:29147:ed-1:v1:en
+  * https://docs.oasis-open.org/csaf/csaf/v2.0/csd01/csaf-v2.0-csd01.html#12-terminology
+  * advisory: reporting item that describes a condition present in an artifact and that requires action by the consumers
+  * VEX: Vulnerability Exploitability eXchange - enables a supplier or other party to assert whether or not a particular product is affected by a specific vulnerability, especially helpful in efficiently consuming SBOM data.
+* Fix definition: 
+  * A reference to the source code with a fix for the vulnerability (e.g., a GitHub commit). 
+* How to include in the spec?- identify the "socket" in the spec:   Category, ReferenceType, Comment
+* Draft into SPDX 2.3 spec - actual text in the specification - Annex F External Reference
+* GitBOM / SWID type addition:
+  * SWID under category Security F2.3 SWID type (Concise SWID https://www.ietf.org/archive/id/draft-ietf-sacm-coswid-21.html)  -> Action item for Henk propose the paragraph for SWID
+  * GitBOM under F4.2 GitBOM -> Action item for Jeff, propose the paragraph for GitBOM
+* Ideas:
+  * Recommended practices for which information to include in which fields
+  * Guidance on limitations to the current approach (a patch) and hints of what's to come in 3.0
+* For next call:
+  * Will v2.3 be pushed to ISO? Who will drive that?

--- a/security/2022/2022-07-20.md
+++ b/security/2022/2022-07-20.md
@@ -1,0 +1,17 @@
+# SPDX Defects Team meeting July 20, 2022
+
+## Attendees
+* Karsten Klein
+* Dick Brooks
+* Thomas Steenbergen is unable to attend/host today due to food poisoning
+
+## Agenda
+* Approval of [meeting minutes](https://github.com/spdx/meetings/pull/205) from last week
+* Continue discussion on SPDX 3.0 Defects example
+* From 3 weeks ago: Example dashboards and reports to support vulnerability assessment, monitoring and reporting use cases
+
+## Notes
+* Pushing agenda items above until next week
+
+### Open Table
+* Karsten presented the vulnerability assessment dashboards and reports to Dick to identify concepts and methods relevant for the group. We will follow up next meeting.

--- a/security/2022/2022-12-21.md
+++ b/security/2022/2022-12-21.md
@@ -1,0 +1,16 @@
+# SPDX Defects Team Workshop December 21, 2022
+
+## Attendees
+* Jeff Schutt
+* Thomas Steenbergen
+* Dick Brooks
+* Henk Birkholz
+* Bob Martin
+
+## Notes
+### Plans for next year
+* Today is the last meeting of the year. Plans for next year:
+  * TODO: present security model in a January spdx-tech meeting
+  * TODO: provide examples of how 2.3 fields map to 3.0
+  * TODO: provide examples of how to use the categorization types
+  * TODO: review any mandatory fields in other specs to determine if they should be required when security profile is in use


### PR DESCRIPTION
Thanks @robcraig-LF for bringing attention to the fact that many security meetings from 2022/2023 had failed to be transferred from the Etherpad to GitHub. This PR addresses that and adds the meeting dates missed in https://github.com/spdx/meetings/pull/453.