### PR TITLE
Add Legal team meeting minutes 2023-11-09

### DIFF
--- a/legal/2023/2023-11-09.md
+++ b/legal/2023/2023-11-09.md
@@ -1,0 +1,21 @@
+# SPDX Legal Team Meeting, Nov. 9, 2023
+
+## Attendees
+
+- Jilayne Lovejoy
+- Mark Atwood
+- Richard Fontana
+- Brad Goldring
+- David Shields
+- Madhuri Padmanabhan
+- Shalini Batra
+
+## Agenda and Notes
+
+- Discussed SAX-PD https://github.com/spdx/license-list-XML/issues/2211, see issue comments
+- Discussed https://github.com/spdx/license-list-XML/issues/2233 plan is to revisit after @bsdimp comments
+- Discussed and agreed on HPND-sell-MIT-disclaimer-xserver https://github.com/spdx/license-list-XML/issues/2177
+- FSFAP-no-wd shorter identifier because of character limit https://github.com/spdx/license-list-XML/issues/2214
+- Discussed https://github.com/spdx/license-list-XML/issues/2201 Not a Inner-Net 2.0 but new license radvd License as it is a senior license from which Inner net was derived
+- New license request gnome https://github.com/spdx/license-list-XML/issues/2209 details in comments
+- https://github.com/spdx/license-list-XML/issues/2208


### PR DESCRIPTION
Add minutes - SPDX Legal Team Meeting, Nov. 9, 2023

(needs to be signed-off by legal team)