### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-05-12

### DIFF
--- a/tech/2026/2026-05-12.md
+++ b/tech/2026/2026-05-12.md
@@ -1,0 +1,101 @@
+# SPDX Tech Team Meeting 2026-05-12
+
+## Attendees
+
+- Alexios Zavras
+- Alfred Strauch
+- Arthit Suriyawongkul
+- Bob Martin
+- Gary O'Neall
+- Joshua Watt
+- Karsten Klein
+- Kate Stewart
+- Marc-Etienne Vargenau
+- Peter Monks
+- Steven Carbno
+- Ted Gauthier
+- Victor Lu
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements & New participants
+- Tooling Available to Support CVE/OSV/… with SPDX 3.0
+- Relationship Cleanup : Can hasHost Relationship link to Build https://github.com/spdx/spdx-3-model/issues/915 
+- Topics based on participants: 
+- From 2026-04-28 meeting:
+- Continue revisit SPDX RDF URI versioning
+- Summary https://github.com/spdx/spdx-spec/issues/1378#issuecomment-4337437107 
+- https://github.com/spdx/spdx-spec/issues/1378
+- https://github.com/spdx/spdx-3-model/issues/1146
+- From 2026-04-07 meeting:
+- Roles https://github.com/spdx/spdx-3-model/pull/1221/changes
+- From 2026-04-14 meeting:
+- How to handle symlinks in SPDX documents? 
+- https://github.com/spdx/spdx-spec/issues/610
+- Generalize *UUID - KEEP 3.1 otherwise will become breaking change.
+- https://github.com/spdx/spdx-3-model/issues/1222
+- Naming of “UUID”
+- Element inlining rules / CreationInfo exception in JSON-LD serialization  - KEEP 3.1 https://github.com/spdx/spdx-3-model/issues/1104
+- Spec tooling (if Alexios, Gary, Art)
+- Merge serialization information from spdx-3-model
+- https://github.com/spdx/spdx-spec/pull/1381
+- Decide if finish for 3.1 or push to 3.2 or close
+- Generalize *Version
+- https://github.com/spdx/spdx-3-model/issues/1225
+- PR: https://github.com/spdx/spdx-3-model/pull/1265 
+- Support attestations as artifacts in SPDX 3.1
+- https://github.com/spdx/spdx-3-model/issues/594
+- ExternalRefType: Revise entry descriptions to support beyond (software) "package" ?
+- https://github.com/spdx/spdx-3-model/issues/1231
+- Move downloadLocation from Software/Package to Software/SoftwareArtifact to use it also in Software/File
+- https://github.com/spdx/spdx-3-model/issues/1032
+- How to count the number of licensing profiles?
+- https://github.com/spdx/spdx-3-model/issues/1238
+- Create SpdxId type for spdxId property
+- https://github.com/spdx/spdx-3-model/pull/407 
+- Acknowledge SPDX tag and license expression usage in REUSE
+- https://github.com/spdx/spdx-spec/issues/502
+- Move additionalInformation to Element
+- https://github.com/spdx/spdx-3-model/pull/1267 
+- Add non-byte size for software artifact https://github.com/spdx/spdx-3-model/issues/1258 
+- PR: https://github.com/spdx/spdx-3-model/pull/1259 
+- Admin
+- Update profile maintainers list
+- https://github.com/spdx/spdx-3-model/issues/1244
+- Examples
+- Update SPDX License List refs to v3.28.0
+- https://github.com/spdx/spdx-spec/pull/1361
+- Regrets for next week from Kate, Joshua (at OSS NA) & Bob (at MITRE event)
+
+## Notes
+
+- Last week’s minutes approved
+- Tools to support CVE/OSV to SPDXv3
+- Gary has template tool that can be updated to SPDX 3.0
+- SPDX 3.0 to dependency-track;  Java skills welcome << HELP NEEDED
+- Viktor Peterson's SBOMify tool - SPDXv3
+- bootlin/sbom-cve-check
+- OpenSSF AIBOM - openVex meeting;  Adolfo participating - follow 
+- Keeping runsOn & hasHost relationships.
+- Relationship Cleanup : Can hasHost Relationship link to Build https://github.com/spdx/spdx-3-model/issues/915    Concensus is to keep both.  Issue closed.
+- Continue revisit SPDX RDF URI versioning
+- 3.0 - verify what getting is ISO approved.   Dropping patch suffix per their request.
+- Spec version in the element is what is used 
+- https://github.com/spdx/spdx-3-model/issues/1146
+- Alias ISO version to 3.0
+- SHACL schema & context files for each released minor version of the specification.
+- Change SHACL to used closed set for vocabularies, rather than open now. 
+- If we have opportunity to change the 3.0 Spec from ISO, we'll change it to be 3.0 rather than having the patch release. (Re: ISO comment on removing patch version — it is documented here https://github.com/spdx/spdx-3-model/issues/1046) 
+- Mixing elements in a document:  always validate against latest, and able to include earlier as long as validate.   Only restricting to ISO version, may impact license list version recognition.    See comments in https://github.com/spdx/spdx-spec/issues/1378
+- Roles
+- Put example in prototype repo;  then move to examples after agreed for definition of role. 
+- Need to adjust so that the relationship should read as a sentence, and redo verb accordingly.   Alexios & Jacob explains that a different is verb is needed.    HasRoleIn - was suggested as better relationship.   Direction is reasonable.   See examples from Security on how it was done.   During a role relationship period and be explicit it should be a roleRelationshipType.  
+- Art to do rereview of https://github.com/spdx/spdx-3-model/pull/1221/changes  will make comments in PR. 
+- Alexios notes assigned by should be clarified.
+
+## Next meeting
+
+## Backlog
+
+- See backlog at “Backlog” tab https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on May 12, 2026, including attendees, discussions, and next steps.