### PR TITLE
Add minutes for SPDX Hardware Team meeting on 2026-06-19

### DIFF
--- a/hardware/2026/2026-06-19.md
+++ b/hardware/2026/2026-06-19.md
@@ -1,0 +1,89 @@
+# SPDX Hardware Team Meeting 2026-06-19
+
+## Attendees
+
+* [ ] Alfred Strauch
+* [x] Steven Carbno
+* [x] Bob Martin (MITRE)
+* [ ] Dishoung White II
+* [ ] Kate Stewart
+* [ ] Victor Lu
+* [x] Jim Vitrano
+* [ ] Amit Kumar
+* [ ] Issac Asay
+* [ ] Lucas Tate
+* [ ] Apoorav Trehan
+* [ ] Alex Volykin
+* [ ] Allan Friedman
+* [ ] Cassie Crossley
+* [x] Felix Reichmanna
+* [ ] Makki Elfatih
+* [x] Greg Shue
+* [ ] Riley Barello-Myers
+* [ ] Henk Berkholz
+* [ ] Dan Hopkins
+* [ ] Courtney Ng
+* [ ] Andrew Viater
+* [ ] Raymond Sheh
+* [ ] Stanislav Pankevich
+* [ ] Karen Bennet
+* [ ] Marcel Kurzamann
+* [ ] Raymond Sheh
+* [ ] Michael Pease (NIST Standards)
+* [ ] Jenn Power (Red Hat)
+* [x] Arthit Suriyawongkul
+
+## Agenda
+
+* Approve previous minutes: https://github.com/spdx/meetings/pull/1119 — OK
+* Continue discussion related to hardware, USB, and supply chain with system engineering elements: https://github.com/gregshue/spdx-examples/tree/conformance-example1-prelim-system-reqs
+* Discuss the definition and role of an interface.
+* Review PR: https://github.com/spdx/spdx-examples/pull/155
+* Model out the certificate/root of trust annotations.
+
+## Notes
+
+* Minutes approved.
+* Reviewed approved items.
+* Alfred apologized for absence due to a previous commitment.
+* Approved the 2026-06-12 minutes.
+* Greg continued presenting the conformance example, `SAMPLE Product 1 - USB Network Interface Dongle`, in StrictDoc.
+* SPDX Regulation Conformance Example 1: SEBoK Product as System - Commodity Consumer Electronics:
+
+  * https://github.com/gregshue/spdx-examples/tree/conformance-example1-prelim-system-reqs
+  * https://github.com/spdx/spdx-examples/pull/155
+* `SAMPLE Product 1` consists of headings such as Product, Form Requirements, and related SEBoK-based sections.
+* Product contains subheadings such as Feature List.
+* The internal name of the product is needed. Market names can change many times.
+* The key heading is Compliance Requirements, where EU CRA is proposed to be added.
+* Compliance Requirements will contain verification statements and rationales explaining how `SAMPLE Product 1` complies with EU CRA.
+* The group discussed how to verify these statements:
+
+  * By test
+  * By demonstration
+  * By analysis
+* The group discussed how these verifications could be automated.
+* Verification is required for each public release.
+* The next step is another PR for product behavior.
+* The group continued discussing additional requirements for the sample product.
+
+### Firmware Update Interfaces
+
+* The group discussed statements for “Firmware Update Interfaces.”
+* To update a product under CRA, the product needs a kind of communication channel, whether secure or not secure, such as USB, Bluetooth, or another channel.
+* The group discussed whether push and pull update mechanisms need to be differentiated.
+* The group discussed the ability to schedule updates and the network locations from which updates will be accepted.
+* Greg will put this material into another PR.
+* Additional statements in the sample remain to be discussed.
+* The group needs to think further about degree of freedom, push/pull mode, and configuration.
+* The group discussed how to write requirements so they are reusable.
+
+## Action Items
+
+* Define the `canProvide` / `isQualifiedFor` relationship after PR 1221.
+* Review the GitHub example and provide suggestions or changes: https://github.com/spdx/spdx-examples/pull/155
+* Refer external individuals, businesses, or organizations to the GitHub example repository so they can make suggestions.
+
+## Decision Items
+
+* None recorded.


### PR DESCRIPTION
Documented the attendees, agenda, notes, action items, and decision items from the SPDX Hardware Team meeting held on June 19, 2026.