### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-04-14

### DIFF
--- a/tech/2026/2026-04-14.md
+++ b/tech/2026/2026-04-14.md
@@ -1,0 +1,177 @@
+# SPDX Tech Team Meeting 2026-04-14
+
+## PR:
+Attendees
+
+- Alfred Strauch
+- Arthit Suriyawongkul
+- Bob Martin
+- Dick Brooks
+- Gary O'Neall
+- Greg Shue
+- Indurwara Gunaesena
+- Karsten Klein
+- Kate Stewart
+- Marc-Etienne Vargenau
+- Maximilian Huber
+- Nicole Pappler
+- Peter Monks
+- Steven Carbo
+- Ted Gauthier
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements & New participants
+- Update from discussion TEA
+- Spec tooling (if Alexios, Gary, Art)
+- Relationships
+- RUNTIME_ENVIRONMENT_OF https://github.com/spdx/spdx-spec/issues/728
+- Assumption relationships  https://github.com/spdx/spdx-3-model/pull/1251 - need merge
+- Decide if finish for 3.1 or push to 3.2 or close
+- How to handle symlinks in SPDX documents?  
+  https://github.com/spdx/spdx-spec/issues/610
+- Element inlining rules / CreationInfo exception in JSON-LD serialization doc https://github.com/spdx/spdx-3-model/issues/1104
+- Generalize *UUID  
+  https://github.com/spdx/spdx-3-model/issues/1222
+- Generalize *Version  
+  https://github.com/spdx/spdx-3-model/issues/1225
+- Support attestations as artifacts in SPDX 3.1  
+  https://github.com/spdx/spdx-3-model/issues/594
+- ExternalRefType: Revise entry descriptions to support beyond (software) "package" ?  
+  https://github.com/spdx/spdx-3-model/issues/1231
+- How to count the number of licensing profiles?  
+  https://github.com/spdx/spdx-3-model/issues/1238
+- Revisit SPDX RDF URI versioning https://github.com/spdx/spdx-3-model/issues/1146, https://github.com/spdx/spdx-spec/issues/1378
+- Update profile maintainers list https://github.com/spdx/spdx-3-model/issues/1244
+- Add a paragraph about file naming  
+  https://github.com/spdx/spdx-spec/pull/1383
+
+## Notes
+
+### Meeting minutes
+Approved.
+
+### New Participants
+Induwara Gunasera (GSoC) Sri Lanka.   Contributed to NTIA Conformance Checker.
+
+### Threats & Controls Minutes are behind.
+Karsten to take a pass and reach out to Gary/Kate if not able to approve.
+
+### Asia Update
+2 people will be at OSS NA;  others?  
+All who have feedback please provide to
+
+### TEA Update
+Lots of support for SPDX in that community;  add issue into TEA, to enable multiple identifiers to support SPDX and TEA.   IANA types will help, but not necessarily required.
+
+Bob looking to update contacts for profile to profiles
+
+Kate & Gary to respond to email
+
+https://github.com/spdx/spdx-3-model/issues/1244 to be acted on.
+
+Media type: The request for application/spdx3+json has been submitted to IANA.  
+The ticket number is 1450117.  
+See the public-view status at: https://tools.iana.org/public-view/viewticket/1450117
+
+### Add a paragraph about file naming
+https://github.com/spdx/spdx-spec/pull/1383 - to be reviewed and targeted into 3.1;   backport to 3.0 based on ISO review comments.
+
+### Serialization
+Recommendation from Max is to create a set of examples so that tools can challenge their tools against it.    We can use it as test cases for the de-serialization tooling.    Creation_info is where this will hit.
+
+The RDF graph of an instance of the SPDX model shall contain all Element nodes (i.e. objects that are subclasses of Element) as a list on top-level under the "@graph" key. This means that all references to Element nodes have to use the URI of the referenced Element.
+
+Inlining/Embedding of Element nodes into other nodes is not allowed.
+
+Non-element data (like those of type "ExternalReference" or similar complex data classes) may be inlined or included as a blank node on top-level under the "@graph".
+
+The above statements makes it easier for people producing SPDX;  so it's better than the TODO that was there before
+
+### Relationships
+Kate volunteering to create PR for runtime_environment
+
+PR for assumptions merged.
+
+### Generalization
+Guidelines for keeping it specific.
+
+Do we want this as UUID with sub properties?  Better in RDF to be specific,  but for tools it's more appropriate for reusing code.  If distinction is useful in domain, then leave it as a specialized therm.    In future,  can consider doing it a s sub property of generalized.
+
+Nicole: likes generalized type, but how UUIDs are used in system engineering, there are specific needs with different.   Favors keep it like it is for now, and evolve it into a generalized type later that can
+
+Art: Is it posible to call it UID rather than UUID?  For domains, it needs to remain Universal for some domains.   We should review this in the calls when
+
+Gary:  We need to check we're following UUID guidance.
+
+Greg:  Must have UUIDs for scalability
+
+Steven:  current UUIDs may not follow ISO specification.   Should leave it as a string.
+
+Greg: Combining unique identifier as well as authenticity, may cause issues for scaling
+
+Nicole:  Only considered in context in numbering scheme and prefix.   Statement needs to say the same.
+
+Gary:  we need to document this.
+
+Art: IETF RFC 9562 https://datatracker.ietf.org/doc/rfc9562/
+
+Greg:  Different algorithms for generating, how validate that algorithms don't clash.
+
+Nicole: prefixes are usually way for handling this - to make them as unique as possible.
+
+Max: forcing a specific scheme is not in our scope, and make it a generic string that people fills.
+
+Greg: Must provide a mechanism for being able to interpret, and identify collisions between suppliers.   Want to see way for customers to add prefixes to make it clear per supplier.
+
+Steven:  Are currently using as external identifiers, and issuing authority is part of it.   Different issuing authorities should create different UUIDs.   Just use externalIdentifier.
+
+Nicole: UUID come from tools doing documentation.   Can't be used the same way as SPDX ids.
+
+Gary: We are putting requirement that it's uniques.
+
+Max - name is still a problem,  like to avoid UUID - compatibility with one practice or tool.    Not globally unique, but rather namespace unique.   Not sure about domain knowledge though,  best practice?
+
+Since range is external identifier, it solves it for Gary about the UUID preconceived
+
+### Summary:
+Universally Unique - leave to domain experts;  agree not general UUID at this point.
+
+Terminology - worry about UUID - has too specific a format.   Microsoft used GUID with implied format.   Hardware chips have globally unique IDs per Greg.
+
+UIID - Unique Immutable Identifier?   Was suggested.   Nicole recommends adapting the name, and be more specific in the description.
+
+May want to reevaluate if distinction is really useful,  may want to keep specific, but may be possible to unify.
+
+Decision to come up with a  new name, and then come back to the group for further discussion and to crisp up.
+
+### Generalize *Version
+https://github.com/spdx/spdx-3-model/issues/1225
+
+Are we going to enforce SEMVER?   No.
+
+What does version actually mean, other that's it's different.
+
+What follows another thing gets complicated.
+
+Moving field from one profile to another should be considered as breaking change (goes to 4.0)
+
+Semantially different should be considered.  Process Version vs. Spec Version, is useful.
+
+Comments are intended for human readable whereas other fields are intended to be machine readable
+
+Properties that are machine readable need to be defined (format, only one way to be decoded)
+
+### Other Open topics
+How to handle symlinks in SPDX documents?  
+https://github.com/spdx/spdx-spec/issues/610 → next week
+
+## Next meeting
+
+- Generalize *UUID - KEEP 3.1 otherwise will become breaking change.  
+  https://github.com/spdx/spdx-3-model/issues/1222
+- Element inlining rules / CreationInfo exception in JSON-LD serialization  - KEEP 3.1 https://github.com/spdx/spdx-3-model/issues/1104
+
+## Backlog
+See backlog at “Backlog” tab https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on April 14, 2026, including attendees, discussions, and decisions made.