### PR TITLE
Add meeting notes for SPDX Tech Team on 2026-08-18

### DIFF
--- a/tech/2026/2026-08-18.md
+++ b/tech/2026/2026-08-18.md
@@ -1,0 +1,106 @@
+```markdown
+# SPDX Tech Team Meeting 2026-08-18
+
+## Attendees
+
+1. Alexios Zavras
+2. Alfred Strauch
+3. Arthit Suriyawongkul
+4. Bob Martin
+5. Gary O'Neall
+6. Kate Stewart
+7. Marc-Etienne Vargenau
+8. Meem Arafat Manab
+9. Nicole Pappler
+10. Peter Monks
+11. Steven Carbno
+12. Ted Gauthier
+
+## Agenda
+
+- Approval of last meeting’s minutes
+- Announcements & New participants
+- SPDX 2.x new release / declare status of support
+  - [spdx/spdx-spec#1461](https://github.com/spdx/spdx-spec/issues/1461)
+- SPDX 3.0 final edits - status
+- CISA minimum elements: what do we need to implement in 3.1
+  - Signing serialization: [spdx/spdx-3-model#1435](https://github.com/spdx/spdx-3-model/pull/1435)
+- SPARQL validation follow-up
+  - [spdx/spdx-3-model#1425](https://github.com/spdx/spdx-3-model/pull/1425)
+  - [spdx/spec-parser#213](https://github.com/spdx/spec-parser/pull/213)
+  - [spdx/spec-parser#216](https://github.com/spdx/spec-parser/pull/216)
+    - Joshua would prefer to keep our file as valid Markdown
+- JSS Signing
+  - [spdx/spdx-3-model#1435](https://github.com/spdx/spdx-3-model/pull/1435)
+- QUDT
+  - `unitQUDT` should be resolvable: [spdx/spdx-3-model#1319](https://github.com/spdx/spdx-3-model/issues/1319)
+  - Quantity range contradiction: [spdx/spdx-3-model#1318](https://github.com/spdx/spdx-3-model/issues/1318)
+- License expression
+  - Case-insensitivity lacks canonicalization/failure guidance: [spdx/spdx-spec#1420](https://github.com/spdx/spdx-spec/issues/1420#issuecomment-5268389713)
+  - Single, authoritative ABNF for license expressions: [spdx/spdx-spec#1435](https://github.com/spdx/spdx-spec/issues/1435)
+    - Simplify full ABNF: [spdx/spdx-spec#1465](https://github.com/spdx/spdx-spec/pull/1465)
+  - Make license expressions fully case sensitive: [spdx/spdx-spec#1464](https://github.com/spdx/spdx-spec/issues/1464)
+  - How to list multiple `WITH` exceptions: [spdx/spdx-spec#479](https://github.com/spdx/spdx-spec/issues/479)
+  - Add `NONE` to the license expression syntax: [spdx/spdx-spec#49](https://github.com/spdx/spdx-spec/issues/49)
+  - Canonical form of composite license expressions: [spdx/spdx-spec#1462](https://github.com/spdx/spdx-spec/issues/1462)
+  - Is `+` useful: [spdx/spdx-spec#1463](https://github.com/spdx/spdx-spec/issues/1463)
+- Follow-up on Microsoft feedback:
+  - Profile teams need to review their issues
+  - Added a 3.1 milestone if the fix may introduce a breaking change
+  - `Action.actionStartTime` opt-in burden: [spdx/spdx-3-model#1323](https://github.com/spdx/spdx-3-model/issues/1323)
+  - Document the 3.0.1 -> 3.1 conformance and backward-compatibility relationship: [spdx/spdx-spec#1430](https://github.com/spdx/spdx-spec/issues/1430)
+  - Note ISO 3166-1 alpha-3 validity for `CountryCodeAlpha3`: [spdx/spdx-3-model#1369](https://github.com/spdx/spdx-3-model/issues/1369)
+  - Editorial cleanup: clarity-only naming/description suggestions (7.6): [spdx/spdx-3-model#1403](https://github.com/spdx/spdx-3-model/issues/1403)
+  - Editorial cleanup: license-expression and PURL annexes (7.2): [spdx/spdx-spec#1420](https://github.com/spdx/spdx-spec/issues/1420)
+  - Editorial cleanup: documentation and annexes (7.1): [spdx/spdx-spec#1419](https://github.com/spdx/spdx-spec/issues/1419)
+    - Add link for CNSSI 4009: [spdx/spdx-spec#1447](https://github.com/spdx/spdx-spec/pull/1447)
+    - Revise Strings in Canonical serialization: [spdx/spdx-spec#1448](https://github.com/spdx/spdx-spec/pull/1448)
+  - Define a normative IRI and `@context` versioning policy: [spdx/spdx-spec#1427](https://github.com/spdx/spdx-spec/issues/1427)
+  - Rename `countyCode` -> `countySubdivisionCode`: [spdx/spdx-3-model#1410](https://github.com/spdx/spdx-3-model/issues/1410)
+  - Property Nature corrections (consolidated): [spdx/spdx-3-model#1316](https://github.com/spdx/spdx-3-model/issues/1316#issuecomment-4966295883)
+  - The following may not need to be resolved for 3.1:
+    - Hash-strength guidance: [spdx/spdx-3-model#1314](https://github.com/spdx/spdx-3-model/issues/1314)
+    - Missing `SubclassOf` declarations: [spdx/spdx-3-model#1317](https://github.com/spdx/spdx-3-model/issues/1317)
+    - `implementedBy` direction reversed: [spdx/spdx-3-model#1320](https://github.com/spdx/spdx-3-model/issues/1320)
+    - Requirement instantiability missing: [spdx/spdx-3-model#1322](https://github.com/spdx/spdx-3-model/issues/1322)
+    - Location vs. `CountryCodeAlpha3` inconsistency: [spdx/spdx-3-model#1326](https://github.com/spdx/spdx-3-model/issues/1326)
+    - `MediaType` regex too loose: [spdx/spdx-3-model#1328](https://github.com/spdx/spdx-3-model/issues/1328)
+    - Specification summary too narrow: [spdx/spdx-3-model#1329](https://github.com/spdx/spdx-3-model/issues/1329)
+    - Type-reference qualification inconsistency: [spdx/spdx-3-model#1330](https://github.com/spdx/spdx-3-model/issues/1330)
+    - Cross-namespace workaround relationships: [spdx/spdx-3-model#1331](https://github.com/spdx/spdx-3-model/issues/1331)
+    - Define a normative IRI and `@context` versioning policy: [spdx/spdx-spec#1427](https://github.com/spdx/spdx-spec/issues/1427#issuecomment-4968219877)
+    - Requirement internationalization: [spdx/spdx-3-model#1340](https://github.com/spdx/spdx-3-model/issues/1340)
+    - `cdxProperty` "map" is misleading: [spdx/spdx-3-model#1345](https://github.com/spdx/spdx-3-model/issues/1345)
+    - Add amendment/supersession patterns for evolving federated SBOMs: [spdx/spdx-3-model#1361](https://github.com/spdx/spdx-3-model/issues/1361)
+- Do we want an `Agents.md`?
+  - Postponed until AI Policy is in the repositories
+
+## Notes
+
+- Last meeting’s minutes approved
+- No announcements
+- SPDX 3.0 ISO submission
+  - No news
+- CISA minimum elements - signatures
+  - We support in-toto
+  - Joshua proposed supporting JSF, as CycloneDX had
+  - CycloneDX moved from JSF to JSS
+  - We can also support JSS
+  - Where to put it?
+    - PR in the `spdx/using` repository
+    - New PR for the `spdx/spdx-spec` repository to mention it in the serialization chapter
+- CISA minimum elements - correspondence of fields
+  - Marc-Etienne proposes having this as an annex to the specification
+  - The annex can be added after the table is finalized
+- SPARQL validation
+  - Amend `spec-parser` to accept, and ignore, empty lines in the middle of nested lists
+- SPDX 2.x new release
+  - Looking to release v2.3.1
+  - Volunteers to help with the release:
+    - Gary O'Neall
+    - Marc-Etienne Vargenau
+    - Kate Stewart
+    - Alexios Zavras
+    - Arthit Suriyawongkul
+  - Separate call scheduled for 2026-09-04
+```


### PR DESCRIPTION
Documented the attendees, agenda, and notes from the SPDX Tech Team meeting held on August 18, 2026.