### PR TITLE
Add minutes for SPDX Hardware Team meeting on 2026-01-16

### DIFF
--- a/hardware/2025/2026-01-16.md
+++ b/hardware/2025/2026-01-16.md
@@ -1,0 +1,89 @@
+# SPDX Hardware Team Meeting 2026-01-16
+
+## Attendees
+- [x] Alfred Strauch
+- [x] Steven Carbno
+- [x] Bob Martin (MITRE)
+- [ ] Dishoung White II
+- [ ] Kate Stewart
+- [x] Victor Lu
+- [ ] Jim Vitrano
+- [ ] Amit Kumar
+- [x] Issac Asay
+- [ ] Lucas Tate
+- [ ] Apoorav Trehan
+- [ ] Alex Volykin
+- [x] Allan Friedman
+- [x] Greg Shue
+- [ ] Riley Barello-Myers
+- [ ] Henk Berkholz
+- [ ] Dan Hopkins
+- [ ] Courtney Ng
+- [ ] Andrew Viater
+- [ ] Raymond Sheh
+- [ ] Stanislav Pankevich
+- [ ] Karen Bennet
+- [ ] Marcel Kurzamann
+- [ ] Michael Pease (NIST Standards)
+- [ ] Jenn Power (Red Hat)
+
+## Agenda
+- Review PRs (none)
+- Question for SPDX management: Why are some HW-SC minutes truncated?
+  - https://github.com/spdx/meetings/pull/1010/files
+- SPDX v3.1 (cr1) release planned for this weekend (Jan 18-19)
+- Review ENISA document:
+  - https://www.enisa.europa.eu/sites/default/files/2025-12/SBOM%20Analysis%20-%20Towards%20an%20Implementation%20Guide_v1.20-Published.pdf
+- Spreadsheet enhancements with Greg (Discuss Sheets, Annex VII):
+  - https://docs.google.com/spreadsheets/d/10KdQTkXH3K-kp1zD7wIhuSUc91U8ttm7gVZ0BEVC004/edit?gid=0#gid=0
+  - Reference: https://owasp.org/www-project-application-security-verification-standard/
+
+## Notes
+- SPDX v3.1 (cr1) will solve many issues and will be frozen.
+- Send message to Kate, Gary, and Alexios regarding truncated minutes.
+
+### ENISA discussion
+- SPDX Hardware and Steering Committee content not considered.
+- SPDX 2.3 appears to be the version referenced/used.
+- Risk analysis focus noted.
+- Question raised: What is the real intention of the ENISA document? (Comparison to NSA standards guidance; clarify intent.)
+- Profiles need to be updated with effective information:
+  - Outreach needs to get profiles updated by group leads.
+  - Allan will review material.
+- Need to build a supply chain document for the website.
+- Open question: Who and what is the process to submit documents to ENISA?
+- SPDX submission requires collection of information.
+- Karen noted additional documents may require submission (including supply chain).
+- Best way to submit is through Karen.
+- Concrete suggestions needed.
+- Engage profile partners to make suggestions.
+- Maintain continuity across EU and US standards and education.
+- Karen will help coordinate SBOM guide feedback; described as more of a survey.
+  - CRA has four specific documents tied to specific wording.
+- Question raised: How will additional profiles planned for v3.1 cr2 be handled?
+  - "Coming soon" items now available need to be identified.
+- Profile teams must submit profiles:
+  - Outreach will resend the profile outline to profile leads for submission.
+
+## Action Items
+- Everyone to review and identify issues:
+  - Use the minutes for collection or create a separate document.
+- Submit changes to ENISA relating to SPDX and other process issues (via the draft points below).
+- Send message to Kate, Gary, and Alexios regarding minutes.
+- Consider systems engineering concerns (Greg):
+  - Argue stages are unclear (example: SBOM completeness; software rollback procedures are not an SBOM issue).
+  - Build elements for different stages.
+  - Distinguish generation stage vs build elements.
+  - Clarify different stakeholder support (TBD).
+
+## Decision
+- Karen and Alfred will coordinate document creation and submission.
+
+## ENISA points for discussion and submission (draft components)
+- SPDX outdated versions referenced: submit updated version information.
+- F.3 Information loss scenarios: incorrect information in multiple locations.
+- Systems engineering stages are not clear.
+- Example: completeness of SBOMs; software rollback procedures are not an SBOM issue.
+  - Build elements for different stages.
+  - Distinguish generation stage vs build elements.
+  - Clarify different stakeholder support (TBD).


### PR DESCRIPTION
Documented the minutes of the SPDX Hardware Team meeting held on January 16, 2026, including attendees, agenda items, notes, action items, and decisions made.