### PR TITLE
Add minutes for SPDX AI Team meeting on 2026-02-18

### DIFF
--- a/ai/2026/2026-02-18.md
+++ b/ai/2026/2026-02-18.md
@@ -1,0 +1,80 @@
+# SPDX AI Team Meeting 2026-02-18
+
+## Attendees
+- Alfed Strauch
+- Ariel Fogel
+- Arthit Suriyawongkul
+- Elyas Rashno
+- Raymond Sheh
+- Steven Carbno
+
+## Agenda
+- Approve previous minutes: https://github.com/spdx/meetings/pulls
+- Welcome any new members
+- General announcements - None
+
+### [3.1-rc2]
+- https://github.com/spdx/spdx-3-model/pull/1187
+- AI fields related to Agent & Foundational Model #1091
+- Examples from AI BOM whitepaper to each class/property #1012
+- `energyConsumption`, `finetuningEnergyConsumption`, `inferenceEnergyConsumption` would vary, so is it correct to record them? #768
+- Identifiers PR (`ExternalIdentityType.md` - enumeration list)
+
+### [3.2] Roles PR
+- Roles have relationships (examples pls?)
+- Roles can be any agent or anything else
+- Roles have expectations, e.g. data host - hardware
+- Roles define responsibilities and requirements between any 2 elements
+- How well the ideal is fulfilled is verified elsewhere using functional safety
+- Each profile defines roles to help users understand and use roles in profiles
+  - What happens if a role has the same name with different purposes in a specific profile?
+- Add “Crosswalk” to compare similar but different terms from different standards
+  - Needs further discussion and design
+- Used for ontology integration
+- IEEE, ISO, CoSine - most complicated
+- May use “contains” in addition to Crosswalk
+  - How will it be expressed?
+
+### SPDX Roles Proposal - Alfred/Steven
+- Anything else?
+- Q1: Roles different between governance and MITRE bottoms-up approach. How to address.
+- Q2: Do ontologies like IEEE COO and ISO/IEF 21838-2 help
+- Ray’s notes on entities/roles/personas/qualifications/fitness: Ray's notes on Role, Persona, Qualification, Fitness
+
+### SPDX Persona List - Raymond
+- Ray's Notes on AI Supply Chain Entities
+
+### SPDX Tooling
+- Knowledge Graph Explorer Tool
+  - Demo/discussion at Feb 23 OWASP meeting
+- OWASP Crosswalk table
+  - To be presented at OWASP Feb 23 meeting
+- (aibom-generator/HF_files/aibom-generator/docs/AI_SBOM_Fields_Mapping_Reference.md at main · GenAI-Security-Project/aibom-generator)
+- Working Draft of Comparison: https://docs.google.com/document/d/1x_3TRaMuau3V-yjFwtZS83eJjV0LpK4ZVPKvlyEg23E/edit?tab=t.0
+
+### Others
+- Do we need to conduct an industry usage landscape survey?
+- What CDX and others are being used?
+
+## AOB
+- Where are we planning to use it?
+- Simple Standard for Sharing Ontological Mappings (SSSOM) may be used instead of a crosswalk
+- https://mapping-commons.github.io/sssom
+- ttps://mapping-commons.github.io/sssom/
+- https://github.com/codemeta/codemeta
+- https://codemeta.github.io/crosswalk/
+
+## Notes
+- Previous meeting minutes approved.
+- New external identifier types (PR 1187) - no objections and will go to 3.1 RC2.
+- Art will create a PR for energy consumption property that uses new QUDT in 3.1.
+- Continued discussion on RoleRelationship proposal via PR.
+- Testable characteristic of a requirement.
+- Update PR to link to Raymond’s notes, which was the kickstart of this discussion.
+- Raymon provided an update on persona work, and we need a PR/home for decisions getting made.
+- Ariel’s rPOC:
+  - https://huggingface.co/ariel-pillar/phi-4_function_calling
+- Arxiv preprint:
+  - https://arxiv.org/abs/2602.04653
+- Question on chat provenance in SBOM.
+- Www https://github.com/pillar-labs/pillar_gguf_scanner


### PR DESCRIPTION
Documented the minutes of the SPDX AI Team meeting held on 2026-02-18, including attendees, agenda items, discussions on roles, proposals, and other notes.