### PR TITLE
Change "Eastern Time" to "Eastern Daylight Time"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository stores meeting minutes for the SPDX project.
 
 The SPDX Project has several Teams and topical groups that meet at regular intervals. Meeting are open to anyone and it is recommended to also join the related mailing list (as applicable), see [SPDX Participate](https://spdx.dev/participate/) for more information. All attendees will be expected to identify themselves by name on all meetings.
 
-Meetings schedules for the SPDX Project are listed below. All times are listed for **US Eastern time zone**, 24-hour.
+Meetings schedules for the SPDX Project are listed below. All times are listed for **US Eastern Daylight Time**, 24-hour.
 
 ## General meeting
 * Time and cadence: once per month on the first Thursday of the month at 11:00


### PR DESCRIPTION
"Eastern Time" is a "float" time and not a fixed point of time in a day, considering that it can be 1-hour forward or backward depending on the day of the year.

A fixed point of time is desired for collaboration across timezones, where some do not observed daylight savings or do observed in a different schedule from the US.

This PR changes "Eastern Time" to "Eastern Daylight Time" to make the time fixed.

If "Eastern Standard Time" is more preferred, we can update this PR.