### PR TITLE
Add SPDX AI Team Meeting Minutes for 2026-01-21

### DIFF
--- a/ai/2026/2026-01-21.md
+++ b/ai/2026/2026-01-21.md
@@ -1,0 +1,58 @@
+## SPDX AI Team Meeting Minutes | 2026-01-21
+
+### Attendees
+* Alfred Strauch
+* Arthit Suriyawongkul
+* Bob Martin
+* Elyas Rashno
+* Gopi Krishnan Rajbahadur
+* Raymond Sheh
+* Karen Bennet
+* Steven Carbno
+
+---
+
+### Announcements & Releases
+* **New Meeting Cycle:** Kickoff for **OpenSSF AI/ML and CosAI WS1** is scheduled for Fridays at noon ET.
+* **Release Strategy:** All AI/Dataset profile PRs are moving to **SPDX 3.1-rc2**. There are currently no AI-specific updates targeting 3.1-rc1.
+* **Website Updates:** Revised text for the AI and Dataset profiles has been updated on the SPDX website.
+    * [AI Profile Draft](https://docs.google.com/document/d/1FBCOPe521uYFIIteIpWHQItCN16gNTbZaY80-W1lJY0/edit?tab=t.0#heading=h.crdnslxyz91k)
+    * [Dataset Profile Draft](https://docs.google.com/document/d/1A-ZalCfnTdJQ--PXmwK1Wk30SMPYDrIrwiVL2Y2w5vo/edit?tab=t.0)
+
+---
+
+### Technical Discussion
+* **External Identifier Types ([PR #1187](https://github.com/spdx/spdx-3-model/pull/1187)):** * Reviewed for inclusion in 3.1-rc2 to support Open Science, FAIR, and IP use cases. 
+    * **Changes:** IBAN was removed due to sensitive data concerns (feedback from Steven and Bob). 
+    * **Process Note:** Bob raised a concern regarding timing; since this PR affects **Core**, it should ideally be in rc1 to avoid introducing new elements to Core in later release candidates.
+* **IEEE 7012-2025 (MyTerms):** Art introduced this standard for standardized privacy terms (e.g., "PDC-AI" for training permissions). While useful for `DatasetPackage`, the consensus is that it remains remote from current SBOM use cases and won't be integrated in the immediate future.
+
+---
+
+### Tooling: AIBoMGen
+* **Status:** Moving to its new home at OWASP to begin SPDX generation.
+* **Resources:** * [Code Repository](https://github.com/idlab-discover/AIBoMGen)
+    * [Research Paper](https://arxiv.org/abs/2601.05703)
+* **Pending:** Gopi to provide an update/video regarding SPDX AIBOMGen status.
+
+---
+
+### External Standards & Reviews
+* **ENISA SBOM Landscape Analysis:** Comments are due this Friday. Karen Bennet will consolidate team feedback for submission.
+* **ETSI EN 304 223 V2.1.1 (AI Security):** Baseline cybersecurity requirements for AI models. Victor and others will review this to see if it aligns with the OpenSSF AI Baseline project.
+* **ETSI PT3 (Vulnerability Handling):** Comments are due in early February.
+
+---
+
+### Action Items
+
+| Task | Assignee | Deadline / Status |
+| :--- | :--- | :--- |
+| **ENISA Review:** Submit consolidated comments on SBOM Landscape | Karen Bennet | Jan 23 (Friday) |
+| **Release Management:** Monitor PR #1187 and finalize Core inclusion | Tech Team | 3.1-rc2 |
+| **AIBoMGen:** Provide status update/demo video | Gopi | ASAP |
+| **ETSI Review:** Evaluate ETSI EN 304 223 for OpenSSF alignment | Victor & Others | Ongoing |
+| **Agenda Item:** Add "SPDX Persona List" to next meeting | Kate/Chair | Jan 28 |
+| **AOB:** Plan Agent, Prompt, and RAG support | Tech Team | 3.1-rc2 |
+
+---


### PR DESCRIPTION
Documented meeting minutes for the SPDX AI Team, including attendees, announcements, technical discussions, tooling updates, external standards, and action items.