### PR TITLE
Update CONTRIBUTING.md regarding YEAR/ directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,23 @@
 # Contributing to the SPDX Meeting Repository
+
 ## General
+
 Each team maintains their own minutes directory.
+
 If a team has conventions different from the conventions documented in this file, they should include a CONTRIBUTING.md file at the top level of their directory.
+
 ## File Naming Conventions
-Meeting minutes are titled by the date in the format `YYYY-MM-DD.md`.
-At the end of the year, that year's files should be moved into a directory named for that year `YYYY`.
+
+For meeting minutes organization and sorting purpose:
+
+- Meeting minutes should be titled using the date in the format `YYYY-MM-DD.md`.
+- Meeting minutes should be stored in a directory named for the year `YYYY`.
+- Additional files relevant to a meeting minutes `YYYY-MM-DD.md` should be
+  named as `YYYY-MM-DD-relevant-file-label.md` (e.g., `2024-12-24-diagram.md`),
+  and stored in the same `YYYY` directory.
+
 ## Pull Requests
+
 New meeting minutes should be added as a pull request.
 Sufficient time should be allowed for review before merging.
 It is suggested that there is at least one review from an attendee of the meeting, but even if no reviews, it should be merged before the next meeting.


### PR DESCRIPTION
This PR proposes that meeting minutes should be store in a `YYYY` year directory since the beginning (as oppose to move them to the directory at the end of the year).

The rational is to reduce admin work and more importantly to avoid dead link situation when the minutes is moved.