### PR TITLE
Add meeting notes for SPDX Tech Team on 2026-05-19

### DIFF
--- a/tech/2026/2026-05-19.md
+++ b/tech/2026/2026-05-19.md
@@ -1,0 +1,100 @@
+# SPDX Tech Team Meeting 2026-05-19
+
+## Attendees
+
+- Alexios Zavras
+- Alfred Strauch
+- Arthit Suriyawongkul
+- Gary O'Neall
+- Greg Shue
+- Karsten Klein
+- Marc-Etienne Vargenau
+- Maximilian Huber
+- Nicole Pappler
+- Steven Carbno
+
+Regrets: Kate (at OSS NA), Joshua (at OSS NA), Bob (at MITRE event)
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements & New participants
+- Admin
+- Update profile maintainers list
+- https://github.com/spdx/spdx-3-model/issues/1244
+- Add meeting links in spdx/meeting repo
+- Serialisation https://github.com/spdx/meetings/issues/1105 
+- Tech Asia https://github.com/spdx/meetings/issues/1106 
+- Topics based on participants: 
+- From 2026-04-28 meeting:
+- Continue revisit SPDX RDF URI versioning
+- Summary https://github.com/spdx/spdx-spec/issues/1378#issuecomment-4337437107 
+- https://github.com/spdx/spdx-spec/issues/1378
+- https://github.com/spdx/spdx-3-model/issues/1146
+- From 2026-04-07 meeting:
+- Roles https://github.com/spdx/spdx-3-model/pull/1221/changes
+- From 2026-04-14 meeting:
+- How to handle symlinks in SPDX documents? 
+- https://github.com/spdx/spdx-spec/issues/610
+- Generalize *UUID - KEEP 3.1 otherwise will become breaking change.
+- https://github.com/spdx/spdx-3-model/issues/1222
+- Naming of “UUID”
+- Element inlining rules / CreationInfo exception in JSON-LD serialization  - KEEP 3.1 https://github.com/spdx/spdx-3-model/issues/1104
+- PR: Merge serialization information from spdx-3-model
+- https://github.com/spdx/spdx-spec/pull/1381
+- Spec tooling (if Alexios, Gary, Art)
+- Decide if finish for 3.1 or push to 3.2 or close
+- Generalize *Version
+- https://github.com/spdx/spdx-3-model/issues/1225
+- PR: https://github.com/spdx/spdx-3-model/pull/1265 
+- Support attestations as artifacts in SPDX 3.1
+- https://github.com/spdx/spdx-3-model/issues/594
+- ExternalRefType: Revise entry descriptions to support beyond (software) "package" ?
+- https://github.com/spdx/spdx-3-model/issues/1231
+- Move downloadLocation from Software/Package to Software/SoftwareArtifact to use it also in Software/File
+- https://github.com/spdx/spdx-3-model/issues/1032
+- How to count the number of licensing profiles?
+- https://github.com/spdx/spdx-3-model/issues/1238
+- Create SpdxId type for spdxId property
+- https://github.com/spdx/spdx-3-model/pull/407 
+- Acknowledge SPDX tag and license expression usage in REUSE
+- https://github.com/spdx/spdx-spec/issues/502
+- Move additionalInformation to Element
+- https://github.com/spdx/spdx-3-model/pull/1267 
+- Add non-byte size for software artifact https://github.com/spdx/spdx-3-model/issues/1258 
+- PR: https://github.com/spdx/spdx-3-model/pull/1259
+- 3.1 review
+- Rename ContactPointRelationshipType -> ContactType https://github.com/spdx/spdx-3-model/pull/1271 
+- Make "createdBy" description more direct https://github.com/spdx/spdx-3-model/pull/1273 
+- Clarify relationship class constraints in rel type https://github.com/spdx/spdx-3-model/pull/1275 
+- Examples
+
+## Notes
+
+- Reminder - serialization team is starting up this Thursday same time as the tech call - need to put it in the calendar
+- Maintainers list #1244: Already merged
+- Add meeting links in spdx/meeting repo - Alexios is adding the serialization calls
+- URI changes - Gary will create a PR
+- When publishing a release, we will publish schemas, context files, and associated files for each minor release
+- We can take this off future agendas as it will be resolved with the PR
+- Roles: 
+- Waiting for Kate’s review
+- Nicole will contribute and example - the example will work with the proposed definitions
+- Symbolic links:
+- PR https://github.com/spdx/spdx-3-model/pull/1254 
+- Discussed clarifying that the symlink doesn’t represent the properties of the file or directory being referenced
+- Added the clarification to the PR
+- A using document describing best practices for the symlinks would be useful - looking for volunteers
+- Generalized UUID: 
+- Discussed on the safety profile - decided the “UID” was as fitting as “UUID”
+- Rename “evidenceUUID” to “evidenceUID”, “requirementUUID” to “requirementUID”, “verificationUUID” to “verificationUID”.
+- The safety profile team decided to keep all 3 terms.
+- Element inlining rules:
+- https://github.com/spdx/spdx-3-model/issues/1104
+- Reviewed and updated spec PR #1381
+
+## Next meeting
+
+## Backlog
+
+See backlog at “Backlog” tab https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Documented the attendees, agenda, notes, and backlog for the SPDX Tech Team meeting held on May 19, 2026.