### PR TITLE
Add meeting minutes for SPDX Hardware Team on 2026-08-07

### DIFF
--- a/hardware/2026/2026-08-07.md
+++ b/hardware/2026/2026-08-07.md
@@ -1,0 +1,153 @@
+# SPDX Hardware Team Meeting 2026-08-07
+
+**PR:**
+
+## Attendees
+
+* [x] Alfred Strauch
+* [x] Steven Carbno
+* [x] Bob Martin (MITRE)
+* [ ] Dishoung White II
+* [ ] Kate Stewart
+* [ ] Victor Lu
+* [ ] Jim Vitrano
+* [ ] Amit Kumar
+* [x] Issac Asay
+* [ ] Lucas Tate
+* [ ] Apoorav Trehan
+* [ ] Alex Volykin
+* [ ] Allan Friedman
+* [ ] Cassie Crossley
+* [x] Felix Reichmanna
+* [ ] Makki Elfatih
+* [x] Greg Shue
+* [ ] Riley Barello-Myers
+* [ ] Henk Berkholz
+* [ ] Dan Hopkins
+* [ ] Courtney Ng
+* [ ] Andrew Viater
+* [ ] Raymond Sheh
+* [ ] Stanislav Pankevich
+* [ ] Karen Bennet
+* [ ] Marcel Kurzamann
+* [ ] Raymond Sheh
+* [ ] Michael Pease (NIST Standards)
+* [ ] Jenn Power (Red Hat)
+* [ ] Arthit Suriyawongkul
+
+## Agenda
+
+* Approve previous minutes:
+
+  * https://github.com/spdx/meetings/pull/1133
+
+* PR to review:
+
+  * Conformance example1 prelim system reqs
+  * https://github.com/spdx/spdx-examples/pull/155
+
+* Issues from Microsoft's SPDX Review document:
+
+  * **[3.1-RC1] Relax Hardware.partNumber for BulkHardware commodities**
+
+    * https://github.com/spdx/spdx-3-model/issues/1383
+    * Last week's conversation item
+
+  * **[3.1-RC1] Editorial cleanup: clarity-only naming/description suggestions (7.6)**
+
+    * https://github.com/spdx/spdx-3-model/issues/1403
+
+  * **Rename vague SupplyChain property names (current/previous/planned*)**
+
+    * https://github.com/spdx/spdx-3-model/issues/1390
+
+  * **[3.1-RC1] Restore suppliedBy/releaseTime on Hardware for traceability**
+
+    * https://github.com/spdx/spdx-3-model/issues/1384
+
+  * **[3.1-RC1] Add a Firmware class linked to its hardware (Hardware profile)**
+
+    * https://github.com/spdx/spdx-3-model/issues/1382
+
+  * **[3.1-RC1] Add RepairAction and ReturnAction to the SupplyChain namespace**
+
+    * https://github.com/spdx/spdx-3-model/issues/1371
+
+  * **[3.1-RC1] Editorial cleanup: Model Operations/FunctionalSafety/Hardware (7.4)**
+
+    * https://github.com/spdx/spdx-3-model/issues/1401
+
+### Probability 3.2
+
+* **[3.1-RC1] Add a redacted/opaque element type for supply-chain black-boxing**
+
+  * https://github.com/spdx/spdx-3-model/issues/1388
+
+* Review Microsoft's SPDX Review document:
+
+  * https://docs.google.com/document/d/1WU1V-8LbmB0uMhKpKIri7qiBdU40GEG8XwZHyOXrJcM/edit?tab=t.0
+
+* Model out the certificate/root of trust annotations
+
+* OpenChain has parallel initiatives CRA and functional safety:
+
+  * https://docs.google.com/document/d/1Wog28BZ9NQhY3tN9Wc2NDml2phBDuvYu9zkXSON5z5o/edit?tab=t.0
+  * https://github.com/OpenChain-Project/CRA-Compliance/blob/main/CRA_Checklist_Requirement_PA%201.0.md
+
+## Notes
+
+* A vertical standard related to interfaces will be released in Sept 26.
+
+* Minutes approved.
+
+* Bulk hardware part # description.
+
+* CO2 use as part number is a question.
+
+* Suggest bulk be related to a specification.
+
+* Part # not defined by owner — change part # to part ID along with definition.
+
+* Add kind of product to definition — SKU or category (CO2 and CO).
+
+* Will conformance example map into SPDX properly — model# did not map directly to a SKU? Guidance required.
+
+* Bulk can be sold as fractional units — what is the unit related to fractional part?
+
+* Batch can be used as a Serial #:
+
+  * Batch identity vs unit.
+  * SKU is a description of shipment, product and charge rate.
+  * Quantities are needed (units).
+
+* Note: emissions are not contained or accurately measured — calculated values.
+
+* Product ID describes or defines type — may use.
+
+* Do we capture byproducts — gas releases?
+
+* If it is for sale need part#.
+
+* QUDT supports fractional units — QUDT units class may need to be revised for more details.
+
+* New summary and description — needs to improved to include identifying information be provide details — SKU creates different part #s — qualified by manufacturer — as defined by the product agent — transport agent.
+
+* Need examples in documentation.
+
+* Do we need a specification related to bulk? Maybe some will want.
+
+* Spec related to movement of water in California — watersheds, evaporation, contamination — what are you wanting to measure? Multiple measurements — how much water did farm x use? Does shipment combine elements related to measure?
+
+  * Collecting milk from different dairies? What is the input measure? Bulk production?
+  * Modelled example to determine if bulk handling based on agents based on relationships works.
+  * Part is lettuce but products change in volume by stage — picking — transport — clearing — transport — sale.
+
+## Action Items
+
+* Model Bulk commodity processes, ID, quality, agents and description.
+* Review PRs and make suggestions or approve.
+
+## Decision Items
+
+* Next week's conversation related to BULK part #.
+* Review DPP.


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Hardware Team meeting held on August 7, 2026, including attendees, discussion points, and action items.