### PR TITLE
Fix link in Tech Meeting 2024-08-14

### DIFF
--- a/tech/2024/2024-08-14.md
+++ b/tech/2024/2024-08-14.md
@@ -40,7 +40,7 @@
    - Do not want any changes against 3.0.1 - before making change;  so release candidate freezing will be the time.
    - Pull requests should respect branch names, via UI, can retarget to different branch. 
    - For reference the 2024-06-11 Tech minutes about branch and translation
-     https://github.com/spdx/meetings/blob/main/tech/2024-06-11.md.
+     https://github.com/spdx/meetings/blob/main/tech/2024/2024-06-11.md.
    - In addition to making the branch changes, we will need to ensure that references to the branches in CI are also fixed,  and may impact other repositories (spec parser, model, etc.).  Art will check on this.
    - RECOMMENDATION:  After release candidate declared - then will consider making changes.    Art will prep the PR and put it out for review.   Gary will rename branch is "main".   Gary to send email about the change,  and then send email with the reopen.
    - Reminder from Arthit:  after we settle with this, also need to update the preferred branch/tag names for development as well in the Contribution guideline  https://github.com/spdx/spdx-spec/blob/development/v3.0.1/CONTRIBUTING.md


### PR DESCRIPTION
Since meetings are moved to 2024/ folders, this link cited in the minutes has to be updated

- https://github.com/spdx/meetings/blob/main/tech/2024-06-11.md -> https://github.com/spdx/meetings/blob/main/tech/2024/2024-06-11.md

Because of this, may be it is better to have meeting minutes in their YEAR/ folder in the first place. So we don't have to worry about updating references.