### PR TITLE
Add minutes for SPDX Hardware Team meeting on 2026-05-15

### DIFF
--- a/hardware/2026/2026-05-15.md
+++ b/hardware/2026/2026-05-15.md
@@ -1,0 +1,85 @@
+# SPDX Hardware Team Meeting 2026-05-15
+PR: 
+##Attendees
+[ X] Alfred Strauch
+[ X] Steven Carbno
+[ X] Bob Martin (MITRE)
+[ ] Dishoung White II
+[ ] Kate Stewart
+[ ] Victor Lu
+[ X] Jim Vitrano 
+[ ] Amit Kumar
+[ X] Issac Asay
+[ ] Lucas Tate
+[ ] Apoorav Trehan 
+[ ] Alex Volykin
+[ X] Allan Friedman
+[ ] Cassie Crossley 
+[ X] Felix Reichmanna                                
+
+[ X] Greg Shue 
+[ ] Riley Barello-Myers 
+[ ] Henk Berkholz
+[ ] Dan Hopkins
+[ ] Courtney Ng
+[ ] Andrew Viater 
+[ ] Raymond Sheh 
+[ ] Stanislav Pankevich
+[ ] Karen Bennet
+[ X] Marcel Kurzamann
+[ ] Raymond Sheh
+[ ] Michael Pease (NIST Standards)
+[ ] Jenn Power (Red Hat) 
+[ ] Arthit Suriyawongkul
+
+
+
+
+# Agenda 
+* Approve previous minutes - ok 
+* Review PRs - PRs for review  - Waiting for tech Team approval - https://github.com/spdx/spdx-3-model/pull/1221 
+Conformance example1 prelim stakeholders and personas by Gregshue · Needs 2nd approval https://github.com/spdx/spdx-examples/pull/146
+* canProvide (isQualifiedFor) as a relationship may be needed - agent role would be used for AI, hardware. - agreed these are different relationships
+* Brian Knight's feedback - 
+https://docs.google.com/document/d/1hnzfgeocTkDv5D2MYKJ8Kn2OqKUyrzQKAo1VjcY0WY8/edit?usp=sharing 
+* Continuing discussion related to hardware (USB) and supply chain with system engineering elements.
+
+## Notes
+* Minutes approved
+* Conformance discussion related to stakeholders' needs. Wants PR reviewed.
+Presented the issue related to the scope of the product and the nature of product enhancements for a product in the future. 
+* Analyze risk according to the consumer
+* Stakeholder requirements - change based on changing requirements
+* examples need to be created
+* Merge of conformance PR was approved in the meeting - post conversation.
+* Several other relationships with different elements will need to be covered
+*  canProvide vs isQualifiedFor 
+* isQualified is an external evaluation 
+Present Definition: Agent is qualified for or can provide the `to` Role.
+New definition: Agent is qualified to provide the `to` Role.
+
+* canProvide is a claim against an item
+New definition: An agent can provide the `to` Role.
+* Brian Knight discussion:
+* DICE discussion - for “root of trust.”
+* representation of items as bundles
+* What is a root of trust: standard as a certificate  https://trustedcomputinggroup.org/resource/tcg-platform-certificate-profile/ 
+* device identity attestation needs to be stored for immutable attestation
+* Device identity and root of trust attestations are both important
+* Reviewed the new security work being completed in the security profile related to certificates.
+* The root of trust would include a duplication of HW certificate.
+	* Source element needs to be defined.
+* Can SPDX elements be freely associated? What is the standardized process?
+* Do you need to decompose DMTF blob? Use an annotation to reference an external file.
+* Assessed elements - can define CVE per-name - may need to include subset artifact (assessedElement). The element may be an HW component.
+
+* Bob presented images related to the supply chain used in a draft paper being created.
+	* Discussion illustrated how HW SCs can be represented in SPDX.
+* No serial numbers included because this detail was not needed in this illustration related to DPP
+
+## Action Items
+* Model out the certificate/root of trust annotations
+* Create PR issue related to assessedElement name and the use related to HW
+
+## Decision Item
+* 


### PR DESCRIPTION
Documented the minutes and discussions from the SPDX Hardware Team meeting held on May 15, 2026, including attendees, agenda items, notes, action items, and decisions made.