### PR TITLE
Add meeting notes for SPDX Tech Team on 2026-03-23

### DIFF
--- a/asia/2026/2026-03-23.md
+++ b/asia/2026/2026-03-23.md
@@ -1,0 +1,47 @@
+# SPDX Tech Team Meeting 2026-03-23
+
+## Attendees
+- Kate Stewart
+- Norio Kobota
+- Takashi Ninjouji
+- Yoshiyuki Ito
+
+## Agenda
+- Approval of last month's minutes
+- Announcements & New participants
+- Topics: SBOM Document Quality Guide
+
+## Notes
+
+### Announcements
+- Java library released
+- OpenChain and Friends: https://openchainproject.org/news/2025/12/09/openchain-and-friends-2026
+- Detailed schedule: https://github.com/Open-Source-Compliance/Sharing-creates-value/blob/openchain_and_friends_2026_prep/Events/OpenChainAndFriends26/OpenChainAndFriends_Program_2026.md
+- Quality Guide - comments and feedback welcome prior to public announce in April
+
+### SBOM Document Quality Guide
+- Share with SPDX and ask for input
+
+### SPDX Lite
+- Chapter 3 - elements to be included
+- It's almost ok - 2 or 3 things to be considered
+- See `SBOM_Chapter3_Gap_Analysis_v3_EN.docx`
+- Expect PR to emerge from work on analysis
+
+### Japanese Automotive Industry Discussion on SBOM Sharing Information
+- Sharing information on how to express a software update
+- Is there going to be a specific property needed for Automotive specific SBOM?
+- Suggest looking at relationship types to see whether what is needed is already there:
+  https://spdx.github.io/spdx-spec/v3.1-RC1/model/Core/Vocabularies/RelationshipType/
+- Discussion of Extension Namespace use:
+  https://spdx.github.io/spdx-spec/v3.0.1/model/Extension/Classes/Extension/
+
+### Extension to License List Metadata
+- Discussion between tech and legal team last week based on:
+  https://github.com/spdx/spdx-3-model/issues/1229
+- Continuing on this week
+
+## Backlog
+- See backlog at “Backlog” tab:
+  https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y
+```


### PR DESCRIPTION
Documented the SPDX Tech Team meeting notes, including attendees, agenda, and discussions on SBOM and licensing.