### PR TITLE
Add minutes for SPDX Tech Team meeting on 2026-08-11

### DIFF
--- a/tech/2026/2026-08-11.md
+++ b/tech/2026/2026-08-11.md
@@ -1,0 +1,119 @@
+# SPDX Tech Team Meeting — 2026-08-11
+
+## Attendees
+
+1. Alexios Zavras
+2. Alfred Strauch
+3. Arthit Suriyawongkul
+4. Bob Martin
+5. Gary O'Neall
+6. Greg Shue
+7. Joshua Watt
+8. Karen Bennet
+9. Karsten Klein
+10. Marc-Etienne Vargenau
+11. Peter Monks
+12. Steven Carbno
+13. Victor Lu
+
+## Agenda
+
+* Approval of last meeting’s minutes
+
+* Announcements and new participants
+
+* SPDX 2.x new release — postponed to next week
+
+* SPDX 3.0 final edits — status
+
+* CISA minimum elements: what needs to be implemented in SPDX 3.1
+
+* `Agents.md` — postponed until the AI Policy is in the repositories
+
+* Follow-up on Microsoft feedback:
+
+  * Profile teams need to review their issues
+  * Add a 3.1 milestone where a fix may introduce a breaking change
+  * `Action.actionStartTime` opt-in burden — [spdx-3-model #1323](https://github.com/spdx/spdx-3-model/issues/1323)
+  * Document the SPDX 3.0.1 → 3.1 conformance and backward-compatibility relationship — [spdx-spec #1430](https://github.com/spdx/spdx-spec/issues/1430)
+  * Note ISO 3166-1 alpha-3 validity for `CountryCodeAlpha3` — [spdx-3-model #1369](https://github.com/spdx/spdx-3-model/issues/1369)
+  * Editorial cleanup: clarity-only naming/description suggestions (7.6) — [spdx-3-model #1403](https://github.com/spdx/spdx-3-model/issues/1403)
+  * Editorial cleanup: license-expression and PURL annexes (7.2) — [spdx-spec #1420](https://github.com/spdx/spdx-spec/issues/1420)
+  * Editorial cleanup: documentation and annexes (7.1) — [spdx-spec #1419](https://github.com/spdx/spdx-spec/issues/1419)
+  * Define a normative IRI and `@context` versioning policy — [spdx-spec #1427](https://github.com/spdx/spdx-spec/issues/1427)
+  * Rename `countyCode` → `countySubdivisionCode` — [spdx-3-model #1410](https://github.com/spdx/spdx-3-model/issues/1410)
+  * Property Nature corrections (consolidated) — [spdx-3-model #1316 comment](https://github.com/spdx/spdx-3-model/issues/1316#issuecomment-4966295883)
+  * `unitQUDT` should be resolvable — [spdx-3-model #1319](https://github.com/spdx/spdx-3-model/issues/1319)
+
+  **Items that may not need to be resolved for SPDX 3.1:**
+
+  * Hash-strength guidance — [spdx-3-model #1314](https://github.com/spdx/spdx-3-model/issues/1314)
+  * Missing `SubclassOf` declarations — [spdx-3-model #1317](https://github.com/spdx/spdx-3-model/issues/1317)
+  * `implementedBy` direction reversed — [spdx-3-model #1320](https://github.com/spdx/spdx-3-model/issues/1320)
+  * Quantity range contradiction — [spdx-3-model #1318](https://github.com/spdx/spdx-3-model/issues/1318)
+  * Requirement instantiability missing — [spdx-3-model #1322](https://github.com/spdx/spdx-3-model/issues/1322)
+  * `Location` vs. `CountryCodeAlpha3` inconsistency — [spdx-3-model #1326](https://github.com/spdx/spdx-3-model/issues/1326)
+  * `MediaType` regex too loose — [spdx-3-model #1328](https://github.com/spdx/spdx-3-model/issues/1328)
+  * Specification summary too narrow — [spdx-3-model #1329](https://github.com/spdx/spdx-3-model/issues/1329)
+  * Type-reference qualification inconsistency — [spdx-3-model #1330](https://github.com/spdx/spdx-3-model/issues/1330)
+  * Cross-namespace workaround relationships — [spdx-3-model #1331](https://github.com/spdx/spdx-3-model/issues/1331)
+  * Define a normative IRI and `@context` versioning policy — [spdx-spec #1427 comment](https://github.com/spdx/spdx-spec/issues/1427#issuecomment-4968219877)
+  * Requirement internationalization — [spdx-3-model #1340](https://github.com/spdx/spdx-3-model/issues/1340)
+  * `cdxProperty` "map" is misleading — [spdx-3-model #1345](https://github.com/spdx/spdx-3-model/issues/1345)
+  * Add amendment/supersession patterns for evolving federated SBOMs — [spdx-3-model #1361](https://github.com/spdx/spdx-3-model/issues/1361)
+  * Single, authoritative ABNF for license expressions — [spdx-spec #1435](https://github.com/spdx/spdx-spec/issues/1435)
+
+* SPARQL validation:
+
+  * [spdx-3-model PR #1425](https://github.com/spdx/spdx-3-model/pull/1425)
+  * [spec-parser PR #213](https://github.com/spdx/spec-parser/pull/213)
+
+## Notes
+
+### Previous Minutes
+
+* Last week’s minutes were approved.
+
+### Announcements
+
+* No additional announcements recorded.
+
+### SPDX 3.0 Submission
+
+* Bob to confirm with Rex that the SPDX 3.0 submission has been sent.
+
+### CISA Minimum Elements
+
+Discussion followed from the OpenSSF call held last Friday.
+
+#### Alternative Package Names
+
+* A package may have more than one name.
+* Related issue: [spdx-3-model #1432](https://github.com/spdx/spdx-3-model/issues/1432)
+* The cardinality of `name` cannot be changed.
+* Implementation options discussed:
+
+  * Property
+  * `ExternalRef`
+  * `ExternalIdentifier`
+* **Decision:** Add an `additionalName` property to `Element`.
+
+#### Signatures
+
+* Discussion on whether SPDX should support JSF (JSON Signing Format), which CycloneDX supports.
+* JSF:
+
+  * Adds a `signature` entry at the top level of a JSON object.
+  * Canonicalizes the data using RFC 8785.
+  * Computes a hash.
+  * Adds a `value` key/value pair containing the resulting signature information.
+* The serialization documentation should be added under `doc/serialization` in `spdx-spec`.
+* **Decision:** Add JSF support to SPDX 3.1.
+* Determine whether JSF support can also be added to SPDX 3.0.1 without breaking backward compatibility due to the additional top-level key.
+
+### SPARQL Validation
+
+* Add a new `## SPARQL` section to model Markdown (`.md`) files.
+* SPARQL queries can be used to express model restrictions.
+* The existing pull request translates all **External Properties Restrictions** and `RelationshipType` wording into SPARQL.
+* **Action:** Alexios to update `spec-parser` to automatically generate SPARQL expressions from **External Properties Restrictions**.


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Tech Team meeting held on August 11, 2026, including attendees, discussions, and decisions made.