### PR TITLE
Relayout the schedule, info in table + keep old anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,147 @@
 # Meeting Minutes
+
 This repository stores meeting minutes for the SPDX project.
 
-# Meeting Schedule
+## Meeting Schedule
 
-The SPDX Project has several Teams and topical groups that meet at regular intervals. Meeting are open to anyone and it is recommended to also join the related mailing list (as applicable), see [SPDX Participate](https://spdx.dev/participate/) for more information. All attendees will be expected to identify themselves by name on all meetings.
+The SPDX project has several teams and topical groups that meet at regular
+intervals.
 
-Meetings schedules for the SPDX Project are listed below. All times are listed for **US Eastern time zone**, 24-hour.
+Meeting are open to anyone and it is recommended to also join the related
+mailing list (as applicable),
+see [SPDX Participate](https://spdx.dev/participate/) for more information.
 
-## General meeting
-* Time and cadence: once per month on the first Thursday of the month at 11:00
-* Where: <https://meet.jit.si/SPDXGeneralMeeting>
-* Description: General call with general updates, updates from each Team, and sometimes guest speakers (e.g., talks on how people are using SPDX, GSoC student presentations, etc.)
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-general-minutes
+All attendees will be expected to identify themselves by name on all meetings.
 
-## Tech Team meetings
-* Time and cadence: weekly on Tuesdays at 12:00
-* Where: <https://zoom.us/j/663426859>
-* Descriptions: Regular meeting to work on drafting new versions of the SPDX specification and to discuss technical documentation and official SPDX libraries.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-tech-minutes
+Meetings schedules for the SPDX Project are listed below.
+All times are listed in [**US Eastern Time Zone**](https://www.time.gov/),
+UTC−05:00 standard and UTC−04:00 daylight, using a 24-hour clock format.
 
-## Legal Team meetings
-* Time and cadence: twice per month on the second and fourth Thursday of the month at 12:00
-* Where: <https://meet.jit.si/SPDXLegalMeeting>
-* .ics files for invites: [second Thursdays](./invites/spdx-legal-2024-second-thursdays.ics), [fourth Thursdays](./invites/spdx-legal-2024-fourth-thursdays.ics)
-* Descriptions: Regular meeting to discuss submissions to SPDX License List, other license list related work, license-related aspects of the SPDX specification, and other related projects.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-legal-minutes
+### Team Meetings
 
-## Outreach Team meetings
-* Time and cadence: weekly on Mondays at 10:00
-* Where: <https://meet.jit.si/SPDXOutreachMeeting>
-* Descriptions: Regular meeting to coordinate public relations efforts and discuss current projects.
-* Meeting minutes and agendas: https://hackmd.io/@spdx/outreach-team/edit 
+### General Meeting
 
-## Sub-groups for specific topics
-### Build Profile group meetings
-<!-- * Time and cadence: weekly on Mondays at 14:00
-* Where: <https://meet.jit.si/SPDXBuildProfile> -->
-* Descriptions: Regular meeting to discuss and propose the SPDX build profile and other adjacent elements.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-build-minutes
-*  *Note*: The group has paused regular meetings until further notice.
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Monthly.<br />1st Thursday 11:00 | [Meeting](https://meet.jit.si/SPDXGeneralMeeting) | General call with general updates, updates from each Team, and sometimes guest speakers (e.g., talks on how people are using SPDX, GSoC student presentations, etc.) | [Agenda](https://spdx.swinslow.net/p/spdx-general-minutes) / [Minutes](./general/) |
 
-### Canonicalisation group meetings
-<!-- * Time and cadence: weekly on Fridays at 09:00 -->
-<!-- * Where: <https://meet.jit.si/SPDXCanonicalMeeting> -->
-* Descriptions: Regular meeting to develop the Canonical Serialisation for SPDX 3.0 and agree on recommendations to make to the Tech Team where appropriate.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-canonicalisation-minutes
-* *Note*: the group has paused their regular meetings, waiting for final serialization(s) outcome.
+### Tech Team
 
-### Security Profile group meetings
-* Time and cadence: weekly on Wednesdays at 14:00
-* Where: https://meet.jit.si/SPDXDefectsMeeting
-* Description: Regular meeting to discuss representation of software vulnerability metadata in the SPDX specification including vulnerability identifiers, status, mitigations and remediations.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-defects-minutes
+ <a name="tech-team-meetings"></a> <!-- To keep old links working -->
 
-### Implementers group meetings
-* Time and cadence: every week on Wednesday at 11:00
-* Where: https://meet.jit.si/SPDXImplementersMeeting
-* Description: Regular meeting for tool creators implementing the SPDX specification to meet and compare notes
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-implementers-minutes
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Tuesdays 12:00 | [Meeting](https://zoom.us/j/663426859) | Regular meeting to work on drafting new versions of the SPDX specification and to discuss technical documentation and official SPDX libraries. | [Agenda](https://spdx.swinslow.net/p/spdx-tech-minutes) / [Minutes](./tech/) |
 
-### AI and Dataset Profiles group meetings
-* Time and cadence: weekly on Wednesdays at 15:00
-* Where: https://zoom.us/j/92452702075
-* Description: Regular meeting to discuss how the SPDX specification can better support and track artificial intelligence and machine learning use-cases.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-ai-minutes
+### Legal Team
 
-### Functional Safety Profile group meetings
-* Time and cadence: weekly on Fridays at 12:00
-* Where: https://zoom.us/j/94445183726
-* Description: Regular meeting to discuss how the SPDX specification can better support and track functional safety plans.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-fusa-minutes
+<a name="legal-team-meetings"></a> <!-- To keep old links working -->
 
-### Serialisation Focus Group meetings
-* The serialization team is currently paused - we will anounce specific topic meetings as serialization issues are raised in the Tuesday tech calls
-* Previous time and cadence: weekly on Thursdays at 11:00
-* Where: https://meet.jit.si/SPDXSerialisationMeeting
-* Description: Regular meeting to discuss the serialisation formats for SPDX, enumerating the use cases for serialisation and determining stakeholder preferences.
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Twice per month.<br />2nd & 4th Thursday 12:00 | [Meeting](https://meet.jit.si/SPDXLegalMeeting) | Regular meeting to discuss submissions to SPDX License List, other license list related work, license-related aspects of the SPDX specification, and other related projects. | [Agenda](https://spdx.swinslow.net/p/spdx-legal-minutes) / [Minutes](./legal/) |
 
-### Software as a Service Profile group meetings
-* Time and cadence: We are currently working asynchronously until we have a pull request ready for review on the final use cases.
-* Where: Once we restart the meetings, they will be at https://zoom.us/j/87627432628
-* Description: Regular meeting to discuss how the SPDX specification can better support and track SAAS use cases.
+### Outreach Team
 
-### Hardware Profile group meetings
-* Time and cadence: weekly on Fridays at 9:00, every other week
-* Where: https://zoom.us/j/99157617857
-* Description: Regular meeting to discuss how the SPDX specification can extend to support firmware, FPGAs, Open Hardware Boards, SOCs, IP blocks, Cores in physical and virtual environments.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-hardware-minutes
-  
-### Operations group meetings
-* Time and cadence: weekly on Fridays at 09:30
-* Where: https://zoom-lfx.platform.linuxfoundation.org/meeting/94606881295?password=3522f337-3890-4940-9d74-9aee22864967
-* Descriptions: Regular meeting focused on the additional information that an organization may wish to associate with a package, for effective management of these artifacts within business operations.
-* Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-operations-minutes
+<a name="outreach-team-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Mondays 10:00 | [Meeting](https://meet.jit.si/SPDXOutreachMeeting) | Regular meeting to coordinate public relations efforts and discuss current projects. | [Agenda](https://hackmd.io/@spdx/outreach-team/edit) / [Minutes](./outreach/) |
+
+### Focus Group Meetings
+
+<a name="sub-groups-for-specific-topics"></a> <!-- To keep old links working -->
+
+#### Asia
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| | | Coordination with participations from Asia timezones | [Agenda](https://spdx.swinslow.net/p/spdx-tech-minutes) / [Minutes](./asia/) |
+
+#### Canonicalisation
+
+<a name="canonicalisation-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Paused <!-- Weekly. Fridays 09:00 --> | N/A <!-- [Meeting](https://meet.jit.si/SPDXCanonicalMeeting) --> | Regular meeting to develop the Canonical Serialisation for SPDX 3.0 and agree on recommendations to make to the Tech Team where appropriate. | [Agenda](https://spdx.swinslow.net/p/spdx-canonicalisation-minutes) / [Minutes](./canonical/) |
+
+#### Implementers
+
+ <a name="implementers-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Wednesdays 11:00 | [Meeting](https://meet.jit.si/SPDXImplementersMeeting) | Regular meeting for tool creators implementing the SPDX specification to meet and compare notes. | [Agenda](https://spdx.swinslow.net/p/spdx-implementers-minutes) / [Minutes](./implementers/) |
+
+#### Serialisation
+
+<a name="serialisation-focus-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Paused | N/A <!-- [Meeting](https://meet.jit.si/SPDXSerialisationMeeting) --> | Regular meeting to discuss the serialisation formats for SPDX, enumerating the use cases for serialisation and determining stakeholder preferences. | [Minutes](./serialisation/) |
+
+### Profile Meetings
+
+#### AI and Dataset
+
+<a name="ai-and-dataset-profiles-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Wednesdays 15:00 | [Meeting](https://zoom.us/j/92452702075) | Regular meeting to discuss how the SPDX specification can better support and track artificial intelligence and machine learning use-cases. | [Agenda](https://spdx.swinslow.net/p/spdx-ai-minutes) / [Minutes](./ai/) |
+
+#### Build
+
+<a name="build-profile-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Paused <!-- Weekly.<br />Mondays 14:00 --> | N/A <!-- [Meeting](https://meet.jit.si/SPDXBuildProfile) -->  | Regular meeting to discuss and propose the SPDX build profile and other adjacent elements. | [Agenda](https://spdx.swinslow.net/p/spdx-build-minutes) / [Minutes](./build/) |
+
+#### Functional Safety
+
+<a name="functional-safety-profile-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Fridays 12:00 | [Meeting](https://zoom.us/j/94445183726) | Regular meeting to discuss how the SPDX specification can better support and track functional safety plans. | [Agenda](https://spdx.swinslow.net/p/spdx-fusa-minutes) / [Minutes](./safety/) |
+
+#### Hardware
+
+<a name="hardware-profile-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Biweekly.<br />Fridays 9:00 | [Meeting](https://zoom.us/j/99157617857) | Regular meeting to discuss how the SPDX specification can extend to support firmware, FPGAs, Open Hardware Boards, SOCs, IP blocks, Cores in physical and virtual environments. | [Agenda](https://spdx.swinslow.net/p/spdx-hardware-minutes) / [Minutes](./hardware/) |
+
+#### Operations
+
+<a name="operations-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Fridays 09:30 | [Meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/94606881295?password=3522f337-3890-4940-9d74-9aee22864967) | Regular meeting focused on the additional information that an organization may wish to associate with a package, for effective management of these artifacts within business operations. | [Agenda](https://spdx.swinslow.net/p/spdx-operations-minutes) / [Minutes](./operations/) |
+
+#### Security
+
+<a name="security-profile-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Weekly.<br />Wednesdays 14:00 | [Meeting](https://meet.jit.si/SPDXDefectsMeeting) | Regular meeting to discuss representation of software vulnerability metadata in the SPDX specification including vulnerability identifiers, status, mitigations and remediation. | [Agenda](https://spdx.swinslow.net/p/spdx-defects-minutes) / [Minutes](./security/) |
+
+#### Software as a Service
+
+<a name="software-as-a-service-profile-group-meetings"></a> <!-- To keep old links working -->
+
+| Time & Cadence | Where | Description | Agendas & Minutes |
+|----------------|-------|-------------|-------------------|
+| Asynchronous | [Meeting](https://zoom.us/j/87627432628) | Regular meeting to discuss how the SPDX specification can better support and track SAAS use cases. | [Minutes](./service/) |
+
+## Meeting Minutes Keeping
+
+Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on keeping
+and submitting meeting minutes.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ UTC−05:00 standard and UTC−04:00 daylight, using a 24-hour clock format.
 
 | Time & Cadence | Where | Description | Agendas & Minutes |
 |----------------|-------|-------------|-------------------|
-| Twice per month.<br />2nd & 4th Thursday 12:00 | [Meeting](https://meet.jit.si/SPDXLegalMeeting) | Regular meeting to discuss submissions to SPDX License List, other license list related work, license-related aspects of the SPDX specification, and other related projects. | [Agenda](https://spdx.swinslow.net/p/spdx-legal-minutes) / [Minutes](./legal/) |
+| Twice per month.<br />2nd & 4th Thursdays 12:00 | [Meeting](https://meet.jit.si/SPDXLegalMeeting) | Regular meeting to discuss submissions to SPDX License List, other license list related work, license-related aspects of the SPDX specification, and other related projects. | [Agenda](https://spdx.swinslow.net/p/spdx-legal-minutes) / [Minutes](./legal/) |
 
 ### Outreach Team
 


### PR DESCRIPTION
- Keep the traditional heading style, so anchor links can be automatically shown on GitHub
- Keep old anchors, so the existing anchor-links will not break
- Put information in table style, grouped & sorted, to make it easier to scan through
- Add links to meeting minutes
- Standardized time & cadence format
- Add info about standard/daylight US Eastern Time Zone + link to https://www.time.gov/ to check the time
- Add link to CONTRIBUTING.md

An alternative to #831 

