### PR TITLE
Add Legal team meeting minutes 2024-01-25

### DIFF
--- a/legal/2024-01-25.md
+++ b/legal/2024-01-25.md
@@ -1,0 +1,33 @@
+# SPDX Legal Team Meeting, Jan. 25, 2024
+
+## Attendees
+
+- Shalini Batra
+- Karsten Klein
+- Jilayne Lovejoy
+- Victor Lu
+- Gary O'Neall
+- Steve Winslow
+- Jim Vitrano
+
+## Agenda and Notes
+
+- Jilayne described list of issues shared with mailing list yesterday
+
+- HPND variants - preparing draft Google Doc regarding variants and analysis
+  of differences between many variants, current link at:
+  https://docs.google.com/document/d/1xqSwTfJJ7btkhbblrIAZxOxv0iZPmAMGar9rU7DLKC8/edit  
+  - will keep there given other priorities currently
+  - https://github.com/spdx/license-list-XML/blob/main/DOCS/license-match.md
+  - also want to clarify the BSD-3-Clause markup at some point
+
+- bzip2-1.0.6 variant: https://github.com/spdx/license-list-XML/issues/2271
+  - add markup to make optional
+  
+- Gary joined for last bit and we discussed the limitiations of regular expressions
+  which is a standard, so we can't change it versus our XML schema. Anything within
+  an <alt> tag is regex, and thus we don't have control over how it is implemented.
+  This is especially relevant when it comes to white space and human readability of
+  XML files for alternative text options. We could, however, look into better ways
+  to convert/display the alternative text options. There is a thread on this in the
+  spdx-legal email list


### PR DESCRIPTION
Add minutes - SPDX Legal Team Meeting, Jan. 25, 2024

(needs to be signed-off by legal team)