### PR TITLE
Add 2025 General Meeting minutes

### DIFF
--- a/general/2025/2025-05-01.md
+++ b/general/2025/2025-05-01.md
@@ -1,0 +1,127 @@
+# SPDX General Meeting Minutes: 2025-05-01
+
+## Attendees
+- Agustin Benito Bethencourt (Toscalix)
+- Alfred Strauch
+- Arthit Suriyawongkul (ADAPT Centre)
+- Brad Goldring (GTC Law Group)
+- Calder Sacks
+- Gary Armstrong (FossID)
+- Gary O’Neall
+- Jeff Mendoza (Kusari)
+- Jilayne Lovejoy
+- Jim Vitrano
+- John Ellis (Codethink)
+- Joshua Watt
+- Karen Bennet (ISO)
+- Kate Stewart
+- Michael Herzog
+- Mimi Flynn
+- Nick Vidal (OSI)
+- Nicole Pappler
+- Pete Allor (Red Hat)
+- Peter Monks
+- Phil Odence
+- Ria Farrell Schalnat (HPE)
+- Robert Martin
+- Rose Judge
+- Steven Carbno (Smart Talk Beacon)
+- Steve Winslow
+- Troy Sabin
+
+## Presentation
+### Discover Dependency License Information Using SBOMs and ClearlyDefined
+- Presenter: Jeff Mendoza (GUAC, ClearlyDefined)
+- SBOM Legal Compliance: complying with the license of the software (license and attribution information)  
+- SBOM Creation tool: dependency detection, identification, hierarchy; Jack of all trades, uses package manager reported license or skips it - license info is afterthought compared to dependency detection
+- Maybe there can be tools that specialize in certain information and we combine the outputs of tools  
+- ScanCode: reads all files of a package looking for legal text; provides detailed scan data but can take a while to run  
+- ClearlyDefined: data project where the data output from other scanners can be shared among OSPOs or anyone else doing legal compliance.   
+- SPDX Declared license would be collected by ClearlyDefined  
+- ClearlyDefined's documentation: [https://docs.clearlydefined.io/](https://docs.clearlydefined.io/)  
+- Harvesting \- trigger clearly defined to scan a package that is new to CD  
+- More info on coordinates: [https://docs.clearlydefined.io/docs/resources/coordinates](https://docs.clearlydefined.io/docs/resources/coordinates)  
+- Tools created by Jeff to enhance SBOMs: [https://github.com/jeffmendoza/cdsbom](https://github.com/jeffmendoza/cdsbom)  
+- How to use clearly defined with SBOMs?  
+  - Translation library based on GUAC: [https://github.com/guacsec/sw-id-core/tree/main/coordinates](https://github.com/guacsec/sw-id-core/tree/main/coordinates)   
+  - CD doesn’t use PURLs but there is a library that translates coordinates to purl  
+- Link to the GUAC project, from where you can also use ClearlyDefined: [https://guac.sh/](https://guac.sh/)
+- We have weekly meetings: [schedule and info](https://docs.clearlydefined.io/docs/community/meetings)
+- Demo  
+- Questions:  
+  - Does ClearlyDefined support public Maven repositories other than the 3 listed in the docs? This is a fairly important requirement in the Maven / JVM ecosystem.  
+    - To check this, please go to: [https://clearlydefined.io/](https://clearlydefined.io/) and select MavenCentral as the provider.   
+  - I have tried a few SBOMs with cdsbom but haven't had a successful run yet -- does that mean ClearlyDefined just doesn't have those components? I have tried a few SBOMs with cdsbom but haven't had a successful run yet -- does that mean ClearlyDefined just doesn't have those components?   
+  - What happens when there are differing interpretations of a license for a package?  
+    - Debate happens via PR; Curation meeting happens between the curators  
+  - Also, feel free to drop an email: [nick.vidal@opensource.org](mailto:nick.vidal@opensource.org), [jlm@jlm.name](mailto:jlm@jlm.name)
+
+## Team Updates
+### Core/Software
+- Most discussions around rationalizing changes from some of the different profiles (i.e. geography is a field we have added to several profiles under development)  
+- Joint call tomorrow between operations and hardware profiles  
+- Safety and hardware also overlap  
+  - Hardware https://github.com/spdx/spdx-3-model/pull/977  
+- SaaS profile ready to merge  
+  - SaaS https://github.com/spdx/spdx-3-model/pull/973  
+- PR from Alexios to refer to the fact that software hash id is now an iso standard \- can we accept that into 3.0.1 or will it cause issues?  
+  - Bob: This can be considered as “editorial”. It points to the same document (as a “progress”).  
+- Interest picking up in Europe wrt CRA
+
+### Licensing Profile
+- Joint legal and tech call coming to discuss NOASSERTION / NONE in the license expression syntax; will also review whether to address other past / pending topics
+
+### Lite Profile
+- No update
+
+### Build Profile
+- No update
+
+### Operations Team - Matthew/Marcel/Ummo
+- Joint call tomorrow between operations and hardware profiles to resolve conflicts in core
+
+### AI / Dataset Profiles Team - Karen/Gopi
+- Karen, Gopi and Kate met last week  
+- Work ongoing for 3.1 foundation classes as well as new ideas coming in from AI side
+- Prototyping work happening, more stuff added soon
+- Tool to generate AI and Dataset Profile from github, documentation, etc information
+
+### Security - Rose
+- 3 month sprint of meetings to address some of the issues that are open
+- [Doodle poll (now closed)](https://doodle.com/meeting/organize/id/azYBpDZe?authToken=cm9zZS5qdWRnZUBicm9hZGNvbS5jb207Um9zZSBKdWRnZQ%3D%3D.rEX1qPYVdNPLIbXqc0)
+- SPDX Cryptographic List meeting next week [(More info here)](https://lists.spdx.org/g/spdx/message/1983)
+
+### Hardware
+- Working on cases with the hardware and AI group  
+- One part from Hardware that overlaps with few Profiles is the "Specification" - Specification/Standard/Regulation
+
+### Implementors - Gary
+- SPDX Organization at [PyPI (Python Package Index)](https://pypi.org/org/spdx/)
+
+### Legal team update
+- Next release 3.27 coming up in the next week or so
+
+### Outreach - Robert
+- OMG published SPDX 3.0 [https://www.omg.org/spec/SPDX/3.0/](https://www.omg.org/spec/SPDX/3.0/) 
+
+### Functional Safety - Nicole/Kate
+- Deconflicting work with hardware happening right now
+- Concepts of requirements, evidence and tasks overlapping
+- PRs coming up
+
+### Software as a Service - Gary
+- Ready for merge
+
+## General announcement
+- Kate presented on SBOMs and ongoing work on why we need them to the academic community: academics don’t understand that SPDX is a language.
+- Tesla keeps a digital twin of every car they sell – info for a system BOM
+- Kate’s slides will be published in the next week or so
+- New release for the Java tools: it’s official now
+- SBOM datasets (could be used for SPDX tests?):
+  - [A Dataset of Software Bill of Materials for Evaluating SBOM Consumption Tools Dataset](https://zenodo.org/records/14233415)
+    - Paper: [https://arxiv.org/abs/2504.06880](https://arxiv.org/abs/2504.06880)
+  - Focus on Java/Maven projects, SPDX Lite -- [Wild SBOMs: a Large-scale Dataset of Software Bills of Materials from Public Code Dataset](https://zenodo.org/records/14250103)
+    - Paper: [https://arxiv.org/abs/2503.15021](https://arxiv.org/abs/2503.15021) Has a stat of SBOM standards and formats found on public code (Software Heritage Archive)
+
+### Next meeting
+- June 5, 2025

--- a/general/2025/2025-06-05.md
+++ b/general/2025/2025-06-05.md
@@ -1,0 +1,81 @@
+# SPDX General Meeting Minutes: 2025-06-05
+
+## Attendees:
+- Alfred Strauch
+- Alin Jerpelea
+- Brad Goldring
+- Ilan Schifter
+- Jesse Porter
+- Jilayne Lovejoy
+- Karen Bennet
+- Kate Stewart
+- Marcel Kruzmann
+- Michael Cameron
+- Phil Odence, Black Duck
+- Ria Farrell Schalnat (HPE)
+- Rose Judge
+- Steven Carbno
+- Troy Sabin
+- Troy Sabin
+- Victor Lu
+
+## Technical Team Report 
+### Core & Software
+- Harmonizing hardware and tech for 3.1 release
+- ISO cover letter in circulation
+- Seeing more tools adopting 3.0
+- Business discussions around business operations vs other types of operations
+- Will look into re-energizing the usage profile
+
+### Security
+- Security work will resume 11am PST on Tuesdays
+
+### Licensing
+- Trying to start a joint call with licensing and core to resolve some issues (targeting July)
+
+### Build
+- Because of some of the abstraction, there may be future implications with build. We won’t remove anything there but might put a more general concept in adding something at a higher level than the build profile.
+
+### Lite
+- Haven’t started 3.1 yet
+
+### AI / Dataset
+- Working through the fields that are proposed for 3.1 with the intent of coming to the Tech call in a few weeks to go through that list.
+- Discussed list of metadata that US government organizations are considering capturing
+- OpenChain AI SBOM meeting - working on a [management guide for supply chain](https://docs.google.com/document/d/1XHztgMALwnu2D02bmWYyXeW3wE_Jw199/edit#heading=h.x3i92tls8mld) - Review on document happening until June 25th - discussion happening at OSS NA
+- SPDX AI talks have been given to this group
+- Being asked to give talks to other open source communities (in particular OASIS) \- starting to define data provenance on a detailed level.
+- [AI BOM Whitepaper](https://www.linuxfoundation.org/hubfs/LF%20Research/lfr_spdx_aibom_102524a.pdf?hsLang=en)
+- If there’s a visual example, Ilan can add to Dots tool
+  - Here's a simple dataset [example](https://github.com/spdx/spdx-examples/tree/master/dataset/example01). Let me know if this is good enough. I can't find Art's example at the moment
+
+### Functional Safety
+- Continuing to work through the classes for 3.1. Have mostly deconflicted with Hardware profile at this point.
+- Meetings will pick up once Nicole is back from vacation
+
+### Canonicalization/Serialization
+- No udpates
+
+### Software as a Service
+- Has been merged - done for 3.1
+- Some wording changes requested so PR will becoming up.
+
+### Hardware
+- Discussion on digital location and external ID requirement and dealing with ownership responsibility (enhancement on the idea of ownership).
+
+### Tooling and Implementers
+- No updates
+   
+### Legal Team Report – Jilayne/Steve
+- Some issues with the publisher so we haven’t released 3.27 yet.
+- Looking for help to update the FAQ page
+
+### Outreach/Website Team Report – Alexios/Bob
+- In the midst of rescheduling the calls that works for everyone.
+- For ISO: We need an explanatory report that justifies how we meet some of their criteria - we need to update some of the public pages on the SPDX website to reflect SPDX 3.0
+
+## General Announcements
+- New steering committee memebers: Ilan Schifter and Mahshid Izady-Vahedy
+
+### Next Meeting
+- August 7, 2025 (Will skip July meeting due to holiday)

--- a/general/2025/2025-08-07.md
+++ b/general/2025/2025-08-07.md
@@ -1,0 +1,151 @@
+# SPDX General Meeting Minutes: 2025-08-07
+
+## Attendees:
+- Agustin Benito Bethencourt
+- Alfred Strauch
+- Alin Jerpelea
+- Arthit Suriyawongkul
+- Bob Martin
+- David Edelsohn
+- Gary O’Neall
+- Greg Shue
+- Ilan Schifter
+- Jilayne Lovejoy
+- Jim Vitrano
+- Joshua Watt
+- Karen Bennet
+- Karsten Klein
+- Marcel Kurzmann
+- Michael Herzog
+- Nicole Pappler
+- Patrick Little
+- Phil Odence
+- Rose Judge
+- Steven Carbno
+- Steve Winslow
+- Teddy Nyambe
+- Troy Sabin
+
+## Mini presentations: New profiles/concepts to be added for 3.1
+### Functional Safety (Nicole Pappler)
+- New classes for types of documentation needed for functional safety
+- New specification class (also used by hardware class)
+- New requirement class (from Element)
+- New evidence class to capture test results, release approval etc.
+- Meetings Friday at 9am Pacific
+- [Functional Safety Update Presentation](https://docs.google.com/presentation/d/1MGTEMEP9lFf-7pB3Z8kGGpGpVDB-d6BjZstotzZ2a-M/edit?usp=sharing)
+
+### Hardware Profile (Alfred Strauch)
+- Includes a supply chain and the work related to this profile is complete for a first round draft
+- Meet on Friday mornings at 8am central US time
+- Will include a significant upgrade to core profile as well
+- Can model any type of hardware (chip, computer, devices, etc)
+- Designed to have a decomposition; can take any element and can be decomposed into other elements - packages, bundles  
+- Can represent physical hardware, virtual hardware
+- Captures physical location (i.e. a fab) and working on virtual location representation
+- Significant integration of software so hardware can be mapped to software elements
+- Hardware branch in the model
+
+### Operations profile (Marcel Kurzmann)
+- A lot of overlap between hardware and operations
+- Defines fields for describing the business context of the system that cannot be extracted from the source repo
+- Business operations and technical operations
+- We need a common language to describe operations for alignment of tool and infrastructure interfaces
+- Working on export control assessments for 3.1
+- Meet every friday at 1400 UTC. There is also a slack channel
+- PR for the operations changes will be opened soon and presented at the tech call (date TBD)
+- Steve Winslow – Operations profile and Legal team should sync to discuss in-scope vs. out-of-scope topics
+
+### Threat Modeling (Karsten Klein)
+- Discussion in tech call yesterday: How can we model threats with SPDX
+- This is not a new profile - Will try to connect this to the security and FuSA profiles
+
+### Cryptography Working group (Agustin Benito Bethencourt)
+- This is a new effort, that started two months ago
+- List for referencing cryptographic algorithms in SPDX
+- Similar to the SPDX license list but for crypto algorithms
+- There is a first draft of 122 algorithms structured in 3 categories (classes): cryptographic-hash algorithm, symmetric-key algorithm and, asymmetric-key algorithm
+- The first draft of the properties description is being reviewed in the GitHub repo
+- Meetings: Wednesdays at 14:00 UTC
+- Repository: [https://github.com/spdx/crypto-algorithms](https://github.com/spdx/crypto-algorithms)
+- Call for participation. We welcome people with use cases in mind to help us shape the list. Also cryptographers to increase the overall knowledge of the current group on this field.
+
+### Concept: Adding component to the model
+- New class called component that is a generalization of an SPDX package
+- Common info about a package instead of specific version
+- Example: openssl
+- Benefit: saves a ton of space because avoids redundant packages
+- Current PR: [https://github.com/spdx/spdx-3-model/pull/1044](https://github.com/spdx/spdx-3-model/pull/1044)
+- Can we not do this today? We can but it is ambiguous - not a concrete definition between producers
+
+## Technical Team Report 
+### Core & Software
+- Trying to understand where there is overlap in the new profiles being added for 3.1
+- Targeting release candidate soon - two priorities:
+  - Optimizing for hardware profile
+  - If any changes to core or software from other new profiles, those are also included.
+- Expect multiple release candidates
+- Tech and Legal joint meeting to try to advance longstanding issues:
+  - License expression syntax for NONE and NOASSERTION identifiers: [https://github.com/spdx/spdx-spec/issues/49](https://github.com/spdx/spdx-spec/issues/49); [https://github.com/spdx/spdx-spec/issues/50](https://github.com/spdx/spdx-spec/issues/50)
+    - Trying to figure out if it makes sense to make them available in compound license statements
+    - Can be included in complex license combinations via the RDF model in 3.0, but not currently expressible as valid under the license expression syntax
+    - Discussed a few use cases where NONE and NOASSERTION can make sense in AND license expressions
+    - Next steps: Alexios will update issues to describe where we landed
+  - Discussion on capturing metadata about licenses related to one another
+    - [https://github.com/spdx/spdx-spec/issues/13](https://github.com/spdx/spdx-spec/issues/13)
+    - Discussions on that moved to the license list xml repo: [https://github.com/spdx/license-list-XML/issues/2805](https://github.com/spdx/license-list-XML/issues/2805)
+
+### Security
+- Currently discussing the addition of signatures to the model
+  - [https://github.com/spdx/spdx-3-model/issues/1065](https://github.com/spdx/spdx-3-model/issues/1065)
+- Meetings are happening Tuesdays at 11 AM Pacific
+
+### Licensing
+- Discussed in tech / legal joint meeting comments listed above
+
+### Build
+- No updates
+
+### Lite
+- No updates
+
+### AI
+- Working through getting our PRs together for 3.1
+- Introducing fields for prompting AI agents and RAG type fields
+
+### Dataset
+- Mapping between different country government AI requirements
+- Meet Wedsneadys at noon pacific time
+
+### Functional Safety
+- See summary above
+
+### Canonicalization/Serialization
+- No update
+
+### Software as a Service
+- Merged and ready to go for 3.1
+
+### Hardware
+- Ready for release candidate
+
+### Tooling and Implementers
+- No update
+
+### Legal Team Report – Jilayne/Steve
+- License list 3.27 released last month
+- Working through issues for 3.28
+
+### Outreach/Website Team Report
+- For all of the groups that are targeting to be in the release candidate, please make sure you have writeups on the website that explain your profile and activities
+- Rose sent out an email to new profile leads
+- Tooling vendors please take a look at: [https://github.com/spdx/spdx-website](https://github.com/spdx/spdx-website) and make sure info is up to date
+
+## General announcement
+- [OSS EU](https://events.linuxfoundation.org/open-source-summit-europe) is happening this month (Aug 25-27)
+- Suggestion: highlights page for the different profiles
+- Landing page for SPDX navigation [here](https://github.com/spdx/)
+- Another summary resource: [https://spdx.dev/learn/areas-of-interest/](https://spdx.dev/learn/areas-of-interest/)
+
+### Next Meeting
+- September 4, 2025

--- a/general/2025/2025-09-04.md
+++ b/general/2025/2025-09-04.md
@@ -1,0 +1,93 @@
+# SPDX General Meeting Minutes: 2025-09-04
+
+## Attendees:
+- Agustin Benito Bethencourt (Toscalix)
+- Alexios Zavras
+- Alfred Strauch (Smart Talk)
+- Arnis
+- Bob Martin
+- David Edelsohn
+- Gary O’Neall
+- Greg Shue
+- Jilayne Lovejoy
+- Joshua Watt
+- Kate Stewart
+- Nicole Pappler
+- Phil Odence
+- Rose Judge
+- Steven Carbno (Smart Talk)
+- Steve Winslow
+
+## Technical Team Report
+### General Updates
+- [CISA Requests Public Comment for Updated Guidance on Software Bill of Materials](https://www.cisa.gov/news-events/alerts/2025/08/22/cisa-requests-public-comment-updated-guidance-software-bill-materials#:~:text=the%20.gov%20website.-,CISA%20Requests%20Public%20Comment%20for%20Updated%20Guidance%20on%20Software%20Bill,and%20this%20Privacy%20&%20Use%20policy)
+  - CISA stakeholders have been discussing a revised minimum set of SBOM elements
+  - SPDX has the opportunity to give feedback about the changes they’re making and what implications it may have
+  - Will discuss feedback in the tech call
+- Harmonization between CISA and CRA?
+  - ["NSA, CISA, and Others Release a Shared Vision of Software Bill of Materials (SBOM)"](https://www.nsa.gov/Press-Room/Press-Releases-Statements/Press-Release-View/Article/4292020/nsa-cisa-and-others-release-a-shared-vision-of-software-bill-of-materials-sbom/)
+- We will use next Tuesday’s tech call to go through the document and start to draft some feedback. Is there anyone that would like to participate that cannot make next Tuesday's meeting?
+  - Will send out response drafted by the tech call to the tech team before steering committee signs off
+  - RFC deadline is October 3rd
+- [Presentation from CISA at OSS EU](https://osseu2025.sched.com/event/25Vq6/sometimes-sequels-are-good-cisas-update-to-the-2021-ntia-sbom-minimum-elements-victoria-ontiveros-cisa)
+- Need Supply Chain Profile logo - Rose will open a ticket with LF
+- Any SPDX “news” please send to Phil so we can update the website
+
+### Core & Software
+- Split the hardware profile into supply chain profile and hardware profile
+  - Pull request is available but hardware hasn’t been moved to the development branch
+- Component element (for software profile): grouping of packages so that you can refer to general packages. Can use relationships to connect it to other packages
+- ISO submission
+- Threat modeling → threat and controls
+
+### Security
+- Draft proposal for how to handle signing in the security mailing list
+
+### Licensing
+- Adding NONE and NOASSERTION to the license annex and syntax - merged into repo
+
+### Build
+- No updates
+
+### Lite
+- No updates
+
+### AI
+- Reviewing new fields for 3.1
+
+### Dataset
+- No updates
+
+### Functional Safety
+- Finalizing fields for the release candidate
+
+### Canonicalization/Serialization
+- No updates
+
+### Software as a Service
+- No updates
+
+### Hardware
+- Looking at next phases and what additional elements need to be added.
+- Hardware and supply chain will meet together - Fridays 9am EST
+
+### Tooling and Implementers
+- Trying to get work going again on the python libraries
+- Black Duck version 2025.7.0 now supports SPDX import and export in 3.0.
+
+### Cryptography
+- First [draft of the list](https://github.com/spdx/crypto-algorithms) completed. 122 crypto algorithms
+  - The [properties description PR](https://github.com/spdx/crypto-algorithms/pull/15) associated to the current version of the list is under review
+- Next steps. Iterating now in several fronts:
+  - Making some of the properties more SPDX friendly when several values are possible\[[2](https://github.com/spdx/crypto-algorithms/issues/17)\]\[[3](https://github.com/spdx/crypto-algorithms/issues/16)\]
+  - Correcting some minor mistakes \[[1](https://github.com/spdx/crypto-algorithms/issues/18)\]
+  - Adding [OID](https://github.com/spdx/crypto-algorithms/issues/20) as property
+- Discussions
+  -  [Elliptic Curve](https://github.com/spdx/crypto-algorithms/issues/21) as property
+- Other points
+  - Several conversations at OSS EU 2025 about the list. Most had no clue about it, as expected. One [talk](https://osseu2025.sched.com/event/25Vp2/know-your-crypto-standardizing-and-detecting-crypto-algorithms-the-open-source-way-matias-daloia-scanoss) named the list
+  - The list was promoted among openchain tooling group
+- The security profile is currently discussing how to utilize this list in their representation of a signature.
+
+### Next meeting
+- October 2, 2025


### PR DESCRIPTION
Note that this commit only covers general meetings recorded using Google Docs, as I cannot access the etherpad notes from meetings prior.