### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-06-02

### DIFF
--- a/tech/2026/2026-06-02.md
+++ b/tech/2026/2026-06-02.md
@@ -1,0 +1,238 @@
+# SPDX Tech Team Meeting 2026-06-02
+
+## Attendees
+
+- Alfred Strauch
+- Arthit Suriyawongkul
+- Gary O’Neall
+- Greg Shue
+- Kate Stewart
+- Marc-Etienne Vargenau
+- Steven Carbno
+- Victor Lu
+
+## Agenda
+
+- Approval of last week's minutes
+- Announcements and new participants
+
+### Admin
+
+- Add meeting links in the `spdx/meeting` repo
+  - [still outstanding] Serialisation: https://github.com/spdx/meetings/issues/1105
+  - PR: https://github.com/spdx/meetings/pull/1111
+  - [still outstanding] Tech Asia: https://github.com/spdx/meetings/issues/1106
+  - [resolved] Google Calendar SPDX Security Call link is out of date. Who needs to update Google Calendar?
+
+### Follow-up from Last Meeting
+
+- [still outstanding] PR: Merge serialization information from `spdx-3-model`
+  - https://github.com/spdx/spdx-spec/pull/1381
+- PR: Remove serialization information redundant with `spdx-spec` repo
+  - https://github.com/spdx/spdx-3-model/pull/1250
+- [still outstanding] Support attestations as artifacts in SPDX 3.1. Confirm with Kate if the in-toto solution is sufficient.
+  - https://github.com/spdx/spdx-3-model/issues/594
+- [still outstanding] Move `downloadLocation` from `Software/Package` to `Software/SoftwareArtifact` to use it also in `Software/File`. Waiting for PR.
+  - https://github.com/spdx/spdx-3-model/issues/1032
+- [still outstanding] How to count the number of licensing profiles. Add `licensing` to `ProfileIdentifierType`.
+  - https://github.com/spdx/spdx-3-model/issues/1238
+- [still outstanding] Document in the `spdx/using` repo describing the details of handling symlinks.
+  - https://github.com/spdx/spdx-spec/issues/610#issuecomment-4489904278
+- [still outstanding] Multiplicity of extensions of the same type. Add documentation.
+  - https://github.com/spdx/spdx-3-model/issues/1204
+
+### Topics Based on Participants
+
+#### Spec Tooling
+
+- Spec tooling, if Alexios, Gary, or Art are present.
+- Decide whether to finish for 3.1, push to 3.2, or close.
+
+#### Data Structure
+
+- Data structure: list, bag, set, ordered set
+- Canonicalization: container types
+  - https://github.com/spdx/spdx-3-model/issues/89
+- Add default container properties
+  - https://github.com/spdx/spdx-3-model/pull/402
+- Merge `CdxPropertyEntry` and `DictionaryEntry`
+  - https://github.com/spdx/spdx-3-model/issues/1168
+- Add non-byte size for software artifact
+  - https://github.com/spdx/spdx-3-model/issues/1258
+  - PR: https://github.com/spdx/spdx-3-model/pull/1259
+
+#### 3.1 Review
+
+- [still outstanding] Roles
+  - https://github.com/spdx/spdx-3-model/pull/1221/changes
+- [still outstanding] Rename `ContactPointRelationshipType` to `ContactType`
+  - https://github.com/spdx/spdx-3-model/pull/1271
+- [resolved] Generalize `*Version`
+  - https://github.com/spdx/spdx-3-model/pull/1265
+- [still outstanding] Move `additionalInformation` to `Element`
+  - https://github.com/spdx/spdx-3-model/pull/1267
+- [still outstanding] `ExternalRefType`: revise entry descriptions to support beyond software "package"
+  - https://github.com/spdx/spdx-3-model/issues/1231
+- [not discussed] Difference between `createdBy` property in 3.0 and `createdBy` relationship type in 3.1
+  - https://github.com/spdx/spdx-3-model/issues/1274
+- [not discussed] Update `rootElement` description to accommodate non-BOM use cases
+  - https://github.com/spdx/spdx-3-model/issues/1278
+
+#### File Tags
+
+- [not discussed] Reuse style file tags and how to support them with SPDX 3.0
+  - https://github.com/spdx/using/issues/12
+- [not discussed] Acknowledge SPDX tag and license expression usage in REUSE
+  - https://github.com/spdx/spdx-spec/issues/502
+- [not discussed] Status of "SPDX File Tags"
+  - https://github.com/spdx/spdx-spec/issues/1393
+- [not discussed] Consider refactoring schema to use `additionalProperties: false`
+  - https://github.com/JPEWdev/shacl2code/issues/60
+
+## Notes
+
+### Meeting Administration
+
+- Minutes approved.
+- ARM will be reviewing the hardware profile.
+- Microsoft will be invited to join on June 23 to provide feedback on SPDX 3.1.
+- Gopi’s AI tool was discussed. The proposal is to have him present at the general meeting this Thursday.
+- Gary and Kate are both traveling next week. They will sync with Alexios on coverage for next week and future meetings.
+
+### Target for RC2
+
+- The group discussed timing for RC2 in light of the upcoming summer holiday season.
+- RC2 is likely targeted for later this summer or fall, with release by the end of the year.
+- The hardware profile is adding features. The group discussed moving some of the features, including controls, to 3.2.
+
+### Meeting README
+
+- Meeting README PR: https://github.com/spdx/meetings/pull/1110
+- Conflict was resolved.
+- Text still needs to be updated to reflect that the meeting occurs every other week.
+
+### Google Calendar SPDX Security Call Link
+
+- The Google Calendar SPDX Security Call link is out of date.
+- Rob asked who needs to update Google Calendar.
+- Kate provided the email in chat, but it was not captured in time for the minutes.
+
+### PURL ECMA Standard Related PRs
+
+- PRs:
+  - https://github.com/spdx/spdx-3-model/pull/1279
+  - https://github.com/spdx/spdx-spec/pull/1394
+- The group is verifying that these are not breaking changes.
+- References to the W3C documents are being checked.
+- Kate will review and verify.
+
+### Attestations
+
+- Issue: https://github.com/spdx/spdx-3-model/issues/594
+- in-toto now supports SPDX 3, so SPDX should be able to reference it.
+- Reference: https://github.com/spdx/spdx-3-model/issues/594#issuecomment-4546184095
+- Jason’s input was included based on comments in the issue.
+
+### Move `downloadLocation`
+
+- Issue: https://github.com/spdx/spdx-3-model/issues/1032
+- Waiting for PR.
+- Moving `downloadLocation` to `Software/SoftwareArtifact` is not a breaking change.
+- The group considered whether it should be a subclass of artifact.
+- It should not be a subclass of artifact because that would be a breaking change.
+- `DataSet` is covered because it is a subclass of `Software/Package`.
+
+### Licensing Profile Identifier Type
+
+- Issue: https://github.com/spdx/spdx-3-model/issues/1238
+- The group ended up with three profile-indexed identifier types:
+  - `simpleLicensing`
+  - `expandedLicensing`
+  - `licensing`
+- The group agreed to add `licensing`, which maps to "license profile."
+- The existing entries should be kept, but they do not add restrictions and are no-ops from a conformance point perspective.
+- This should be revisited in 4.0.
+- License Profile has a type restriction and must have declared and concluded license.
+- Waiting for PR for 3.1-RC2.
+- Question: should this be backported to 3.0 if a revision is done?
+  - Ask Steve and Alexios.
+- Text should be added stating that the `expandedLicensing` and `simpleLicensing` enumerations should not be used because they are not related to conformance and are only namespaces.
+- A PR is needed to implement the additional identifier type and document that `expandedLicensing` and `simpleLicensing` should not be used. Prefer `licensing`.
+
+### Symlink Documentation
+
+- Issue: https://github.com/spdx/spdx-spec/issues/610#issuecomment-4489904278
+- The group is looking for a volunteer to write this documentation.
+- This can happen asynchronously from the release.
+- The root problem has been fixed.
+
+### Multiplicity of Extensions of the Same Type
+
+- Issue: https://github.com/spdx/spdx-3-model/issues/1204
+- The group is looking for a volunteer to write this documentation.
+- The group would like this to be in 3.1-RC2, but it is not a blocking change.
+
+### Roles
+
+- PR: https://github.com/spdx/spdx-3-model/pull/1221/changes
+- Kate to review.
+
+### Rename `ContactPointRelationshipType` to `ContactType`
+
+- PR: https://github.com/spdx/spdx-3-model/pull/1271
+- To be studied.
+- Renaming the type makes sense, but needs further review.
+- Kate to review.
+- If roles are approved, roles may satisfy the same use case.
+- Once roles are merged, review whether `ContactType` can be removed.
+
+### SPDX Examples Conformance PR
+
+- Question raised: Can approved PR 151, "Conformance example1 prelim soi sample stubs stk usrs prd mgr by gregshue," be merged into the `spdx-examples/conformanceexamples` branch?
+- Kate reviewed and merged.
+
+### Generalize `*Version`
+
+- PR: https://github.com/spdx/spdx-3-model/pull/1265
+- Renaming datatypes does not impact the spec.
+- These datatypes are only used internally and are not present in the generated spec.
+- Reviewed and merged.
+
+### Move `additionalInformation` to `Element`
+
+- PR: https://github.com/spdx/spdx-3-model/pull/1267
+- Detailed review needed.
+
+### `ExternalRefType`
+
+- Issue: https://github.com/spdx/spdx-3-model/issues/1231
+- The group agreed to generalize the entry description for use beyond software.
+- The group considered referencing `Artifact`.
+- A PR is needed, targeting RC2.
+
+### Relationship Type Display
+
+- Art is working on how to better display the relationship types and make them easier to navigate.
+- Demo: https://openregtech.github.io/spdx-spec/v3.1-dev/model/Core/Vocabularies/RelationshipType/
+- Comments are welcome.
+
+### Outreach Status
+
+- Greg is giving a presentation to COSAI.
+
+### CSV / VEX / Related Data
+
+- The group asked when CSV, VEX, and related data will be available.
+- Scope increased and was merged today.
+- People should be informed that this is available.
+
+## Next Meeting
+
+- The next two meetings may be cancelled, pending Alexios.
+- Gary and Kate cannot attend due to travel and vacation.
+- Kate will handle the general meeting this Thursday.
+
+## Backlog
+
+- See backlog at the "Backlog" tab:
+  - https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on June 2, 2026, including attendees, topics discussed, and follow-up actions.