### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-04-21

### DIFF
--- a/tech/2026/2026-04-21.md
+++ b/tech/2026/2026-04-21.md
@@ -1,0 +1,108 @@
+# SPDX Tech Team Meeting 2026-04-21
+
+## Attendees
+
+- Alexios Zavras
+- Alfred Strauch
+- Amaury Chamayou
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Greg Shue
+- Induwara Gunasena
+- Joshua Watt
+- Karen Bennet
+- Karsten Klein
+- Kate Stewart
+- Marc-Etienne Vargenau
+- Maximilian Huber
+- Nicole Bates
+- Nicole Pappler
+- Peter Monks
+- Steven Carbno
+- Ted Gauthier
+- Victor Lu
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements & New participants
+- CBOR & SPDX - Guest speaker (Amaury & Nicole)
+- From 2026-04-07 meeting:
+  - Roles https://github.com/spdx/spdx-3-model/pull/1221/changes
+- From 2026-04-14 meeting:
+  - How to handle symlinks in SPDX documents? 
+    https://github.com/spdx/spdx-spec/issues/610
+  - Generalize *UUID - KEEP 3.1 otherwise will become breaking change.
+    https://github.com/spdx/spdx-3-model/issues/1222
+  - Element inlining rules / CreationInfo exception in JSON-LD serialization  - KEEP 3.1 https://github.com/spdx/spdx-3-model/issues/1104
+- Spec tooling (if Alexios, Gary, Art)
+- Relationships
+- RUNTIME_ENVIRONMENT_OF https://github.com/spdx/spdx-spec/issues/728 (if Joshua)
+- Revisit SPDX RDF URI versioning
+  - https://github.com/spdx/spdx-spec/issues/1378
+  - https://github.com/spdx/spdx-3-model/issues/1146
+- Update profile maintainers list https://github.com/spdx/spdx-3-model/issues/1244
+- Add a paragraph about file naming
+  - https://github.com/spdx/spdx-spec/pull/1383
+- Decide if finish for 3.1 or push to 3.2 or close
+- Generalize *Version
+  - https://github.com/spdx/spdx-3-model/issues/1225
+- Support attestations as artifacts in SPDX 3.1
+  - https://github.com/spdx/spdx-3-model/issues/594
+- ExternalRefType: Revise entry descriptions to support beyond (software) "package" ? 
+  - https://github.com/spdx/spdx-3-model/issues/1231 
+- How to count the number of licensing profiles? 
+  - https://github.com/spdx/spdx-3-model/issues/1238
+- Create SpdxId type for spdxId property https://github.com/spdx/spdx-3-model/pull/407 
+- Acknowledge SPDX tag and license expression usage in REUSE
+  - https://github.com/spdx/spdx-spec/issues/502
+- Merge serialization information from spdx-3-model https://github.com/spdx/spdx-spec/pull/1381 
+- Add Greg, Karsten, Ummo names to Acknowledgments
+  - https://github.com/spdx/spdx-spec/pull/1357
+- Update SPDX License List refs to v3.28.0
+  - https://github.com/spdx/spdx-spec/pull/1361
+
+## Notes
+
+- Minutes approved
+- Introduction of Nicole & Amaury background
+- CBOR & SPDX presentation by Nicole & Amaury - [Slides](Deterministic CBOR encoding for SPDX 3+.pdf)
+- Motivation: JSON-LD encoded SPDX is very large and not necessarily reproducible. Canonicalization procedure exists but not complete
+- CBOR https://datatracker.ietf.org/doc/rfc8949/ 
+- Compaction, shorter IDs
+- Compaction ratio between 2x-6x depending on structure/repetitions
+- 2x-3x worse than LZMA compression but can do random access
+- Question on (human-)readability. CBOR is binary format, so it is not designed in the first place for that. But there’s a tool to help with that.
+- Peter: Readability is a requirement. SPDX 2 is human readable. SPDX 3 may reduce human readability because of its size and complexity.
+- Gary: What we are discussing here is if we are open to multiple serialization formats.
+- Max: Why are we thinking about random access? We are defining a transport format and not the internal data representation of tools?
+- Need to work with signed artifacts;  and then let them access.   Signature needs to match and be able to extract at runtime to match.   Payload and signature, don't need to re-encode.   CBOR encoded file is what is signed in their scenario.   Key is smaller and takes less memory.  Canonical is interesting for separate reasons.
+- random access is not sufficient without a full graph understanding; Jason sees some benefit once the document is indexed.   Parsing a subset of json document isn't common. 
+- Peter: Is disk based access not possible with a combination of non-SPDX in-memory lookup tables (presumably using byte offsets), and mmap?
+- Deterministic encoding:  some ambiguities that have been resolved, provides reproducibility.
+- We have canonical representation in JSON;  
+- Max: how does CBOR understand which lists are sorted and which are unsorted? Is that defined on a schema level?  List of dependencies are also unsorted?
+- CBOR arrays don't have a notion of being sorted or not.   Serialized has order.
+- How to canonically represent unsorted lists?  Will need to add additional rules for canonicalization on top of CBOR?   RFC8949 should have most of it.  
+- The schema is complete. SPDX 3.0.1 is mapped to CDDL (a schema language for CBOR https://cborbook.com/part_1/cbor_schemas_with_cddl.html 
+- the external references have hashes and verification codes
+- https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/ExternalMap/ (verifiedUsing)
+- Joshua recommends generating from SHACL model, rather than JSON LD.   Using this will avoid reparsing issues.  (see: https://github.com/JPEWdev/shacl2code )
+- Alexios points out Joshua has a large set of files, to help with biasing the encoding. 
+- Elements should be lowest number (it's part of everything) - currently done with Python scripts. 
+- Note: it's not robust currently against schema changes. 
+- Discussion that it's more for random access;  not much advantage over JSON for streaming.   Model and serializations chapter of the spec https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md 
+- Next steps:  
+  - Implementers call to discuss next steps, and bring up in whether serialization meetings should start up again.     (Alexios & Joshua interested)
+  - Create markdown in spdx-spec, that would include information on the CBOR.   
+  - Set of rules to do this reliably would need to be encoded.   
+  - Per Alexios - We will also need to encode the binary representation in the model. 
+  - CDDL spec has some this.  May need to consider importing.
+- Relevant to the questions of the versioned IRI
+- Next week:   URI's for version next week. 
+
+## Next meeting
+
+## Backlog
+See backlog at “Backlog” tab https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y 


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on April 21, 2026, including attendees, discussion points, and next steps.