### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-05-05

### DIFF
--- a/tech/2026/2026-05-05.md
+++ b/tech/2026/2026-05-05.md
@@ -1,0 +1,137 @@
+# SPDX Tech Team Meeting 2026-05-05
+
+## Attendees
+
+- Alfred Strauch
+- Arthit Suriyawongkul
+- Bob Martin
+- Greg Shue
+- Induwara Gunasena (GSoC 2026)
+- Joshua Watt
+- Karsten Klein
+- Kate Stewart
+- Marc-Etienne Vargenau
+- Maximilian Huber
+- Nicole Pappler
+- Steven Carbno
+- Ted Gauthier
+- Victor Lu
+
+## Regrets
+
+- Alexios Zavras
+- Gary O'Neall
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements & New participants
+- Examples (PRs in spdx-examples repo) (if Art)
+  - build profile example-1
+  - https://github.com/spdx/spdx-examples/pull/90
+  - Lite profile examples
+  - https://github.com/spdx/spdx-examples/pull/91
+  - Add Example 01 diagram
+  - https://github.com/spdx/spdx-examples/pull/135
+  - Dataset example 2 - Image dataset
+  - https://github.com/spdx/spdx-examples/pull/139
+  - Conformance example1 prelim stakeholder reqs
+  - https://github.com/spdx/spdx-examples/pull/146
+- Relationship Cleanup
+  - RUNTIME_ENVIRONMENT_OF https://github.com/spdx/spdx-spec/issues/728
+  - Can hasHost Relationship link to Build https://github.com/spdx/spdx-3-model/issues/915
+
+## Notes
+
+### hasHost Relationship
+
+- see discussion summary at https://github.com/spdx/spdx-3-model/issues/915#issuecomment-4381026411
+- Ambiguous with runsOn
+
+### Examples
+
+#### build profile example-1
+
+- https://github.com/spdx/spdx-examples/pull/90
+- Agree should be merged after updating to 3.0.1
+- May need to double check date format?   See buildtime.
+
+#### Lite profile examples
+
+- https://github.com/spdx/spdx-examples/pull/91
+- Need to rerun it's still valid.
+- Well written example.   Joshua & Bob reviewing.
+
+#### Add Example 01 diagram
+
+- https://github.com/spdx/spdx-examples/pull/135
+- Art added diagram.
+- JSON file is quite huge.
+- Request Steven take a look at it.   Will also ask for reviewer
+
+#### Dataset example 2 - Image dataset
+
+- https://github.com/spdx/spdx-examples/pull/139
+- Non AI data set.
+- Kate to take
+
+#### Conformance example1 prelim stakeholder reqs
+
+- https://github.com/spdx/spdx-examples/pull/146
+- Not going to master at this point.
+- Introduces a collection of requirement stakeholders from CRA.
+- None are in SPDX format at this point,  need to get SPDX expression version, currently Strictdoc format.    Kate to take a pass.
+- Need to stay as draft until strictdoc/spdx interaction worked out.
+- Stakeholders need roles sorted to be progressed.
+- Greg worked through the example with the Strictdoc for SEBOK;  focus on stakeholder needs.    Goal is to express in SPDX for exchanging it.
+- In CRA it starts to come together.    Need to be able to express a Risk assessment;  being discussed in Threats and Controls group.
+- So far, not much security engagement on Threat's and Controls
+- First example will be a USB Dongle
+- Strictdoc is fully linked within itself.   Can SPDX express all the same relationships, and not loose any fidelity, as well being able to roundtrip.
+- This is a validation check to make sure that the SPDX specification is suitable.
+- Victor suggests reaching out to https://openssf.org/projects/oss-crs/ to see if we can pull in their expertise, and the bugs identified are real.    Greg & Victor to see if useful.
+- For all that want to learn more about StrictDoc: https://strictdoc.readthedocs.io/en/stable/
+- Another project from OpenSSF that may related https://openssf.org/projects/gemara/ It uses CUE as a language to express policies https://gemara.openssf.org/schema/
+- Discussion about terminology.   Held in reset vs. held in reset state.    What are assumptions we're making about foundational context.   Audience will tool writers to support that area.   Won't be a hardware engineer,  will be someone running tools to do asset management.
+
+## Next meeting
+
+- From 2026-04-28 meeting:
+  - Continue revisit SPDX RDF URI versioning
+  - Summary https://github.com/spdx/spdx-spec/issues/1378#issuecomment-4337437107
+  - https://github.com/spdx/spdx-spec/issues/1378
+  - https://github.com/spdx/spdx-3-model/issues/1146
+- From 2026-04-07 meeting:
+  - Roles https://github.com/spdx/spdx-3-model/pull/1221/changes
+- From 2026-04-14 meeting:
+  - How to handle symlinks in SPDX documents?
+  - https://github.com/spdx/spdx-spec/issues/610
+  - Generalize *UUID - KEEP 3.1 otherwise will become breaking change.
+  - https://github.com/spdx/spdx-3-model/issues/1222
+  - Element inlining rules / CreationInfo exception in JSON-LD serialization  - KEEP 3.1 https://github.com/spdx/spdx-3-model/issues/1104
+- Spec tooling (if Alexios, Gary, Art)
+  - Merge serialization information from spdx-3-model
+  - https://github.com/spdx/spdx-spec/pull/1381
+  - Decide if finish for 3.1 or push to 3.2 or close
+  - Generalize *Version
+  - https://github.com/spdx/spdx-3-model/issues/1225
+  - Support attestations as artifacts in SPDX 3.1
+  - https://github.com/spdx/spdx-3-model/issues/594
+  - ExternalRefType: Revise entry descriptions to support beyond (software) "package" ?
+  - https://github.com/spdx/spdx-3-model/issues/1231
+  - Move downloadLocation from Software/Package to Software/SoftwareArtifact to use it also in Software/File
+  - https://github.com/spdx/spdx-3-model/issues/1032
+  - How to count the number of licensing profiles?
+  - https://github.com/spdx/spdx-3-model/issues/1238
+  - Create SpdxId type for spdxId property
+  - https://github.com/spdx/spdx-3-model/pull/407
+  - Acknowledge SPDX tag and license expression usage in REUSE
+  - https://github.com/spdx/spdx-spec/issues/502
+- Admin
+  - Update profile maintainers list
+  - https://github.com/spdx/spdx-3-model/issues/1244
+- Examples
+  - Update SPDX License List refs to v3.28.0
+  - https://github.com/spdx/spdx-spec/pull/1361
+- Backlog
+  - See backlog at “Backlog” tab https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Documented the minutes of the SPDX Tech Team meeting held on May 5, 2026, including attendees, regrets, agenda items, notes, and next meeting details.