### PR TITLE
Add meeting notes for SPDX Hardware Team 2026-01-09

### DIFF
--- a/hardware/2025/2026-01-09.md
+++ b/hardware/2025/2026-01-09.md
@@ -1,0 +1,45 @@
+# SPDX Hardware Team Meeting 2026-01-09
+
+## Attendees
+- [x] Alfred Strauch
+- [x] Steven Carbno
+- [x] Bob Martin (MITRE)
+- [ ] Dishoung White II
+- [ ] Kate Stewart
+- [x] Victor Lu
+- [x] Jim Vitrano
+- [ ] Amit Kumar
+- [x] Issac Asay
+- [ ] Lucas Tate
+- [ ] Apoorav Trehan
+- [ ] Alex Volykin
+- [ ] Allan Friedman
+- [x] Greg Shue
+- [ ] Riley Barello-Myers
+- [ ] Henk Berkholz
+- [ ] Dan Hopkins
+- [ ] Courtney Ng
+- [ ] Andrew Viater
+- [ ] Raymond Sheh
+- [ ] Stanislav Pankevich
+- [x] Karen Bennet
+- [ ] Marcel Kurzamann
+- [ ] Raymond Sheh
+- [ ] Michael Pease (NIST Standards)
+- [ ] Jenn Power (Red Hat)
+
+## Agenda
+- Review PRs and 3.1 status (no new PR)
+- Refresh thinking related to where we left off in Dec; any new CRA developments?
+- Determine next steps and roadmap
+
+## Background information
+- Threat modeling issues need to be discussed; important for CRA evaluation.
+- Risk is threat plus potential harm.
+- Need to define product scope; needs to be done by this group.
+- Can SPDX fulfill the needs of a product manufacturer? Submit conformance requirements.
+  - This issue will touch on several profiles.
+- The engineering process needs to be considered, especially those supported by numerous organisations.
+- How will they be expressed in SPDX?
+- Spreadsheet enhancements with Greg; discuss Sheets; Annex VII:
+  - https://docs.google.com/spreadsheets/d/10KdQTkXH3K-kp1zD7wIhu


### PR DESCRIPTION
Documented attendees and agenda for the SPDX Hardware Team meeting on January 9, 2026.