### PR TITLE
Add meeting minutes for SPDX Hardware Team on 2026-07-24

### DIFF
--- a/hardware/2026/2026-07-24.md
+++ b/hardware/2026/2026-07-24.md
@@ -1,0 +1,198 @@
+# SPDX Hardware Team Meeting — 2026-07-24
+
+## Attendees
+
+* [x] Alfred Strauch
+* [x] Steven Carbno
+* [ ] Bob Martin (MITRE)
+* [ ] Dishoung White II
+* [ ] Kate Stewart
+* [x] Victor Lu
+* [x] Jim Vitrano
+* [ ] Amit Kumar
+* [x] Issac Asay
+* [ ] Lucas Tate
+* [ ] Apoorav Trehan
+* [ ] Alex Volykin
+* [ ] Allan Friedman
+* [ ] Cassie Crossley
+* [ ] Felix Reichmanna
+* [ ] Makki Elfatih
+* [x] Greg Shue
+* [ ] Riley Barello-Myers
+* [ ] Henk Berkholz
+* [ ] Dan Hopkins
+* [ ] Courtney Ng
+* [ ] Andrew Viater
+* [ ] Raymond Sheh
+* [ ] Stanislav Pankevich
+* [ ] Karen Bennet
+* [x] Marcel Kurzamann
+* [ ] Raymond Sheh
+* [ ] Michael Pease (NIST Standards)
+* [ ] Jenn Power (Red Hat)
+* [ ] Arthit Suriyawongkul
+
+## Agenda
+
+### Approval of Previous Minutes
+
+* Approve previous minutes:
+  https://github.com/spdx/meetings/pull/1129
+
+### SPDX Items Merged Last Week
+
+* **VirtualHardwareModelType improvement** — Merged
+  https://github.com/spdx/spdx-3-model/pull/1408/changes
+
+* **ResponsibilityType improvement** — Merged
+  https://github.com/spdx/spdx-3-model/pull/1407/changes
+
+* **[SupplyChain] Update location-related property descriptions** — Merged
+  https://github.com/spdx/spdx-3-model/pull/1406/changes
+
+* **ChangeAction, postalName, ProcessReadinessType, and bulkQuantity** — Merged
+  https://github.com/spdx/spdx-3-model/pull/1405/changes
+
+* **plannedTransportRoute: Use singular and revise description** — Merged
+  https://github.com/spdx/spdx-3-model/pull/1404
+
+* **Responsibility category fix** — Merged
+  https://github.com/spdx/spdx-3-model/pull/1300/changes
+
+### Zephyr Project and CO₂ Modeling
+
+* The Zephyr project has a custom action for CO₂. Bulk hardware may require an SPDX enhancement to better capture CO₂ produced during an action.
+* SPDX visualization:
+  https://kartben.github.io/spdx3_viz/
+
+### Pull Requests to Review
+
+* **ProjectOwner and productAgent: Consistent language and expanded abbreviation**
+  https://github.com/spdx/spdx-3-model/pull/1296
+
+* **Conformance Example 1 preliminary system requirements**
+  https://github.com/spdx/spdx-examples/pull/155
+
+### Issues from Microsoft’s SPDX Review Document
+
+* **[3.1-RC1] Editorial cleanup: Clarity-only naming and description suggestions (7.6)**
+  https://github.com/spdx/spdx-3-model/issues/1403
+
+* **Rename vague SupplyChain property names (`current*`, `previous*`, and `planned*`)**
+  https://github.com/spdx/spdx-3-model/issues/1390
+
+* **[3.1-RC1] Scope the CreateProcess description to software, datasets, and models**
+  https://github.com/spdx/spdx-3-model/issues/1389
+
+* **[3.1-RC1] Add a redacted or opaque element type for supply-chain black-boxing**
+  https://github.com/spdx/spdx-3-model/issues/1388
+
+* **[3.1-RC1] Restore suppliedBy and releaseTime on Hardware for traceability**
+  https://github.com/spdx/spdx-3-model/issues/1384
+
+* **[3.1-RC1] Relax Hardware.partNumber for BulkHardware commodities**
+  https://github.com/spdx/spdx-3-model/issues/1383
+
+* **[3.1-RC1] Add a Firmware class linked to its hardware in the Hardware profile**
+  https://github.com/spdx/spdx-3-model/issues/1382
+
+* **[3.1-RC1] Add RepairAction and ReturnAction to the SupplyChain namespace**
+  https://github.com/spdx/spdx-3-model/issues/1371
+
+* **[3.1-RC1] Add Incoterms and customs-role modeling to TransportAction**
+  https://github.com/spdx/spdx-3-model/issues/1371
+
+### Additional Discussion Topics
+
+* Review Microsoft’s SPDX Review document:
+  https://docs.google.com/document/d/1WU1V-8LbmB0uMhKpKIri7qiBdU40GEG8XwZHyOXrJcM/edit?tab=t.0
+
+* Model the certificate and root-of-trust annotations.
+
+* OpenChain has parallel initiatives addressing the Cyber Resilience Act and functional safety:
+  https://docs.google.com/document/d/1Wog28BZ9NQhY3tN9Wc2NDml2phBDuvYu9zkXSON5z5o/edit?tab=t.0
+
+* Microsoft discussion.
+
+## Notes
+
+* A vertical standard related to interfaces will be released in September 2026.
+* The previous meeting minutes were approved.
+* Reviewed and approved the pull requests from the previous week.
+* A repaired item can retain the same ID. In some cases, a new ID is created when a new serial number is assigned.
+* Discussed whether changing the serial number creates a new instance.
+* Changing a serial number must create a new product unit of the same type.
+* A change to the model, brand, or manufacturer creates a new product.
+* Reviewed the smaller proposed changes.
+
+### CO₂ and Bulk Hardware
+
+* Discussed the Zephyr CO₂ use case and representing CO₂ as a part number.
+* Use QUDT to identify bulk measurements.
+* Agent type uses International Union of Pure and Applied Chemistry definitions:
+  https://iupac.org/body/800/
+* Discussed CO₂ emissions associated with transportation and operations.
+
+### Pull Requests Requiring Review
+
+* Approval is needed for the following pull request:
+  https://github.com/spdx/spdx-3-model/pull/1296
+
+* Please review and approve the preliminary system requirements for Conformance Example 1:
+  https://github.com/spdx/spdx-examples/pull/155
+
+### Microsoft Review Issues
+
+#### RepairAction and ReturnAction
+
+* **[3.1-RC1] Add RepairAction and ReturnAction to the SupplyChain namespace**
+  https://github.com/spdx/spdx-3-model/issues/1371
+
+* This is supported through the ChangeAction pull-request enhancement:
+  https://github.com/spdx/spdx-3-model/pull/1404
+
+#### Firmware Class
+
+* **Add a Firmware class linked to its hardware in the Hardware profile**
+  https://github.com/spdx/spdx-3-model/issues/1382
+
+* A simple example is needed to clarify where firmware, software, and hardware should be associated.
+
+* An embedded system would contain three distinct elements: firmware, software, and hardware.
+
+* This represents a system with a minimal scope.
+
+* Firmware may be updatable or non-updatable, and that distinction must be addressed.
+
+* The distinction between software and firmware may depend on whether it can be updated without the device running.
+
+* Discussed whether BIOS should be considered firmware or immutable firmware.
+
+* Firmware is software and could be represented as a subclass of a software element.
+
+* If firmware is expressed in a simplified manner that leads to a software description related to the firmware element, that definition must be explicit.
+
+* The issue needs to be addressed by the Software Team.
+
+* A theoretical Firmware class would need to be defined by the Software profile.
+
+* This is a cross-profile issue that should be taken to the Technical Team.
+
+* A software package can be modified.
+
+* Firmware cannot be modified.
+
+* A dataset is a subset of software.
+
+* Discussed `contains` relationships compared with `runsOn`.
+
+* The concept of a system is important.
+
+* Meaningful digital data is software.
+
+## Action Items
+
+* Review the pull requests and provide suggestions or approvals.
+
+## Decision Items


### PR DESCRIPTION
Documented the minutes of the SPDX Hardware Team meeting held on July 24, 2026, including attendees, agenda items, and action points.