### PR TITLE
Add minutes of Outreach Team calls for 2024

### DIFF
--- a/outreach/2024/2024-06-10.md
+++ b/outreach/2024/2024-06-10.md
@@ -1,0 +1,21 @@
+# SPDX Outreach Meeting 2024-06-10
+
+## Attendees
+
+* Alexios Zavras
+* Bob Martin
+
+## Agenda
+
+* OMG updates
+
+## Notes
+
+* Bob currently in OMG meeting
+* talked to Jason Smith, about tool for translating Markdown to PDF
+* OMG spec has history of collaboration section
+* maybe an informational annex/section
+* list of contributors
+* Bob to ask about links in documents
+* OMG finalization task force also interest in commercial viability
+

--- a/outreach/2024/2024-06-17.md
+++ b/outreach/2024/2024-06-17.md
@@ -1,0 +1,24 @@
+# SPDX Outreach Meeting 2024-06-17
+
+## Attendees
+
+* Alexios Zavras
+* Bob Martin
+* Victor Lu
+
+## Agenda
+
+* Updates on initiatives
+* Updates on OMG production of spec PDF
+
+## Notes
+
+* ECMA has a new Technical Committee [TC54](https://ecma-international.org/technical-committees/tc54/) with two Task Groups, focusing on:
+  *  [Transparency Exchange API](https://ecma-international.org/task-groups/tc54-tg1/), and
+  *  [Package URL](https://ecma-international.org/task-groups/tc54-tg2/)
+
+* working with Jason Smith
+  * Alexios explained the current production setup via email
+  * Jason is using LaTeX to generate the output
+  * short call to be arrnged in the week for sync up
+

--- a/outreach/2024/2024-06-24.md
+++ b/outreach/2024/2024-06-24.md
@@ -1,0 +1,25 @@
+# SPDX Outreach Meeting 2024-06-24
+
+## Attendees
+
+* Alexios Zavras
+* Bob Martin
+* Gary O'Neall
+* Victor Lu
+ 
+## Agenda
+
+* Update on PDF generation
+* Tools responses
+* Go libraries
+
+## Notes
+
+* Update on PDF generation
+  * last week Alexios collaborated with Jason (from OMG) and found a way forward 
+* Tools responses
+  * still waiting for LF to provide info on web infrastructure (Zephyr-like) 
+  * one tool to be added to the website
+* Go libraries
+  * GUAC waits for libraries
+

--- a/outreach/2024/2024-07-01.md
+++ b/outreach/2024/2024-07-01.md
@@ -1,0 +1,16 @@
+# SPDX Outreach Meeting 2024-07-01
+
+## Attendees
+
+* Alexios Zavras
+* Bob Martin
+
+## Agenda
+
+* Updates
+
+## Notes
+
+- Alexios workign on the PDF production
+- Bob will contact OMG for introductory sections of the spec
+

--- a/outreach/2024/2024-07-08.md
+++ b/outreach/2024/2024-07-08.md
@@ -1,0 +1,20 @@
+# SPDX Outreach Meeting 2024-07-08
+
+* Alexios Zavras
+* Bob Martin
+
+## Agenda
+
+* Tools update
+* Spec PDF production
+
+## Notes
+
+- Tools update
+  - we still don't have the new setup on web site
+  - we have got some replie from tools
+  - we should probably add the information 
+  - Alexios to work with Gary on it
+- Alexios workign on the PDF production
+  - open decisions for hierarchy and numbering 
+

--- a/outreach/2024/2024-07-15.md
+++ b/outreach/2024/2024-07-15.md
@@ -1,0 +1,26 @@
+# SPDX Outreach Meeting 2024-07-15
+
+- Alexios Zavras
+- Bob Martin
+- Karen Bennet
+
+## Agenda
+
+- spec Production
+- tutorial on SBOM per lifecycle
+- efforts to record standards and regulations
+
+## Notes
+
+- Spec Production
+  - waiting for Jason on hierarhy sections
+- SBOM types
+  - as per stages in software lifecycle
+  - AI group wants presentation
+  - Bob will do it this Wednesday
+- recording requirements of standards/regulations
+  - document on spdx/using repo
+    - https://github.com/spdx/using/blob/main/docs/using-SPDX-to-comply-with-industry-guidance.md
+  - MITRE System of Trust
+    - https://sot.mitre.org/
+

--- a/outreach/2024/2024-07-22.md
+++ b/outreach/2024/2024-07-22.md
@@ -1,0 +1,25 @@
+# SPDX Outreach Meeting 2024-07-22
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+
+## Agenda
+
+- Spec structure
+- Other published documents
+- Tools
+
+## Notes
+
+- Spec structure
+  - will also dicsuss it on tech call tomorrow
+- Other published docs
+  - web presence: think about how to communicate new version
+  - spdx/using repo: needs updating, after spec
+- Tools
+  - question on slack
+  - quick reply on issues, if no planned progress/resolution
+- Extensions of an SPDX file. OMG needs one extension per one file
+

--- a/outreach/2024/2024-07-29.md
+++ b/outreach/2024/2024-07-29.md
@@ -1,0 +1,26 @@
+# SPDX Outreach Meeting 2024-07-29
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Victor Liu
+
+## Agenda
+
+- Tools page on website
+- Spec updates
+
+## Notes
+
+- Tools page on website
+  - missing responses
+  - create an issue for tracking open source tools
+    - https://github.com/spdx/outreach/issues/78
+  - project libraries and tools should appear also on top, before list
+- Spec updates
+  - all contents
+- Lite
+  - There are information differences (for example, in cardinality)
+    between "Annex H: SPDX Lite" and the Lite Profile.
+

--- a/outreach/2024/2024-08-05.md
+++ b/outreach/2024/2024-08-05.md
@@ -1,0 +1,27 @@
+# SPDX Outreach Meeting 2024-08-05
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Ilan Schifter
+- Victor Liu
+
+## Agenda
+
+- Spec updates
+- Tools page on website
+- Ilan update
+
+## Notes
+
+- Spec updates
+  - trying to finalize
+- Ilan trying to make videos 
+  - duration of a few minutes
+  - put it to youtube
+    (to check if SPDX has its own YouTube channel.
+    The Linux Foundation has one at https://www.youtube.com/@LinuxfoundationOrg )
+- Discussion about the Dot tool with Ilan, which can be part of his video
+  - Relationship between SpdxDocument and Sbom 
+  - The tool should not let the user create ListedLicense,
+    as they can only be defined in the official SPDX License List.
+

--- a/outreach/2024/2024-08-12.md
+++ b/outreach/2024/2024-08-12.md
@@ -1,0 +1,15 @@
+# SPDX Outreach Meeting 2024-08-12
+
+- Alexios Zavras
+- Bob Martin
+- Gary O'Neall
+- Kate Stewart
+
+## Agenda
+
+Discussion on work on PDF generation
+
+## Notes
+
+Discussion on work on PDF generation
+

--- a/outreach/2024/2024-08-19.md
+++ b/outreach/2024/2024-08-19.md
@@ -1,0 +1,23 @@
+# SPDX Outreach Meeting 2024-08-19
+
+- Alexios Zavras
+- Bob Martin
+- Gary O'Neall
+- Ilan Schifter
+
+## Agenda
+
+- Discussion on work on PDF generation
+- Ilan's questions
+
+## Notes
+
+- Discussion on work on PDF generation
+- Ilan's questions:
+    - Q: where are the RDF files?
+    - A: committed in the repo, https://github.com/spdx/spdx-spec/tree/development/v3.0.1/rdf
+    - Q: I also need descriptions
+    - A: you can run spec-parser and use the json dump
+    - Q: anything else missing from the model, like listed licenses
+    - A: nothing now, there will be a list of crypto algorithms in the future
+

--- a/outreach/2024/2024-10-07.md
+++ b/outreach/2024/2024-10-07.md
@@ -1,0 +1,21 @@
+# SPDX Outreach Meeting 2024-10-07
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Ilan Schifter
+
+## Agenda
+
+- PDF versions of the spec
+- SPDX website
+
+## Notes
+
+- PDFs of the 3.0.1 spec
+  - Bob to connect with OMG editor
+  - She is the final approver of the OMG document
+  - The ISO document will go to OMG/LF standards people
+- Website
+  - As soon as the spec is out of our hands, we should go through all pages and add mentions and references to SPDXv3
+

--- a/outreach/2024/2024-10-28.md
+++ b/outreach/2024/2024-10-28.md
@@ -1,0 +1,15 @@
+# SPDX Outreach Meeting 2024-10-28
+
+- Arthit Suriyawongkul
+- Gary O'Neall
+
+## Agenda
+
+- SPDX adoption in tools
+- Microsoft SPDX support beyond 2.2
+  - Write SPDX 2.2 https://github.com/microsoft/sbom-tool
+  - Read SPDX 2.2 https://github.com/microsoft/component-detection
+  - If sbom-tool support 2.2.1, it will support German BSI TR-03183 2.0.0
+    https://github.com/microsoft/sbom-tool/issues/738
+    https://github.com/microsoft/sbom-tool/issues/537
+

--- a/outreach/2024/2024-11-04.md
+++ b/outreach/2024/2024-11-04.md
@@ -1,0 +1,23 @@
+# SPDX Outreach Meeting 2024-11-04
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Ilan Schifter
+
+## Agenda
+
+
+
+## Notes
+
+- FOSDEM CfP sent to mailing lists
+- No feedback from OMG about the spec yet
+
+- Work needed:
+    - Go over the website to find out what needs updating
+    - Adoption needs tools; we need to find someone for the Go libraries
+    - Java and Python are work-in-progress
+    - Examples of SPDXv3 data
+

--- a/outreach/2024/2024-11-18.md
+++ b/outreach/2024/2024-11-18.md
@@ -1,0 +1,29 @@
+# SPDX Outreach Meeting 2024-11-18
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Ilan Schifter
+
+## Agenda
+
+- PDF update
+- old channels
+- SPDX Ambassadors
+
+## Notes
+
+- update on PDF for OMG/ISO
+  - almost done
+  - Bob and Alexios meeting Jory on Thursday
+- ancient communication channels
+  - Sebastian wants to hand over Matrix and IRC channel
+  - ask Kate about IRC / Matrix channels
+  - two X/twitter accounts: SPDXTeam and SPDX_SBOM
+- Ilan is interested in modeling processes
+  - propose the idea (what, why, how) and depending on the interest a new profile team might be formed
+- SPDX Ambassadors
+  - Steering committee to decide on process and details
+  - Then run by Outreach team
+

--- a/outreach/2024/2024-11-25.md
+++ b/outreach/2024/2024-11-25.md
@@ -1,0 +1,21 @@
+# SPDX Outreach Meeting 2024-11-25
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+
+## Agenda
+
+- updates: FOSDEM, UO
+- LF member summit update
+
+## Notes
+
+- FOSDEM
+  - deadline end of Nov (this week)
+- capstone project
+  - Univ. of Oregon Comp. Sci. department
+  - team of 6 students
+- LF member summit update
+

--- a/outreach/2024/2024-12-02.md
+++ b/outreach/2024/2024-12-02.md
@@ -1,0 +1,41 @@
+# SPDX Outreach Meeting 2024-12-02
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Ilan Schifter
+- Victor Liu
+
+## Agenda
+
+- updates
+- spec diagrams
+- info on other efforts
+
+## Notes
+
+- Updates
+  - FOSDEM
+    - Deadline for submissions
+    - 20+ submissions
+    - now review
+    - program to be announced on Dec 15th
+  - Channels
+    - Alexios told Sebastian to go ahead and delete unused Matrix and IRC channels
+  - Ambassadors
+    - proposal to be submitted to Steering Committee on Jan 7th
+- Model diagrams in spec
+  - Alexios working on them
+  - Do we need enumeration values?
+    - No one is in favor
+    - Alexios to prepare new versions and show them in Tech call
+- Other efforts
+  - Basic Formal Ontology (BFO) https://basic-formal-ontology.org/
+- Kubernetes BOM tool
+- Request for podcast guest on SPDX by Viktor Petersson 
+- AR: update presentations list
+- Next calls:
+  - Alexios will be out next week
+  - No calls during the two weeks of holidays
+

--- a/outreach/2024/2024-12-16.md
+++ b/outreach/2024/2024-12-16.md
@@ -1,0 +1,25 @@
+# SPDX Outreach Meeting 2024-12-16
+
+- Alexios Zavras
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Karen Bennet
+- Victor Liu
+
+## Agenda
+
+- Go libs
+- updates
+
+## Notes
+
+- Go libraries for SPDXv3 not ready yet
+- Updates
+  - FOSDEM
+    - presentations accepted/rejected
+    - schedule published
+- Open Source Stewards and Maintainers
+  - OpenSSF establishes working group
+  - Is SLSA competitive to SPDX?
+


### PR DESCRIPTION
This simply transfers the meeting minutes from the online editor.

