### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-06-23

### DIFF
--- a/tech/2026/2026-06-23.md
+++ b/tech/2026/2026-06-23.md
@@ -1,0 +1,151 @@
+# SPDX Tech Team Meeting 2026-06-23
+
+## Attendees
+
+* Alexios Zavras
+* Alfred Strauch
+* Arthit Suriyawongkul
+* Bob Martin
+* Gary O'Neall
+* Greg Shue
+* Joshua Watt
+* Karsten Klein
+* Kate Stewart
+* Marc-Etienne Vargenau
+* Nicole Pappler
+* Steven Carbno
+* Ted Gauthier
+
+## Agenda
+
+* Approval of last meeting’s minutes
+* Announcements and new participants
+* ISO updates — Alexios
+* Licensing profile(s) — Alexios
+* Drop minor version in context annotation file: https://github.com/spdx/spdx-spec/pull/1403
+* Determine whether this URL is part of the specification and should be added to the Serialization section: https://spdx.org/rdf/3.0.1/spdx-json-serialize-annotations.ttl
+* Use qualified name in relationship type: https://github.com/spdx/spdx-3-model/pull/1293
+* Security Certificate Model example
+
+  * Potential simplification
+  * SPDX Cryptology list integration into the Security Profile
+
+## Notes
+
+### Minute Approval
+
+* Prior meeting minutes were approved: https://github.com/spdx/meetings/pull/1117
+
+### Announcements
+
+* The Linux kernel merged automatic SPDX 3.0 SBOM generation: https://lore.kernel.org/linux-spdx/178215830073.1395317.8452895579708677139.pr-tracker-bot@kernel.org/T/#t
+* Zephyr merged SPDX 3.0 SBOM generation: https://github.com/zephyrproject-rtos/zephyr/pull/110752
+* PX4 merged automatic SPDX 2.3 generation: https://github.com/PX4/PX4-Autopilot/releases/tag/v1.18.0-alpha1
+
+### ISO Updates
+
+* SPDX 3.0 passed the ISO ballots.
+* Editorial changes were requested from Japan and Korea.
+* The requested changes will not require SPDX version number changes. The version will remain SPDX 3.0.
+* Some changes will be made in the model, and others will be made in the specification and specification parser.
+* The detailed diagrams received strong review, including identification of typos that are being corrected.
+* The group discussed whether to use 3.0.1 or 3.0.2 and landed on creating a new tag: `3.0.1-ISO`.
+
+**Action Item:** Kate to schedule a meeting with ISO consultants, Bob, Alexios, and Gary.
+
+### Licensing Profile
+
+* The group discussed Licensing, Simple Licensing, and Extended Licensing Profiles in relation to conformance points.
+* Licensing includes a conformance point that every software artifact should have a concluded license.
+* Simple Licensing and Extended Licensing are two different ways of representing licenses.
+* Obligations should apply to both Simple Licensing and Extended Licensing, but this needs to be written down.
+* The expectation is that a software artifact must have at least one concluded license.
+* Gary suggested that Licensing should only be a conformance point, while Simple Licensing and Extended Licensing should be treated as namespaces only.
+* Alexios noted that the profile vocabulary is confusing regarding which profile or profiles should be present.
+* Gary clarified that the property referring to vocabulary is the only conformance point. He did not think vocabulary namespaces were needed beyond conformance points.
+* The recommendation was to move Simple Licensing and Extended Licensing to conformance points and drop Licensing as a profile.
+* This was not expected to create a breaking change because Licensing is not formally in the vocabulary.
+* The group discussed copying the top-level wording to both Simple Licensing and Extended Licensing.
+* Steve raised model-file considerations.
+* The group confirmed this should be possible without impacting the ontology.
+* Licensing does appear as a namespace for `NONE` and `NOASSERTION` URIs, so it cannot be removed entirely.
+* The group discussed changing the Markdown page description to refer to Simple and Complex Licensing.
+* Further cleanup should be considered for SPDX 4.0.
+* The group also discussed why `SAMEAS` was originally introduced. The general view was that it is safe to delete at this point.
+
+**Action Item:** Alexios to take a pass at cleaning this up in the current tree.
+
+**Action Item:** Create a new SPDX 4.0 issue so the cleanup item is not lost.
+
+### Drop Minor Version in Context Annotation File
+
+Reference: https://github.com/spdx/spdx-spec/pull/1403
+
+* The minor version has been removed in the model file and specification parser.
+* The remaining issue is to resolve it in serialization.
+* The file contains information that was not agreed to be included in the SHACL file.
+
+### Serialization Annotation URL
+
+Reference: https://spdx.org/rdf/3.0.1/spdx-json-serialize-annotations.ttl
+
+* The group discussed whether this URL is part of the specification and whether it should be added to the Serialization section.
+* The URL does not currently appear in the specification.
+* The group noted that valid bindings cannot be generated without it.
+
+**Action Item:** Art to include this in the Serialization section of the specification when discussing JSON-LD.
+
+### Use Qualified Name in Relationship Type
+
+Reference: https://github.com/spdx/spdx-3-model/pull/1293
+
+* There was general agreement that adding the qualified name should be acceptable.
+* The group noted that if a relationship is profile-specific but used in multiple profiles and eventually needs to move to core, the shift would need to wait until SPDX 4.0.
+* The group discussed whether this should only clean up the current item or whether other documentation changes should also be updated.
+* Art has tooling that extracts this information to support SHACL.
+* If an item is in core, it does not proceed with the namespace in JSON schema. However, this is somewhat different because the issue concerns relationship type descriptions rather than fields.
+* Within the class or profile being worked on, qualification is not needed.
+* Consensus was that it is worth adding the qualified name and checking whether any other references should also be qualified.
+* Art noted that software purpose has approximately 40 references that need to be considered.
+* Software artifact references require further investigation.
+* The scope should be limited to software artifacts.
+* The group noted that further restriction could possibly be a breaking change, but because this is currently only a description, it requires offline investigation.
+
+**Action Item:** Kate to review, pass, and merge if no issues are detected.
+
+### Security Certificate Model
+
+* Jason’s signature proposal and cryptographic topics need to be prepared for the next meeting.
+* A white paper is needed to obtain feedback.
+* The group should review the mailing list discussion.
+* The following cross-authority evaluation of cryptography may also be relevant to integrate into the minutes or future discussion: https://github.com/org-metaeffekt/metaeffekt-cryptography
+* The group discussed how to define parameters in security discussions.
+* Two approaches were noted, including per-file definition.
+* The group noted this may create issues for tooling.
+* Tooling may need to hide some of this complexity.
+
+**Action Item:** Alfred and Steve to present approaches at a future meeting and support further discussion.
+
+### Other Items
+
+* RDF/SHACL generated from fully qualified class names in relationship type descriptions: https://github.com/user-attachments/files/29219483/spdx-model.ttl.txt
+* The following pull request still needs review: https://github.com/spdx/spdx-spec/pull/1403
+* The group discussed that `base` does not resolve and asked whether this is deliberate.
+* Gary confirmed this item with Alexios and Art.
+
+## Action Items
+
+| Owner            | Action Item                                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| Kate             | Schedule a meeting with ISO consultants, Bob, Alexios, and Gary.                                            |
+| Alexios          | Take a pass at cleaning up the Licensing Profile structure in the current tree.                             |
+| TBD              | Create a new SPDX 4.0 issue so the Licensing Profile cleanup item is not lost.                              |
+| Art              | Add the serialization annotation URL to the Serialization section when discussing JSON-LD.                  |
+| Kate             | Review the qualified-name relationship type change, pass it, and merge if no issues are detected.           |
+| Alfred and Steve | Present approaches for Security Certificate Model and cryptographic parameter handling at a future meeting. |
+
+## Next Meeting Topics
+
+* Microsoft feedback on SPDX
+* Crypto, signatures, and certificates
+* Follow up with Karsten, Cryptology, and the Security group


### PR DESCRIPTION
Documented the minutes of the SPDX Tech Team meeting held on June 23, 2026, including attendees, agenda items, discussions, and action items.