### PR TITLE
Add Legal team meeting minutes 2023-12-14

### DIFF
--- a/legal/2023/2023-12-14.md
+++ b/legal/2023/2023-12-14.md
@@ -1,0 +1,25 @@
+# SPDX Legal Team Meeting, Dec. 14, 2023
+
+## Attendees
+
+- Jimmy Ahlberg
+- Shalini Batra
+- Richard Fontana
+- Brad Goldring
+- Jilayne Lovejoy
+- Victor Lu
+- Madhuri Padmanabhan
+- Steve Winslow
+- Brad Goldring
+
+## Agenda and Notes
+
+### Next release
+
+- Plan to get back onto regular calendar for release 3.23, end of Jan. 2024
+
+### Issues to review - see issues for details
+
+- 2186: https://github.com/spdx/license-list-XML/issues/2186 => realized this is a duplicate with https://github.com/spdx/license-list-XML/issues/2214 / https://github.com/spdx/license-list-XML/issues/2255
+- 2206: https://github.com/spdx/license-list-XML/issues/2206
+- 2213: https://github.com/spdx/license-list-XML/issues/2213


### PR DESCRIPTION
Add minutes - SPDX Legal Team Meeting, Dec. 14, 2023

