### PR TITLE
Add meeting notes for SPDX Hardware Team on 2026-05-22

### DIFF
--- a/hardware/2026/2026-05-22.md
+++ b/hardware/2026/2026-05-22.md
@@ -1,0 +1,71 @@
+# SPDX Hardware Team Meeting 2026-05-22
+
+## Attendees
+
+- [X] Alfred Strauch
+- [X] Steven Carbno
+- [X] Bob Martin (MITRE)
+- [ ] Dishoung White II
+- [ ] Kate Stewart
+- [X] Victor Lu
+- [ ] Jim Vitrano
+- [ ] Amit Kumar
+- [ ] Issac Asay
+- [ ] Lucas Tate
+- [ ] Apoorav Trehan
+- [ ] Alex Volykin
+- [X] Allan Friedman
+- [ ] Cassie Crossley
+- [ ] Felix Reichmanna
+- [X] Makki Elfatih
+- [X] Greg Shue
+- [ ] Riley Barello-Myers
+- [ ] Henk Berkholz
+- [ ] Dan Hopkins
+- [ ] Courtney Ng
+- [ ] Andrew Viater
+- [ ] Raymond Sheh
+- [ ] Stanislav Pankevich
+- [ ] Karen Bennet
+- [ ] Marcel Kurzamann
+- [ ] Raymond Sheh
+- [ ] Michael Pease (NIST Standards)
+- [ ] Jenn Power (Red Hat)
+- [ ] Arthit Suriyawongkul
+
+## Agenda
+
+- Approve previous minutes - https://github.com/spdx/meetings/pull/1107
+- Version Issue - https://github.com/spdx/spdx-3-model/pull/1265 Use generic version property in `/Core/DefinedProcess`, `/Hardware/Hardware`, `/Hardware/ProductSpecification`, `/Software/Package`
+- Review PRs - PRs for review - Waiting for Tech Team approval - https://github.com/spdx/spdx-3-model/pull/1221
+- Conformance example1 prelim soi sample stubs stk usrs prd mgr by Gregshue - Needs approval - https://github.com/spdx/spdx-examples/pull/151/changes
+- Brian Knight's feedback - Continue at Operational Design Domain Declaration - https://docs.google.com/document/d/1hnzfgeocTkDv5D2MYKJ8Kn2OqKUyrzQKAo1VjcY0WY8/edit?usp=sharing
+- Continuing discussion related to hardware (USB) and supply chain with system engineering elements.
+
+## Notes
+
+- Minutes approved.
+- Conversation related to the present and future definition and use of BOMs.
+- Discussed characteristics of SPDX and CDX.
+- Relationship of metadata, systems engineering, and system operations represents a future conversation.
+- Conformance PR:
+  - Needs are specific to the role or stakeholder.
+  - Needs can become a requirement.
+  - Use X has a "Need" that requires definition. Discussed engineering student example.
+  - Reviewed specific elements related to needs in PR in example repos.
+- Labeling issues arise.
+- How do you organize all the roles and responsibilities? How do you locate information?
+- Key statement: Is SPDX valid for the definition of simple and complex use cases?
+- Conformance example is the method for defining the use of SPDX, and what examples work for CRA compliance?
+- Need to refine focus on product example with specific examples - USB dongle - hardware interface connections.
+
+## Action Items
+
+- Model out the certificate/root of trust annotations.
+- Create PR issue related to assessedElement name and the use related to HW.
+- Define `canProvide` (`isQualifiedFor`) relationship after PR 1221.
+
+## Decision Items
+
+- No decision items recorded.
+```


### PR DESCRIPTION
Documented meeting notes for the SPDX Hardware Team, including attendees, agenda items, discussion points, action items, and decisions made during the meeting.