### PR TITLE
Add minutes for SPDX Hardware Team meeting on 2026-08-14

### DIFF
--- a/hardware/2026/2026-08-14.md
+++ b/hardware/2026/2026-08-14.md
@@ -1,0 +1,140 @@
+# SPDX Hardware Team Meeting 2026-08-14
+
+## Attendees
+
+* [x] Alfred Strauch
+* [x] Steven Carbno
+* [x] Bob Martin (MITRE)
+* [ ] Dishoung White II
+* [ ] Kate Stewart
+* [ ] Victor Lu
+* [ ] Jim Vitrano
+* [ ] Amit Kumar
+* [ ] Issac Asay
+* [ ] Lucas Tate
+* [ ] Apoorav Trehan
+* [ ] Alex Volykin
+* [ ] Allan Friedman
+* [ ] Cassie Crossley
+* [x] Felix Reichmanna
+* [ ] Makki Elfatih
+* [x] Greg Shue
+* [ ] Riley Barello-Myers
+* [ ] Henk Berkholz
+* [ ] Dan Hopkins
+* [ ] Courtney Ng
+* [ ] Andrew Viater
+* [ ] Raymond Sheh
+* [ ] Stanislav Pankevich
+* [ ] Karen Bennet
+* [ ] Marcel Kurzamann
+* [ ] Michael Pease (NIST Standards)
+* [ ] Jenn Power (Red Hat)
+* [ ] Arthit Suriyawongkul
+
+## Agenda
+
+* Approve previous minutes:
+
+  * [https://github.com/spdx/meetings/pull/1135](https://github.com/spdx/meetings/pull/1135)
+* Review last week's bulk conversation and define a new summary and description.
+* Review PR:
+
+  * Conformance example1 prelim system requirements
+  * [https://github.com/spdx/spdx-examples/pull/155](https://github.com/spdx/spdx-examples/pull/155)
+
+### Issues from Microsoft's SPDX Review Document
+
+* Fixed:
+
+  * [https://github.com/spdx/spdx-3-model/pull/1300](https://github.com/spdx/spdx-3-model/pull/1300)
+* Determine whether the following issue can be closed:
+
+  * [https://github.com/spdx/spdx-3-model/issues/1312](https://github.com/spdx/spdx-3-model/issues/1312)
+* **[3.1-RC1] Relax Hardware.partNumber for BulkHardware commodities**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1383](https://github.com/spdx/spdx-3-model/issues/1383)
+  * Last week's conversation item.
+* **[3.1-RC1] Editorial cleanup: clarity-only naming/description suggestions (7.6)**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1403](https://github.com/spdx/spdx-3-model/issues/1403)
+* **Rename vague SupplyChain property names (current/previous/planned*)**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1390](https://github.com/spdx/spdx-3-model/issues/1390)
+* **[3.1-RC1] Restore suppliedBy/releaseTime on Hardware for traceability**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1384](https://github.com/spdx/spdx-3-model/issues/1384)
+* **[3.1-RC1] Add a Firmware class linked to its hardware (Hardware profile)**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1382](https://github.com/spdx/spdx-3-model/issues/1382)
+* **[3.1-RC1] Add RepairAction and ReturnAction to the SupplyChain namespace**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1371](https://github.com/spdx/spdx-3-model/issues/1371)
+* **[3.1-RC1] Editorial cleanup: Model Operations/FunctionalSafety/Hardware (7.4)**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1401](https://github.com/spdx/spdx-3-model/issues/1401)
+
+### Probability 3.2
+
+* **[3.1-RC1] Add a redacted/opaque element type for supply-chain black-boxing**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1388](https://github.com/spdx/spdx-3-model/issues/1388)
+
+### Additional Topics
+
+* Review Microsoft's SPDX Review document:
+
+  * [https://docs.google.com/document/d/1WU1V-8LbmB0uMhKpKIri7qiBdU40GEG8XwZHyOXrJcM/edit?tab=t.0](https://docs.google.com/document/d/1WU1V-8LbmB0uMhKpKIri7qiBdU40GEG8XwZHyOXrJcM/edit?tab=t.0)
+* Model out the certificate/root of trust annotations.
+* OpenChain has parallel CRA and functional safety initiatives:
+
+  * [https://docs.google.com/document/d/1Wog28BZ9NQhY3tN9Wc2NDml2phBDuvYu9zkXSON5z5o/edit?tab=t.0](https://docs.google.com/document/d/1Wog28BZ9NQhY3tN9Wc2NDml2phBDuvYu9zkXSON5z5o/edit?tab=t.0)
+  * [https://github.com/OpenChain-Project/CRA-Compliance/blob/main/CRA_Checklist_Requirement_PA%201.0.md](https://github.com/OpenChain-Project/CRA-Compliance/blob/main/CRA_Checklist_Requirement_PA%201.0.md)
+
+## Notes
+
+* A vertical standard related to interfaces will be released in September 2026.
+* Minutes approved.
+* Discussion on how SysEng can be used in relation to a niche implementation within an organization:
+
+  * Product functionality must be examined from a systems engineering perspective to determine functionality.
+  * How will SysEng be implemented or integrated into SPDX as a component?
+* A description of the system is needed. Once defined, the implementation model for SysEng can be established.
+
+  * Example: threats and controls, with an emphasis on controls.
+* Need a way to connect, integrate, or encourage the use of SysEng as part of the process.
+* Requirements, as part of SPDX, will be used to drive analysis for other profiles.
+* Validation and verification will need to be elevated to Core to make this concept work.
+* Closed issue:
+
+  * [https://github.com/spdx/spdx-3-model/issues/1312](https://github.com/spdx/spdx-3-model/issues/1312)
+* **[3.1-RC1] Relax Hardware.partNumber for BulkHardware commodities**
+
+  * [https://github.com/spdx/spdx-3-model/issues/1383](https://github.com/spdx/spdx-3-model/issues/1383)
+* Part number assignment:
+
+  * Does assignment make an entity a manufacturer or supplier?
+  * Consider white labeling.
+* If a packager adds a UPC label and sell-by date, does that create a new product?
+
+  * Who is the producer?
+  * The manufacturer has responsibility.
+* Which party sets the bulk ID?
+
+  * An industry specification may be involved.
+  * The owner of the mine produces the product code.
+* May need to change the definition of Product Agent to account for manufacturer, harvester, assembler, etc.
+* Product Agent definition can remain unchanged.
+* There may be more than one manufacturer involved in an assembly.
+* Custody vocabulary:
+
+  * Change "legal authority" to "legal accountability."
+
+## Action Items
+
+* Review PRs and make suggestions or approve.
+* Review DPP.
+
+## Decision Item
+
+* In `ResponsibilityType.md`, change the Custody vocabulary from **"legal authority"** to **"legal accountability."**


### PR DESCRIPTION
Documented the minutes of the SPDX Hardware Team meeting held on August 14, 2026, including attendees, agenda items, issues discussed, and action items.