### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-07-21

### DIFF
--- a/tech/2026/2026-07-21.md
+++ b/tech/2026/2026-07-21.md
@@ -1,0 +1,159 @@
+# SPDX Tech Team Meeting — 2026-07-21
+
+## Attendees
+
+- Gary O’Neall
+- Steven Carbno
+- Alfred Strauch
+- Greg Shue
+- Joshua Watt
+- Nicole Pappler
+- Karen Bennet
+- Ted Gauthier
+
+## Agenda
+
+- Approval of last meeting’s minutes (7 July 2026)
+- Announcements and new participants
+- Profile team follow-up on new issues labeled `profile:xxx`
+- Licensing profile(s) — Alexios
+
+### Fix Existing
+
+#### `assessedElement` Fix
+
+- [spdx-3-model PR #1281](https://github.com/spdx/spdx-3-model/pull/1281)
+
+#### `hasInput`/`hasOutput`: Add `AIPackage` to the `from`
+
+- [spdx-3-model PR #1301](https://github.com/spdx/spdx-3-model/pull/1301)
+
+#### Add UUID to `spdxIds` in Example Data
+
+- [spdx-spec PR #1325](https://github.com/spdx/spdx-spec/pull/1325)
+- Follows suggestions in [SPDX ID property documentation](https://spdx.github.io/spdx-spec/v3.1-dev/model/Core/Properties/spdxId/)
+- Agreed in call; follow-up and reviews/approvals needed.
+
+#### Merge Serialization Information from `spdx-3-model`
+
+- [spdx-3-model PR #1250](https://github.com/spdx/spdx-3-model/pull/1250)
+- Agreed on 7 April 2026 Tech call / 8 April 2026 Implementers call.
+
+#### Add JSON Serialization Annotation URL to Serialization Section
+
+- SPDX 3.0: [spdx-spec PR #1406](https://github.com/spdx/spdx-spec/pull/1406)
+- SPDX 3.1: [spdx-spec PR #1405](https://github.com/spdx/spdx-spec/pull/1405)
+- Agreed on 23 June 2026 Tech call.
+
+#### Use ECMA-427 for Package-URL
+
+- Remove Annex: [spdx-spec PR #1397](https://github.com/spdx/spdx-spec/pull/1397)
+- Remove references to Annex: [spdx-3-model PR #1287](https://github.com/spdx/spdx-3-model/pull/1287)
+- Agreed on 24 March 2026 to remove, but to decide whether we can wait to use the ISO version.
+- Information from Michael Herzog indicates Package-URL will receive ISO status approximately May 2027: [issue comment](https://github.com/spdx/spdx-spec/issues/1144#issuecomment-4664282228).
+- Target release for SPDX 3.1 is the end of 2026.
+
+#### Move `downloadLocation` to `SoftwareArtifact`
+
+- [spdx-3-model PR #1292](https://github.com/spdx/spdx-3-model/pull/1292)
+- Agreed on 26 May 2026 Tech call.
+
+### Proposal — New
+
+#### Add SBOM Version
+
+- [spdx-3-model issue #1288](https://github.com/spdx/spdx-3-model/issues/1288)
+
+#### Add Version to `Tool`
+
+- [spdx-3-model issue #1303](https://github.com/spdx/spdx-3-model/issues/1303)
+
+### Proposal — Revision
+
+#### Consider Use of `SupportTerms` Rather Than `SupportRelationship`
+
+- [spdx-3-model issue #1284](https://github.com/spdx/spdx-3-model/issues/1284)
+
+### Follow-Up on Microsoft Feedback
+
+- Profile teams need to review their issues.
+- A 3.1 milestone was added if the fix may introduce a breaking change.
+- Fill in stub class/property pages with prose and examples before RC2: [spdx-3-model issue #1373](https://github.com/spdx/spdx-3-model/issues/1373)
+- New profiles are not fully specified for conformance: [spdx-3-model issue #1306](https://github.com/spdx/spdx-3-model/issues/1306)
+- `PhysicalLocation` allows empty instances: [spdx-3-model issue #1325](https://github.com/spdx/spdx-3-model/issues/1325)
+- `Action.actionStartTime` opt-in burden: [spdx-3-model issue #1323](https://github.com/spdx/spdx-3-model/issues/1323)
+- Document the 3.0.1 → 3.1 conformance and backward-compatibility relationship: [spdx-spec issue #1430](https://github.com/spdx/spdx-spec/issues/1430)
+- Add missing `ExternalIdentifierType` values and update its RFC citation: [spdx-3-model issue #1367](https://github.com/spdx/spdx-3-model/issues/1367)
+- Update the `ExternalRefType` `x509Cert` citation to RFC 5280: [spdx-3-model issue #1368](https://github.com/spdx/spdx-3-model/issues/1368)
+- Note ISO 3166-1 alpha-3 validity for `CountryCodeAlpha3`: [spdx-3-model issue #1369](https://github.com/spdx/spdx-3-model/issues/1369)
+- Editorial cleanup: clarity-only naming/description suggestions (7.6): [spdx-3-model issue #1403](https://github.com/spdx/spdx-3-model/issues/1403)
+- Editorial cleanup: license-expression and PURL annexes (7.2): [spdx-spec issue #1420](https://github.com/spdx/spdx-spec/issues/1420)
+- Editorial cleanup: documentation and annexes (7.1): [spdx-spec issue #1419](https://github.com/spdx/spdx-spec/issues/1419)
+- Define a normative IRI and `@context` versioning policy: [spdx-spec issue #1427](https://github.com/spdx/spdx-spec/issues/1427)
+- Rename `countyCode` → `countySubdivisionCode`: [spdx-3-model issue #1410](https://github.com/spdx/spdx-3-model/issues/1410)
+- Property Nature corrections (consolidated): [spdx-3-model issue #1316 comment](https://github.com/spdx/spdx-3-model/issues/1316#issuecomment-4966295883)
+
+#### The Following May Not Need to Be Resolved for 3.1
+
+- Hash-strength guidance: [spdx-3-model issue #1314](https://github.com/spdx/spdx-3-model/issues/1314)
+- Missing `SubclassOf` declarations: [spdx-3-model issue #1317](https://github.com/spdx/spdx-3-model/issues/1317)
+- `implementedBy` direction reversed: [spdx-3-model issue #1320](https://github.com/spdx/spdx-3-model/issues/1320)
+- `quantity` range contradiction: [spdx-3-model issue #1318](https://github.com/spdx/spdx-3-model/issues/1318)
+- `unitQUDT` should be resolvable: [spdx-3-model issue #1319](https://github.com/spdx/spdx-3-model/issues/1319)
+- Requirement instantiability missing: [spdx-3-model issue #1322](https://github.com/spdx/spdx-3-model/issues/1322)
+- `Location` versus `CountryCodeAlpha3` inconsistency: [spdx-3-model issue #1326](https://github.com/spdx/spdx-3-model/issues/1326)
+- `MediaType` regex too loose: [spdx-3-model issue #1328](https://github.com/spdx/spdx-3-model/issues/1328)
+- Specification summary too narrow: [spdx-3-model issue #1329](https://github.com/spdx/spdx-3-model/issues/1329)
+- Type-reference qualification inconsistency: [spdx-3-model issue #1330](https://github.com/spdx/spdx-3-model/issues/1330)
+- Cross-namespace workaround relationships: [spdx-3-model issue #1331](https://github.com/spdx/spdx-3-model/issues/1331)
+- Define a normative IRI and `@context` versioning policy: [spdx-spec issue #1427 comment](https://github.com/spdx/spdx-spec/issues/1427#issuecomment-4968219877)
+- Requirement internationalization: [spdx-3-model issue #1340](https://github.com/spdx/spdx-3-model/issues/1340)
+- `cdxProperty` “map” is misleading: [spdx-3-model issue #1345](https://github.com/spdx/spdx-3-model/issues/1345)
+- Add amendment/supersession patterns for evolving federated SBOMs: [spdx-3-model issue #1361](https://github.com/spdx/spdx-3-model/issues/1361)
+- Single, authoritative ABNF for license expressions: [spdx-spec issue #1435](https://github.com/spdx/spdx-spec/issues/1435)
+
+## Notes
+
+- Minutes approved.
+- Issues from Microsoft for the different profiles:
+  - Operations: Update references to more recent editions. Need to follow up offline with the Operations team.
+  - AI/Data: Will be covered in tomorrow’s meeting.
+  - Hardware and Supply Chain: Being followed up on from the Microsoft document.
+  - Nicole will review Functional Safety.
+  - Licensing has already been addressed by Alexios.
+- `assessedElement` fix:
+  - Review at tomorrow’s Implementers call.
+  - If it does not cause compatibility issues, proceed with merging.
+- `hasInput`/`hasOutput`: Add `AIPackage` to the `from`:
+  - Will be discussed in tomorrow’s AI/Dataset call.
+  - Art will fix the merge conflict before the call.
+- Add UUID to `spdxIds` in example data:
+  - Await feedback from Alexios.
+  - Preference is to merge this version and, if needed, create a new PR if a different ID approach is selected.
+- Use ECMA-427 for Package-URL / remove references to Annex for Package-URL:
+  - One more review is needed before merging.
+- Consider use of `SupportTerms` rather than `SupportRelationship`:
+  - Take up next week when Kate is on the call.
+- Move `downloadLocation` to `SoftwareArtifact`:
+  - No objections.
+  - One more review is needed before merging.
+- Add SBOM version:
+  - Discussed and agreed that the Relationship approach works.
+  - The version field presents issues when there is no central repository or authority for an SBOM.
+  - Closed as not planned.
+- Add version to `Tool`:
+  - No objections.
+  - Approved and merged.
+- Microsoft feedback:
+  - Will be taken up next week.
+
+## Next Meeting
+
+### Proposal — Revision
+
+- Consider use of `SupportTerms` rather than `SupportRelationship`: [spdx-3-model issue #1284](https://github.com/spdx/spdx-3-model/issues/1284)
+- Follow-up on Microsoft feedback.
+- Follow-up on crypto, signatures, and certificates:
+  - Reach out to Karsten and the Cryptology and Security group.
+- Add `hasInstall` and `hasUninstall` relationships: [spdx-3-model PR #1297](https://github.com/spdx/spdx-3-model/pull/1297)
+:::


### PR DESCRIPTION
Documented the attendees, agenda, and notes from the SPDX Tech Team meeting held on July 21, 2026, including follow-ups on various issues and proposals.