### PR TITLE
Adding Cryptography meeting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,10 @@ Meetings schedules for the SPDX Project are listed below. All times are listed f
 * Where:  https://zoom-lfx.platform.linuxfoundation.org/meeting/92368452781?password=8b17d642-11d7-4eac-b0e2-e93c5d662afa 
 * Descriptions: Regular meeting focused on the additional information that an organization may wish to associate with a package, for effective management of these artifacts within business operations.
 * Meeting minutes and agendas: https://spdx.swinslow.net/p/spdx-operations-minutes
+
+## Cryptography Team meetings
+* Time and cadence: weekly on Wednesdays at 10:00
+* Where: <https://meet.jit.si/SPDXCryptoMeeting>
+* Descriptions: Regular meeting focused on creating and maintaining an Algorithm List and its uses in SPDX data
+* Meeting minutes and agendas: https://hackmd.io/@spdx/crypto-group
+

--- a/cryptography/2025-05-07.md
+++ b/cryptography/2025-05-07.md
@@ -1,0 +1,43 @@
+# SPDX Cryptography Meeting 2025-05-07
+
+- Alexios Zavras
+- Agustin Benito Bethencourt
+- Alfred L Strauch
+- Bob Martin
+- Jerónimo Ortiz
+- Quique Goñi
+- Steven Carbno
+
+## Agenda
+
+- Introduction
+- Cryptographic Algorithms List
+    - What attributes should there be for each entry?
+- Information related to Cryptography that should be included in a BOM
+    - What information?
+    - How to include such information? (updates on the SPDXv3 model)
+
+## Notes
+
+Alexios explains that the goal is that this list becomes something similar to the SPDX list. He provides some background on how the SPDX License list started.
+
+This is a pure list of data, algorithms.
+
+The second goal is to provide crypto algorithms related info that should be added to SPDX. Use cases: security and export control
+
+Current crypto algorithm list as starting point: https://github.com/spdx/crypto-algorithms/tree/main
+
+We need to put focus on the use cases to understand the info we need to add to the list.
+
+Meetings
+- Weekly at this time
+   - Both goals will be covered on every meeting at first
+   - No agenda specific meetings
+
+Any other efforts
+- We will need to sync up with other efforts or initiatives trying to model cryptographic information. Let's start collecting this.
+
+For next call:
+- collect info on other efforts/initiatives
+- explain the current state of the list
+

--- a/cryptography/2025-05-14.md
+++ b/cryptography/2025-05-14.md
@@ -1,0 +1,38 @@
+# SPDX Cryptography Meeting 2025-05-14
+
+- Alexios Zavras
+- Agustin Benito Bethencourt
+- Alfred L Strauch
+- Jean Camp
+- Quique Goñi
+- Steven Carbno
+
+## Agenda
+
+- where to point people: minutes, mailing list and calendar
+- Description of the existing repo
+- other initiatives
+
+## Notes
+
+- contact
+  - mailing list: use the tech one
+     - <mailto:spdx-tech@lists.spdx.org>
+     - https://lists.spdx.org/g/spdx-tech
+  - minutes posted in minutes repo
+    - https://github.com/spdx/meetings
+    - AR: Alexios to also update README with meeting info
+  - calendar invitation
+    - add it to SPDX calendar
+- existing repo
+  - https://github.com/spdx/crypto-algorithms
+  - currently id, name, securityStrength
+  - thinking about adding "categories"
+  - use case: detection
+  - use GitHub issues for discussion of topics
+  - type vs functionality (use)
+- Other initiatives
+    - CycloneDX
+        - Authoritative Guide to CBOM: https://cyclonedx.org/guides/OWASP_CycloneDX-Authoritative-Guide-to-CBOM-en.pdf
+        - in this guide one can see in page 9/10 the different "asset types" and "types of assets"
+


### PR DESCRIPTION
- Updates top-level README with info on Cryptography group meetings
- Adds minutes from the first two group meetings
