### PR TITLE
Add meeting minutes for SPDx Hardware Team 2026-07-17

### DIFF
--- a/hardware/2026/2026-07-17.md
+++ b/hardware/2026/2026-07-17.md
@@ -1,0 +1,81 @@
+# SPDX Hardware Team Meeting 2026-07-17
+
+## Attendees
+
+- [x] Alfred Strauch
+- [x] Steven Carbno
+- [ ] Bob Martin (MITRE)
+- [ ] Dishoung White II
+- [ ] Kate Stewart
+- [x] Victor Lu
+- [x] Jim Vitrano
+- [ ] Amit Kumar
+- [ ] Issac Asay
+- [ ] Lucas Tate
+- [ ] Apoorav Trehan
+- [ ] Alex Volykin
+- [ ] Allan Friedman
+- [ ] Cassie Crossley
+- [x] Felix Reichmanna
+- [ ] Makki Elfatih
+- [ ] Greg Shue
+- [ ] Riley Barello-Myers
+- [ ] Henk Berkholz
+- [ ] Dan Hopkins
+- [ ] Courtney Ng
+- [ ] Andrew Viater
+- [ ] Raymond Sheh
+- [ ] Stanislav Pankevich
+- [ ] Karen Bennet
+- [ ] Marcel Kurzamann
+- [ ] Raymond Sheh
+- [ ] Michael Pease (NIST Standards)
+- [ ] Jenn Power (Red Hat)
+- [ ] Arthit Suriyawongkul
+
+## Agenda
+
+- Approve previous minutes:  
+  https://github.com/spdx/meetings/pull/1127
+
+- PR: fix changeaction, postalName, ProcessReadinessType and bulkQuantity  
+  https://github.com/spdx/spdx-3-model/pull/1405
+
+- PR Editorial cleanup: Model SupplyChain/Dataset/Security/Licensing (7.5) #1407  
+  https://github.com/spdx/spdx-3-model/pull/1407/changes
+
+- Review Mass Units issues recently discussed.
+
+- Review Microsoft's SPDX Review document:  
+  https://docs.google.com/document/d/1WU1V-8LbmB0uMhKpKIri7qiBdU40GEG8XwZHyOXrJcM/edit?tab=t.0
+
+- Zephyr project has a custom action for CO2; bulk hardware may need SPDX enhancement to better capture CO2 produced during an action.  
+  https://kartben.github.io/spdx3_viz/
+
+- Model out the certificate/root of trust annotations.
+
+## Notes
+
+- Minutes approved.
+- Reviewed approved items.
+- Had a brief conversation related to the relationship of system engineering capture of data in SPDX and the use of SPDX data elements that include sys eng data and operational data.
+- PR 1407 — quickly reviewed elements of PR — approved as presented.
+- QUDT units for measurement — simplification.
+- Quality will move from string for validation.
+- Have measure of unit class only — restrict QUDT to link only.
+- Hardware X-axis points to length, Y to height, Z to width.
+- CO2 emissions need a unit of measurement — can it be modeled for ease of use and standardization — who and what is the measure — transportation act — QUDT measures quality — what is the calculation used? Key issue — how do we represent owner, the representative, etc.
+- Attribution of CO2 by someone, based on some principle, and relationship to a product or item is the question?
+- Bulk hardware: CO2 has volume, quantity, or mass attached in Kg — agents define the actor.
+- May be multiple methods of calculation based on country.
+- Information link:  
+  https://blog.qima.com/sustainability/circulatory-carbon-regulatory-priorities-2025-2026
+- Keep it simple for now vs. this is not simply a CO2 issue — i.e., training for an AI model.
+  - By product → emission → model as output.
+
+## Action Items
+
+- Review PRs and make suggestions or approve.
+
+## Decision Item
+:::


### PR DESCRIPTION
Documented the minutes and agenda for the SPDx Hardware Team meeting held on July 17, 2026, including attendees, discussion points, notes, action items, and decision items.