### PR TITLE
Add meeting minutes for SPDX Tech Team on 2026-06-22

### DIFF
--- a/asia/2026/2026-06-22.md
+++ b/asia/2026/2026-06-22.md
@@ -1,0 +1,46 @@
+# SPDX Tech Team Meeting 2026-06-22 ASIA
+
+## Attendees
+
+* Kate Stewart
+* Yoshiyuki Ito
+* Norio Kobota
+* Takashi Ninjouji
+
+## Agenda
+
+* Approval of last month's minutes
+* Announcements and new participants
+* SPDX 3.1 Lite feedback
+
+## Notes
+
+### SPDX 3.1 Lite Feedback
+
+* ENISA draft document states that SBOMs should include creation date and version number.
+* Timestamp appears clear enough, but it remains unclear what should be used for the document version.
+* Possible approaches discussed:
+
+  * Consider use of the `Comment` field.
+  * Rewrite the document and point to the prior version using a relationship derived from it.
+  * Use the document URI as a unique identifier or version, together with the timestamp, based on the prior BSI URI discussion.
+* SBOM documents may evolve over time.
+* Compile options and toolchain information were discussed.
+* Multiple variants may need to be represented.
+* Pointing to prior versions with a `DescendentOf` relationship provides the most clarity.
+
+### Announcements
+
+* SPDX 3.0 passed ISO balloting.
+* SPDX 3.0 SBOMs are now automatically generated with Linux kernel builds and have been merged into the upstream kernel.
+* OSS EU CFP is open.
+* The OpenChain SBOM group is submitting a talk.
+
+## Next Meeting
+
+* To be determined.
+
+## Backlog
+
+See backlog at the “Backlog” tab:
+https://docs.google.com/document/d/1NdHYU_VZtLacD4bEmf2GiUVRTbrcev1beaJpq8s8-pU/edit?tab=t.4wfxhy2gdx3y


### PR DESCRIPTION
Document the minutes of the SPDX Tech Team meeting held on June 22, 2026, including attendees, agenda, notes, and announcements.