### PR TITLE
Add meeting notes for SPDX Tech Team on 2026-05-26

### DIFF
--- a/tech/2026/2026-05-26.md
+++ b/tech/2026/2026-05-26.md
@@ -1,0 +1,97 @@
+# SPDX Tech Team Meeting 2026-05-26
+
+## Attendees
+
+- Alfred Strauch
+- Arthit Suriyawongkul
+- Bob Martin
+- Greg Shue
+- Joshua Watt
+- Marc-Etienne Vargenau
+- Maximilian Huber
+- Nicole Pappler
+- Steven Carbno
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements & New participants
+- Admin
+  - Add meeting links in spdx/meeting repo
+  - Serialisation: https://github.com/spdx/meetings/issues/1105
+  - Tech Asia: https://github.com/spdx/meetings/issues/1106
+
+### Follow-up from Last Meeting
+
+- PR: Merge serialization information from spdx-3-model  
+  https://github.com/spdx/spdx-spec/pull/1381
+- PR: Remove serialization information redundant with spdx-spec repo  
+  https://github.com/spdx/spdx-3-model/pull/1250
+- PR: Keep distinct ID properties but use "UID" instead of "UUID"  
+  https://github.com/spdx/spdx-3-model/pull/1276
+
+### Topics Based on Participants
+
+- Spec tooling (if Alexios, Gary, Art)
+- Decide if finish for 3.1 or push to 3.2 or close
+- Simplified SPDX 3.1 serialization  
+  https://github.com/spdx/spdx-3-model/issues/396
+- Support attestations as artifacts in SPDX 3.1  
+  https://github.com/spdx/spdx-3-model/issues/594
+- Move downloadLocation from Software/Package to Software/SoftwareArtifact to use it also in Software/File  
+  https://github.com/spdx/spdx-3-model/issues/1032
+- How to count the number of licensing profiles?  
+  https://github.com/spdx/spdx-3-model/issues/1238
+- Add non-byte size for software artifact  
+  https://github.com/spdx/spdx-3-model/issues/1258
+- PR: https://github.com/spdx/spdx-3-model/pull/1259
+- Create SpdxId type for spdxId property  
+  https://github.com/spdx/spdx-3-model/pull/407
+- Document in the spdx/using repo describing the details of handling symlinks  
+  https://github.com/spdx/spdx-spec/issues/610#issuecomment-4489904278
+- Multiplicity of extensions of the same type  
+  https://github.com/spdx/spdx-3-model/issues/1204
+- Data structure (list, bag, set, ordered set)
+- Canonicalization: container types  
+  https://github.com/spdx/spdx-3-model/issues/89
+- Add default container properties  
+  https://github.com/spdx/spdx-3-model/pull/402
+- Merge CdxPropertyEntry and DictionaryEntry  
+  https://github.com/spdx/spdx-3-model/issues/1168
+
+### 3.1 Review
+
+- Roles  
+  https://github.com/spdx/spdx-3-model/pull/1221/changes
+  - Kate to review
+- Rename ContactPointRelationshipType -> ContactType  
+  https://github.com/spdx/spdx-3-model/pull/1271
+- Generalize *Version  
+  https://github.com/spdx/spdx-3-model/pull/1265
+- Move additionalInformation to Element  
+  https://github.com/spdx/spdx-3-model/pull/1267
+- ExternalRefType: Revise entry descriptions to support beyond (software) "package"?  
+  https://github.com/spdx/spdx-3-model/issues/1231
+- Diff between createdBy property (3.0) and "createdBy" relationship type (3.1)  
+  https://github.com/spdx/spdx-3-model/issues/1274
+
+### File Tags
+
+- Reuse style file tags and how to support them with SPDX 3.0  
+  https://github.com/spdx/using/issues/12
+- Acknowledge SPDX tag and license expression usage in REUSE  
+  https://github.com/spdx/spdx-spec/issues/502
+- Status of "SPDX File Tags"  
+  https://github.com/spdx/spdx-spec/issues/1393
+
+### Examples
+
+## Notes
+
+- Approve the last week minutes.
+
+## Next Meeting
+
+## Backlog
+
+See backlog at "Backlog" tab: https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Documented the agenda, attendees, and topics for the SPDX Tech Team meeting on May 26, 2026.