### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-07-28

### DIFF
--- a/tech/2026/2026-07-28.md
+++ b/tech/2026/2026-07-28.md
@@ -1,0 +1,207 @@
+# SPDX Tech Team Meeting — 2026-07-28
+
+## Attendees
+
+* Alexios Zavras
+* Alfred Strauch
+* Bob Martin
+* Gary O'Neall
+* Greg Shue
+* Joshua Watt
+* Karsten Klein
+* Kate Stewart
+* Maximilian Huber
+* Nicole Pappler
+* Steven Carbno
+* Ted Gauthier
+
+## Agenda
+
+1. Approval of the previous meeting minutes from 21 July 2026
+2. Announcements and new participants
+3. SPDX 3.0 final edits — status
+4. Proposal revisions
+5. Consider using `SupportTerms` rather than `SupportRelationship`
+
+   * [Issue #1284](https://github.com/spdx/spdx-3-model/issues/1284)
+6. Follow-up on Microsoft feedback
+
+   * Profile teams need to review their issues.
+   * A 3.1 milestone was added where a fix may introduce a breaking change.
+7. Fill in stub class and property pages with prose and examples before RC2
+
+   * [Issue #1373](https://github.com/spdx/spdx-3-model/issues/1373)
+8. New profiles are not fully specified for conformance
+
+   * [Issue #1306](https://github.com/spdx/spdx-3-model/issues/1306)
+9. `PhysicalLocation` allows empty instances
+
+   * [Issue #1325](https://github.com/spdx/spdx-3-model/issues/1325)
+10. `Action.actionStartTime` opt-in burden
+
+    * [Issue #1323](https://github.com/spdx/spdx-3-model/issues/1323)
+11. Document the SPDX 3.0.1 to 3.1 conformance and backward-compatibility relationship
+
+    * [Issue #1430](https://github.com/spdx/spdx-spec/issues/1430)
+12. Add IBAN, VAT number, and EORI to `ExternalIdentifierType`
+
+    * [Pull Request #1420](https://github.com/spdx/spdx-3-model/pull/1420)
+13. Note ISO 3166-1 alpha-3 validity for `CountryCodeAlpha3`
+
+    * [Issue #1369](https://github.com/spdx/spdx-3-model/issues/1369)
+14. Editorial cleanup: clarity-only naming and description suggestions (7.6)
+
+    * [Issue #1403](https://github.com/spdx/spdx-3-model/issues/1403)
+15. Editorial cleanup: license-expression and PURL annexes (7.2)
+
+    * [Issue #1420](https://github.com/spdx/spdx-spec/issues/1420)
+16. Editorial cleanup: documentation and annexes (7.1)
+
+    * [Issue #1419](https://github.com/spdx/spdx-spec/issues/1419)
+17. Define a normative IRI and `@context` versioning policy
+
+    * [Issue #1427](https://github.com/spdx/spdx-spec/issues/1427)
+18. Rename `countyCode` to `countySubdivisionCode`
+
+    * [Issue #1410](https://github.com/spdx/spdx-3-model/issues/1410)
+19. Property Nature corrections, consolidated
+
+    * [Issue #1316 comment](https://github.com/spdx/spdx-3-model/issues/1316#issuecomment-4966295883)
+
+### Items That May Not Need Resolution for SPDX 3.1
+
+* Hash-strength guidance
+
+  * [Issue #1314](https://github.com/spdx/spdx-3-model/issues/1314)
+* Missing `SubclassOf` declarations
+
+  * [Issue #1317](https://github.com/spdx/spdx-3-model/issues/1317)
+* `implementedBy` direction reversed
+
+  * [Issue #1320](https://github.com/spdx/spdx-3-model/issues/1320)
+* Quantity range contradiction
+
+  * [Issue #1318](https://github.com/spdx/spdx-3-model/issues/1318)
+* `unitQUDT` should be resolvable
+
+  * [Issue #1319](https://github.com/spdx/spdx-3-model/issues/1319)
+* Requirement instantiability missing
+
+  * [Issue #1322](https://github.com/spdx/spdx-3-model/issues/1322)
+* `Location` versus `CountryCodeAlpha3` inconsistency
+
+  * [Issue #1326](https://github.com/spdx/spdx-3-model/issues/1326)
+* `MediaType` regex too loose
+
+  * [Issue #1328](https://github.com/spdx/spdx-3-model/issues/1328)
+* Specification summary too narrow
+
+  * [Issue #1329](https://github.com/spdx/spdx-3-model/issues/1329)
+* Type-reference qualification inconsistency
+
+  * [Issue #1330](https://github.com/spdx/spdx-3-model/issues/1330)
+* Cross-namespace workaround relationships
+
+  * [Issue #1331](https://github.com/spdx/spdx-3-model/issues/1331)
+* Define a normative IRI and `@context` versioning policy
+
+  * [Issue #1427 comment](https://github.com/spdx/spdx-spec/issues/1427#issuecomment-4968219877)
+* Requirement internationalization
+
+  * [Issue #1340](https://github.com/spdx/spdx-3-model/issues/1340)
+* `cdxProperty` “map” is misleading
+
+  * [Issue #1345](https://github.com/spdx/spdx-3-model/issues/1345)
+* Add amendment and supersession patterns for evolving federated SBOMs
+
+  * [Issue #1361](https://github.com/spdx/spdx-3-model/issues/1361)
+* Single authoritative ABNF for license expressions
+
+  * [Issue #1435](https://github.com/spdx/spdx-spec/issues/1435)
+
+## Notes
+
+### Approval of Previous Minutes
+
+The minutes from the previous meeting were approved.
+
+### Announcements
+
+* “Indentured” BOMs
+* New Cyber Resilience Act implementation guides: *Commission publishes new guidance to support timely Cyber Resilience Act implementation | Shaping Europe’s digital future*
+* Bob presented in Germany on BOMs for the supply chain.
+* Kate presented in Washington, D.C., at DevSecOps Day on safety for critical infrastructure.
+
+### SPDX 3.0
+
+* The team discussed the status of Rex’s email concerning additional editorial changes.
+* Different profile conformance points should now be merged.
+* Some items need to be added to the Word document held by Rex.
+* Alexios will inform Kate, Bob, and Gary about the supported SPDX 3.0 branch changes and confirm that no pull requests remain unresolved.
+* The changes need to be collected and inserted into the Word document.
+
+### Crypto Profile
+
+* Kate contacted Hart, who is willing to provide input on crypto and wants to involve the CBOMkit participants.
+* Bob will follow up when his colleague is available.
+
+### SPDX 3.1
+
+#### `SupportRelationship`
+
+The discussion indicated that the most consistent approach is to leave `SupportRelationship` unchanged. The term could be reused in a different context.
+
+The issue will be closed.
+
+#### Microsoft Analysis
+
+* Issues were marked either for SPDX 3.1 or as potentially breaking changes.
+* Profiles were annotated.
+
+#### Issue #1373 — Examples in Class and Property Pages
+
+* Examples should be included in the text, potentially through links, using one authoritative approach.
+* The examples should not be included in the ISO submission.
+* Examples should appear on the website in HTML, but not in the PDF or Word versions.
+* Alexios will recommend a Markdown tag that allows the specification parser to include content in HTML while excluding it from PDF and Word outputs.
+* The approach should cover both properties and examples.
+* Alexios prefers that the examples remain outside the model files and be incorporated during website generation.
+* The group discussed using a shadow directory under `examples`, with examples stored in JSON-LD format.
+* Examples found in that directory would be published on the applicable web pages.
+* Maximilian suggested keeping examples near the code rather than in a separate directory. Some participants supported this approach because it would make missing examples clearer to contributors.
+* The group discussed the tooling implications.
+* Because the specification parser does not have a concept of versions, using a separate directory may simplify support for older versions.
+* Maximilian noted that all elements require creation information, an SPDX identifier, and related information. This may create substantial overhead, so the examples need a clear way to emphasize the relevant portions.
+
+#### Issue #1326 — Location and Country Code Alpha-3
+
+* The group agreed that SHACL validation would be too difficult to maintain.
+* The descriptive text may be updated to provide greater clarity.
+* A proposed change was requested.
+* An issue should be added to include a reference in the specification.
+
+## Action Items
+
+* **Alexios:** Notify Kate, Bob, and Gary about the supported SPDX 3.0 branch changes and confirm that no pull requests remain unresolved.
+* **Alexios:** Recommend a Markdown tag that allows the specification parser to include examples in HTML while excluding them from PDF and Word outputs.
+* **Alexios:** Update the specification parser to support the agreed example-handling approach.
+* **Bob:** Follow up regarding participation in the Crypto Profile discussion.
+* **Gary:** Create the `examples` directory.
+* **Gary:** Move the first example into the new structure.
+* **Gary:** Populate additional examples.
+* **Art and Alexios:** Work on examples.
+* **Project team:** Configure continuous integration to validate the examples.
+* **Project team:** Develop a method to autogenerate example files.
+* **Issue #1326 participants:** Submit proposed descriptive text clarifying the relationship between location and country codes.
+* **Project team:** Add an issue for including the appropriate reference in the specification.
+
+## Next Meeting
+
+The next meeting will address:
+
+* Remaining changes proposed through the Microsoft review
+* Follow-up items
+* Crypto, signatures, and certificates, including outreach to Karsten and the Cryptology and Security group
+* Add `hasInstall` and `hasUninstall` relationships
+
+  * [Pull Request #1297](https://github.com/spdx/spdx-3-model/pull/1297)


### PR DESCRIPTION
Documented the minutes and action items from the SPDX Tech Team meeting held on July 28, 2026, including discussions on SPDX 3.0 and 3.1, and various issues.