### PR TITLE
docs: fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository stores meeting minutes for the SPDX project.
 
 # Meeting Schedule
 
-The SPDX Project has several Teams and topical groups that meet at regular intervals. Meeting are open to anyone and it is recommended to also join the related mailing list (as applicable), see [SPDX Participate](https://spdx.dev/participate/) for more information. All attendees will be expected to identify themselves by name on all meetings.
+The SPDX Project has several Teams and topical groups that meet at regular intervals. Meetings are open to anyone and it is recommended to also join the related mailing list (as applicable), see [SPDX Participate](https://spdx.dev/participate/) for more information. All attendees will be expected to identify themselves by name on all meetings.
 
 Meetings schedules for the SPDX Project are listed below. All times are listed for **US Eastern Time**, 24-hour.
 


### PR DESCRIPTION
I found a typo changing `Meeting` to `Meetings` in the opening paragraph on the README for the `Meeting Schedule` section. While not an important fix really at all, I knew no one else would probably notice it, so I might as well open a PR for it.

Also if you're wondering, no I did not just randomly stumble upon this project. Ria Farrell Schalnat did a talk and presentation on SPDX for my Humanitarian FOSS class at Rochester Institute of Technology which is how I found this project. I may pop in to the next general meeting if I can in May.