### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-06-09

### DIFF
--- a/tech/2026/2026-06-09.md
+++ b/tech/2026/2026-06-09.md
@@ -1,0 +1,155 @@
+# SPDX Tech Team Meeting 2026-06-09
+
+## Attendees
+
+* Alexios Zavras
+* Alfred Strauch
+* Bob Martin
+* Greg Shue
+* Joshua Watt
+* Karen Bennet
+* Marc-Etienne Vargenau
+* Steven Carbno
+
+## Agenda
+
+* Approval of last week's minutes
+* Announcements & New participants
+* SPDX info in files
+
+### Follow-up from last meeting
+
+* [still outstanding] PR: Merge serialization information from spdx-3-model
+  [https://github.com/spdx/spdx-spec/pull/1381](https://github.com/spdx/spdx-spec/pull/1381)
+
+* PR: Remove serialization information redundant with spdx-spec repo
+  [https://github.com/spdx/spdx-3-model/pull/1250](https://github.com/spdx/spdx-3-model/pull/1250)
+
+* [still outstanding] Support attestations as artifacts in SPDX 3.1 – confirm with Kate if in-toto solution is sufficient
+  [https://github.com/spdx/spdx-3-model/issues/594](https://github.com/spdx/spdx-3-model/issues/594)
+
+* [still outstanding] Move downloadLocation from Software/Package to Software/SoftwareArtifact to use it also in Software/File – wait for PR
+  [https://github.com/spdx/spdx-3-model/issues/1032](https://github.com/spdx/spdx-3-model/issues/1032)
+
+* [still outstanding] How to count the number of licensing profiles? – add “licensing” to ProfileIdentifierType
+  [https://github.com/spdx/spdx-3-model/issues/1238](https://github.com/spdx/spdx-3-model/issues/1238)
+
+* [still outstanding] Document in the spdx/using repo describing the details of handling symlinks.
+  [https://github.com/spdx/spdx-spec/issues/610#issuecomment-4489904278](https://github.com/spdx/spdx-spec/issues/610#issuecomment-4489904278)
+
+* [still outstanding] Multiplicity of extensions of the same type – to add documentation
+  [https://github.com/spdx/spdx-3-model/issues/1204](https://github.com/spdx/spdx-3-model/issues/1204)
+
+### Topics based on participants
+
+* Spec tooling, if Alexios, Gary, Art
+* Decide if finish for 3.1 or push to 3.2 or close
+* Data structure: list, bag, set, ordered set
+* Canonicalization: container types
+  [https://github.com/spdx/spdx-3-model/issues/89](https://github.com/spdx/spdx-3-model/issues/89)
+* Add default container properties
+  [https://github.com/spdx/spdx-3-model/pull/402](https://github.com/spdx/spdx-3-model/pull/402)
+* Merge CdxPropertyEntry and DictionaryEntry
+  [https://github.com/spdx/spdx-3-model/issues/1168](https://github.com/spdx/spdx-3-model/issues/1168)
+* Add non-byte size for software artifact
+  [https://github.com/spdx/spdx-3-model/issues/1258](https://github.com/spdx/spdx-3-model/issues/1258)
+* PR: [https://github.com/spdx/spdx-3-model/pull/1259](https://github.com/spdx/spdx-3-model/pull/1259)
+
+### 3.1 review
+
+* [still outstanding] Roles
+  [https://github.com/spdx/spdx-3-model/pull/1221/changes](https://github.com/spdx/spdx-3-model/pull/1221/changes)
+
+* [still outstanding] Rename ContactPointRelationshipType -> ContactType
+  [https://github.com/spdx/spdx-3-model/pull/1271](https://github.com/spdx/spdx-3-model/pull/1271)
+
+* [still outstanding] Move additionalInformation to Element
+  [https://github.com/spdx/spdx-3-model/pull/1267](https://github.com/spdx/spdx-3-model/pull/1267)
+
+* [still outstanding] ExternalRefType: Revise entry descriptions to support beyond software "package"?
+  [https://github.com/spdx/spdx-3-model/issues/1231](https://github.com/spdx/spdx-3-model/issues/1231)
+
+* [not discussed] Diff between createdBy property in 3.0 and "createdBy" relationship type in 3.1
+  [https://github.com/spdx/spdx-3-model/issues/1274](https://github.com/spdx/spdx-3-model/issues/1274)
+
+* [not discussed] Update rootElement description to accommodate non-BOM use cases
+  [https://github.com/spdx/spdx-3-model/issues/1278](https://github.com/spdx/spdx-3-model/issues/1278)
+
+* How to reference listed licenses and listed cryptographic algorithms from within a SPDX document?
+
+* External elements fails SHACL validation
+  [https://github.com/spdx/spdx-3-model/issues/956](https://github.com/spdx/spdx-3-model/issues/956)
+
+* Represent a SPDX cryptographic algorithm in SPDX 3.1 cryptographic algorithm list?
+  [https://github.com/spdx/spdx-3-model/issues/1282](https://github.com/spdx/spdx-3-model/issues/1282)
+
+### File tags
+
+* [not discussed] Reuse style file tags and how to support them with SPDX3.0
+  [https://github.com/spdx/using/issues/12](https://github.com/spdx/using/issues/12)
+
+* [not discussed] Acknowledge SPDX tag and license expression usage in REUSE
+  [https://github.com/spdx/spdx-spec/issues/502](https://github.com/spdx/spdx-spec/issues/502)
+
+* [not discussed] Status of “SPDX File Tags”
+  [https://github.com/spdx/spdx-spec/issues/1393](https://github.com/spdx/spdx-spec/issues/1393)
+
+* [not discussed] Consider refactoring schema to use additionalProperties: false
+  [https://github.com/JPEWdev/shacl2code/issues/60](https://github.com/JPEWdev/shacl2code/issues/60)
+
+* Examples
+
+## Notes
+
+Last week’s minutes approved.
+
+### Announcements
+
+* No call next week.
+* SPDX 3.0 ballot approved by ISO. Japan and Korea provided editorial feedback, but also approved.
+* Next step: Alexios and others to read feedback, apply changes, or respond.
+
+### SPDX info in files
+
+* Informative annex in SPDXv2; in SPDXv3 doc in spdx/using repo.
+* `SPDX-License-Identifier: <license expression>`
+* SPDXv2 had “SPDX-” plus any tag from tag/value format, for example `FileCopyrightText`.
+* SPDXv3 does not have tags.
+* Agreement to have a defined list of valid “tags”.
+* Suggestion for `CryptographicAlgorithmId`, with the meaning “this code implements…”.
+* Also need `Snippet-Begin`, `Snippet-End`.
+* No `SPDX3-...`, just `SPDX-`.
+* It should not be part of profile conformance, as it is not part of the spec; not SPDX data.
+* We should promote the spdx/using site more.
+
+### Move downloadLocation from Software/Package to Software/SoftwareArtifact to use it also in Software/File
+
+[https://github.com/spdx/spdx-3-model/issues/1032](https://github.com/spdx/spdx-3-model/issues/1032)
+
+* This changes the concepts from SPDXv2.
+  See: [https://github.com/spdx/spdx-3-model/issues/1032#issuecomment-2985904960](https://github.com/spdx/spdx-3-model/issues/1032#issuecomment-2985904960)
+* Might be useful for AI weights, etc.
+* Would it lead to confusion with single Files with `downloadURL` without Packages?
+* If done, wording should change in Package, File, and `downloadLocation`.
+* Wait for PR.
+
+### How to count the number of licensing profiles? – add “licensing” to ProfileIdentifierType
+
+[https://github.com/spdx/spdx-3-model/issues/1238](https://github.com/spdx/spdx-3-model/issues/1238)
+
+* There is no “licensing” entry.
+* Alexios proposes to delete the “Licensing” profile.
+* The requirements should be in Simple and Expanded licensing, anyway.
+* Simple, for example, does not have conformance points; this is wrong.
+* Is this breaking compatibility with 3.0?
+* There are no classes in `/Licensing`; no data.
+* More investigation required.
+
+## Next meeting
+
+In two weeks, 2026-06-23.
+
+## Backlog
+
+See backlog at “Backlog” tab:
+[https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y](https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y)


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on June 9, 2026, including attendees, follow-ups, and topics discussed.