### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-08-04

### DIFF
--- a/tech/2026/2026-08-04.md
+++ b/tech/2026/2026-08-04.md
@@ -1,0 +1,164 @@
+# SPDX Tech Team Meeting — 2026-08-04
+
+## Attendees
+
+* Alexios Zavras
+* Alfred Strauch
+* Arthit Suriyawongkul
+* Bob Martin
+* Gary O'Neall
+* Joshua Watt
+* Karsten Klein
+* Kate Stewart
+* Maximilian Huber
+* Nicole Pappler
+* Steven Carbno
+* Ted Gauthier
+* Yang Liu
+
+## Agenda
+
+1. Approval of last meeting’s minutes (28 July 2026)
+2. Announcements and new participants
+3. SPDX 3.0 final edits — status
+4. CISA minimum elements: What do we need to implement in 3.1?
+
+   * SBOM version: https://github.com/spdx/spdx-3-model/issues/1288
+   * JSON signatures: https://github.com/spdx/spdx-3-model/issues/1065
+5. Do we want an `Agents.md`?
+6. Follow-up on Microsoft feedback:
+
+   * Profile teams need to review their issues.
+   * Added a 3.1 milestone if the fix may introduce a breaking change.
+   * Action.actionStartTime opt-in burden: https://github.com/spdx/spdx-3-model/issues/1323
+   * Document the 3.0.1 → 3.1 conformance and backward-compatibility relationship: https://github.com/spdx/spdx-spec/issues/1430
+   * Note ISO 3166-1 alpha-3 validity for CountryCodeAlpha3: https://github.com/spdx/spdx-3-model/issues/1369
+   * Editorial cleanup: clarity-only naming/description suggestions (7.6): https://github.com/spdx/spdx-3-model/issues/1403
+   * Editorial cleanup: license-expression and PURL annexes (7.2): https://github.com/spdx/spdx-spec/issues/1420
+   * Editorial cleanup: documentation and annexes (7.1): https://github.com/spdx/spdx-spec/issues/1419
+   * Define a normative IRI and `@context` versioning policy: https://github.com/spdx/spdx-spec/issues/1427
+   * Rename `countyCode` → `countySubdivisionCode`: https://github.com/spdx/spdx-3-model/issues/1410
+   * Property Nature corrections (consolidated): https://github.com/spdx/spdx-3-model/issues/1316#issuecomment-4966295883
+
+### Items That May Not Need to Be Resolved for 3.1
+
+* Hash-strength guidance: https://github.com/spdx/spdx-3-model/issues/1314
+* Missing `SubclassOf` declarations: https://github.com/spdx/spdx-3-model/issues/1317
+* `implementedBy` direction reversed: https://github.com/spdx/spdx-3-model/issues/1320
+* Quantity range contradiction: https://github.com/spdx/spdx-3-model/issues/1318
+* `unitQUDT` should be resolvable: https://github.com/spdx/spdx-3-model/issues/1319
+* Requirement instantiability missing: https://github.com/spdx/spdx-3-model/issues/1322
+* Location vs. CountryCodeAlpha3 inconsistency: https://github.com/spdx/spdx-3-model/issues/1326
+* MediaType regex too loose: https://github.com/spdx/spdx-3-model/issues/1328
+* Specification summary too narrow: https://github.com/spdx/spdx-3-model/issues/1329
+* Type-reference qualification inconsistency: https://github.com/spdx/spdx-3-model/issues/1330
+* Cross-namespace workaround relationships: https://github.com/spdx/spdx-3-model/issues/1331
+* Define a normative IRI and `@context` versioning policy: https://github.com/spdx/spdx-spec/issues/1427#issuecomment-4968219877
+* Requirement internationalization: https://github.com/spdx/spdx-3-model/issues/1340
+* `cdxProperty` “map” is misleading: https://github.com/spdx/spdx-3-model/issues/1345
+* Add amendment/supersession patterns for evolving federated SBOMs: https://github.com/spdx/spdx-3-model/issues/1361
+* Single, authoritative ABNF for license expressions: https://github.com/spdx/spdx-spec/issues/1435
+
+### SPARQL Validation
+
+* https://github.com/spdx/spdx-3-model/pull/1425
+* https://github.com/spdx/spec-parser/pull/213
+
+## Notes
+
+### Approval of Previous Minutes
+
+Last week’s minutes were approved.
+
+### Announcements
+
+* New CISA and other governments’ Minimum Elements can be found at: https://www.cisa.gov/sites/default/files/2026-07/2026_cisa_sbom_minimum_elements_508c.pdf
+* Hart and the CBOMKit team are meeting with the Cryptography Group.
+
+### SPDX ISO 3.0 Submission
+
+* Kate to tell Rex to send as is now.
+* Bob and Alexios are good on it.
+
+### Guidance Document for Adherence to New Minimum Elements
+
+* Draft from Bob: **CISA SBOM Minimum Analysis — Working Draft**
+* What do we want to add to SPDX 3.1 and work around in SPDX 3.0?
+* Data field? Discussion of what it means.
+* SBOM properties that relate to SBOMs — version and signature.
+
+### SBOM Version
+
+* Reopen issue [#1288](https://github.com/spdx/spdx-3-model/issues/1288).
+* Can we use Document ID? Vendor-specific how to interpret.
+* Semantic version on BOM — business-to-business relationships where documents are transferred rather than used internally.
+* “Most recent version of BOM.”
+* Only use this field if used by a single agent.
+* Opinion expressed: tired of explaining. Add version to SPDX 3.1 under BOM and include the documentation.
+* This is just like a software version.
+* Do not reset the version to 1.0.
+* Should we use an external identifier? No.
+* It is the agent that creates the document that sets the version.
+* The best solution is still an `Amends` relationship, but Josh can see the use case.
+* New version:
+
+  * Unique SPDX identifier.
+  * Version number.
+* Challenge: the new relation does not have to point back.
+* Version 300 versus shipping version 299 previously, etc.
+* If the version is for presentation, the BOM document must have a name.
+* Use SPARQL to enforce this.
+* Can check policy via date.
+* Versions refer only to SBOM names.
+* SPDX IDs do not tie to version.
+* It has to be issued from the same creator ID.
+* Document relationship alternative.
+* Recommend using them in conjunction.
+* Human-digestible versus graph query.
+* It is a helpful string.
+* Version number is controlled by the author.
+* Decision: it has to be a string.
+* The global ID of the document is the default ID.
+* Agreed that this goes into the BOM class.
+* The full set of constraints will be added to issue #1288.
+* Will use the same version property used for Package and add it to BOM.
+
+### JSON Signatures
+
+* JSF is a hard issue, but the serializations need to be specified.
+* Signature methods.
+* On a specific element or the entire document?
+* Discussed in the Security Group.
+* Signature as a file, using the same properties.
+* Signing the entire document is probably good enough.
+* in-toto does this for us.
+* in-toto and DSE sign binary data and provide a more complete solution.
+* JSF signs JSON content and would work.
+* Could this be done in the same way CycloneDX does it?
+* Sign the entire document versus individual elements.
+* Possibly sign the whole document for now and evolve later to sign individual elements.
+* SBOM author signature — constraint.
+* DSE and in-toto.
+* Do not acknowledge ambiguity; show how to do it.
+* Specification elements in capture set.
+* Sign the BOM and all relationships.
+* Each supplier may be signing its part of the graph.
+* Difference between BOM and Document: if we can sign a document, we are good.
+* Keep this simple.
+* Look at adding JSF in addition to what is currently done for in-toto.
+* Want an SBOM signature element under metadata about the document.
+* Version and signature are metadata about the SBOM.
+* Should return a tool name as well.
+* Metadata guidance for SPDX 2.2, 2.3, 3.0, and 3.1 is to use in-toto for now.
+
+## Next Meeting
+
+* Continue reviewing changes proposed from Microsoft.
+* CISA minimum elements: What do we need to implement in 3.1?
+
+  * SBOM version
+  * JSON signatures
+* Follow-up on cryptography, signatures, and certificates.
+
+  * Reach out to Karsten and the Cryptology and Security Group.
+* Add `hasInstall` and `hasUninstall` relationships: https://github.com/spdx/spdx-3-model/pull/1297


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on August 4, 2026, including attendees, discussions on SPDX 3.0 final edits, CISA minimum elements, and JSON signatures.