### PR TITLE
Add minutes for SPDX Hardware Team meeting on 2026-08-21

### DIFF
--- a/hardware/2026/2026-08-21.md
+++ b/hardware/2026/2026-08-21.md
@@ -1,0 +1,120 @@
+# SPDX Hardware Team Meeting 2026-08-21
+
+## Attendees
+
+- [x] Alfred Strauch
+- [x] Steven Carbno
+- [x] Bob Martin (MITRE)
+- [ ] Dishoung White II
+- [ ] Kate Stewart
+- [x] Victor Lu
+- [x] Jim Vitrano
+- [ ] Amit Kumar
+- [ ] Issac Asay
+- [ ] Lucas Tate
+- [ ] Apoorav Trehan
+- [ ] Alex Volykin
+- [ ] Allan Friedman
+- [ ] Cassie Crossley
+- [x] Felix Reichmanna
+- [ ] Makki Elfatih
+- [x] Greg Shue
+- [ ] Riley Barello-Myers
+- [ ] Henk Berkholz
+- [ ] Dan Hopkins
+- [ ] Courtney Ng
+- [ ] Andrew Viater
+- [ ] Raymond Sheh
+- [ ] Stanislav Pankevich
+- [ ] Karen Bennet
+- [ ] Marcel Kurzamann
+- [ ] Michael Pease (NIST Standards)
+- [ ] Jenn Power (Red Hat)
+- [ ] Arthit Suriyawongkul
+
+## Agenda
+
+- Approve previous minutes:
+  - https://github.com/spdx/meetings/pull/1137
+
+- Review last week's bulk conversation and define a new summary and description.
+
+- PR to review:
+  - Custody vocabulary (`ResponsibilityType.md`): change "legal authority" to "legal accountability"
+    - https://github.com/spdx/spdx-3-model/pull/1434
+    - https://github.com/spdx/spdx-3-model/issues/1383
+
+- `partNumber` discussion for new text in Summary and Description as related to:
+  - [PhysicalHardware](https://spdx.github.io/spdx-spec/v3.1-dev/model/Hardware/Classes/PhysicalHardware/)
+  - [BulkHardware](https://spdx.github.io/spdx-spec/v3.1-dev/model/Hardware/Classes/BulkHardware/)
+
+- Conformance Example 1: preliminary system requirements
+  - https://github.com/spdx/spdx-examples/pull/155
+
+- Issues from Microsoft's SPDX Review document:
+  - Rename vague SupplyChain property names (`current` / `previous` / `planned*`)
+    - https://github.com/spdx/spdx-3-model/issues/1390
+  - `[3.1-RC1]` Restore `suppliedBy` / `releaseTime` on Hardware for traceability
+    - https://github.com/spdx/spdx-3-model/issues/1384
+  - `[3.1-RC1]` Editorial cleanup: clarity-only naming/description suggestions (7.6)
+    - https://github.com/spdx/spdx-3-model/issues/1403
+  - `[3.1-RC1]` Add a Firmware class linked to its hardware (Hardware profile)
+    - https://github.com/spdx/spdx-3-model/issues/1382
+  - `[3.1-RC1]` Add `RepairAction` and `ReturnAction` to the SupplyChain namespace
+    - https://github.com/spdx/spdx-3-model/issues/1371
+  - `[3.1-RC1]` Editorial cleanup: Model Operations/FunctionalSafety/Hardware (7.4)
+    - https://github.com/spdx/spdx-3-model/issues/1401
+
+- Probability: 3.2
+  - `[3.1-RC1]` Add a redacted/opaque element type for supply-chain black-boxing
+    - https://github.com/spdx/spdx-3-model/issues/1388
+
+- Review Microsoft's SPDX Review document:
+  - https://docs.google.com/document/d/1WU1V-8LbmB0uMhKpKIri7qiBdU40GEG8XwZHyOXrJcM/edit?tab=t.0
+
+- Model out the certificate/root of trust annotations.
+
+- OpenChain has parallel initiatives for CRA and functional safety:
+  - https://docs.google.com/document/d/1Wog28BZ9NQhY3tN9Wc2NDml2phBDuvYu9zkXSON5z5o/edit?tab=t.0
+  - https://github.com/OpenChain-Project/CRA-Compliance/blob/main/CRA_Checklist_Requirement_PA%201.0.md
+
+## Notes
+
+- A vertical standard related to interfaces will be released in September 2026.
+- Minutes approved.
+- Custody vocabulary illustrated.
+- Improve the summary description of `partNumber`.
+- What is the value and usage?
+- Defined by the manufacturer, qualified by the other parameters or fields.
+- Product agent may decide the name, but it is determined by other parameters. The role of the "agent" is to make the decision based on those other parameters, for example, the bulk lettuce example.
+- Definition of product agent needs clarification:
+  - Specific agents versus individuals.
+  - Role can change over time.
+  - Agent versus role.
+- The agent at the time of product identification, as a role, is the product agent responsible for decision-making.
+- Relationships of roles with the product manager are the agent's responsibility for `partNumber`.
+- Do all products need a specification related to identification?
+- `modelNumber` may be different from `partNumber`:
+  - Is a part number actually a model number?
+  - A part number is used for stock keeping and tracking, while a model number is an identifier used by consumers.
+  - Individual units versus groups.
+- Need to support both part number and model number.
+- Applies to VM implementations as well.
+- Hardware is a composite made of components. The same issue applies to the definition of systems.
+- `modelNumber` is part of a specification and the Hardware class.
+- Reference to the manufacturer can be vague for bulk hardware.
+  - The decomposition process will need to be defined.
+  - Relationships and chaining of items need to be considered.
+  - `contains` relationship.
+- Update `ResponsibilityType`: change wording from "over someone" to "over something."
+
+## Action Items
+
+- Create a PR related to `modelNumber`, defined as a string by the product manufacturer/manager.
+- Update `ResponsibilityType`.
+
+## Decision Items
+
+- `partNumber` stays unchanged.
+- Add `modelNumber`.
+- `modelNumber` will not be mandatory.


### PR DESCRIPTION
Documented the minutes and agenda for the SPDX Hardware Team meeting held on August 21, 2026, including attendees, discussions, and action items.